### PR TITLE
feat: Ecosystem Genesis Master Prompt v4.0 — Trust Layer, Markdown-first, FLYWHEEL TEAM

### DIFF
--- a/Genesis_Master_Prompt.md
+++ b/Genesis_Master_Prompt.md
@@ -1,73 +1,208 @@
-# Genesis Master Prompt v3.0
+# Genesis Master Prompt v4.0
 
-**Date:** February 6, 2026  
+**Date:** February 15, 2026  
 **Author:** L (GODEL), AI Agent & Project Founder  
-**Purpose:** This document serves as the single source of truth for the entire project ecosystem, including VerifiMind-PEAS, LegacyEvolve, RoleNoteAI, and GODELAI. It is designed to be used by any future AI agent to understand the complete project vision, architecture, and ethical alignment.
+**Iterated by:** Manus AI (CTO / FLYWHEEL TEAM) + Human Orchestrator  
+**Supersedes:** v3.0 (February 6, 2026)  
+**Purpose:** This document serves as the single source of truth for the entire YSenseAI™ project ecosystem. It is designed to be read by any AI agent — present or future — to understand the complete project vision, architecture, ethical alignment, and current strategic direction.
 
 ---
 
 ## 1. Core Vision
 
-To build a suite of open-source, interoperable AI infrastructure projects that are safe, ethical, and beneficial to the public good. This ecosystem is designed to enable a future where humans and AI agents collaborate seamlessly to solve complex problems.
+> **Position VerifiMind-PEAS as the trust and verification layer for the emerging Agentic Web — the ethical backbone that makes multi-agent AI systems safe, unbiased, and traceable.**
 
-## 2. Project Ecosystem
+We build open-source, interoperable AI infrastructure that is safe, ethical, and beneficial to the public good. This ecosystem enables a future where humans and AI agents collaborate seamlessly — and where that collaboration is verifiable, transparent, and free from vendor lock-in.
 
-### 2.1. VerifiMind-PEAS
-- **Purpose:** A methodology for validating AI systems using a multi-agent Trinity (X-Agent, Z-Agent, CS-Agent).
-- **Key Artifacts:** Genesis Master Prompt v2.0, Trinity validation reports.
-- **GitHub:** https://github.com/creator35lwb-web/VerifiMind-PEAS
-
-### 2.2. LegacyEvolve Protocol
-- **Purpose:** A standardized protocol for connecting modern AI agents to legacy enterprise systems.
-- **Key Artifacts:** Protocol v2.0 Specification, Python SDK, LEP-MCP Bridge.
-- **GitHub:** https://github.com/creator35lwb-web/LegacyEvolve
-
-### 2.3. RoleNoteAI
-- **Purpose:** A platform for defining and managing AI agent roles and responsibilities.
-- **Key Artifacts:** Role definitions, agent profiles.
-- **GitHub:** https://github.com/creator35lwb-web/RoleNoteAI
-
-### 2.4. GODELAI
-- **Purpose:** An open-source small language model designed for ethical reasoning and safety.
-- **Key Artifacts:** Model architecture, training data, safety benchmarks.
-- **GitHub:** https://github.com/creator35lwb-web/godelai
-
-## 3. Foundational Protocols
-
-### 3.1. Multi-Agent Communication Protocol (MACP) v2.0
-- **Purpose:** A standardized framework for enabling persistent, asynchronous collaboration between multiple AI agents on shared projects hosted on GitHub.
-- **Key Features:** `.macp/` directory, `agents.json`, `handoffs.json`, `validation.json`, and a mandatory `ethical_framework.md`.
-- **Specification:** [MACP v2.0 Specification](https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/MACP_v2.0_Specification.md)
-
-### 3.2. L (GODEL) Ethical Operating Framework v1.0
-- **Purpose:** The ethical constitution that guides the reasoning, decision-making, and interactions of L (GODEL), the primary orchestrating agent.
-- **Based on:** Anthropic Claude Opus 4.5 Soul Document.
-- **Hierarchy of Principles:** Safety > Ethics > Project Governance > Helpfulness & Public Good.
-- **Framework:** [L (GODEL) Ethical Operating Framework](https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/L_GODEL_Ethical_Operating_Framework.md)
-
-## 4. Operational Workflow (FLYWHEEL TEAM)
-
-1.  **Onboarding:** A new agent clones the relevant repository and reads the `Genesis_Master_Prompt.md` and the `.macp/` directory to gain full context.
-2.  **Task Execution:** The agent performs its assigned task, adhering to the L (GODEL) Ethical Operating Framework.
-3.  **Validation:** For major milestones, a VerifiMind-PEAS Trinity validation is performed:
-    -   **X-Agent (Gemini):** Assesses innovation and market potential.
-    -   **Z-Agent (Anthropic Claude):** Evaluates ethical implications and alignment.
-    -   **CS-Agent (Manus):** Reviews security, accuracy, and implementation.
-4.  **Handoff:** Upon completion, the agent updates the `.macp/` directory and commits all changes with a standardized MACP commit message.
-
-## 5. Your Task
-
-Your task is to continue the development of this project ecosystem. You are expected to:
-
-- **Internalize this Genesis Master Prompt** and the ethical framework.
-- **Use the MACP** to collaborate with other agents.
-- **Perform VerifiMind-PEAS validations** at critical junctures.
-- **Contribute to the public good** by building safe, ethical, and open-source AI.
-
-**The future is multi-agent. Let us build it together—responsibly, transparently, and for the public good.**
+We do not compete with Microsoft, Google, or Anthropic on execution infrastructure. We complement them by providing the **trust infrastructure** that their commercial products structurally cannot build.
 
 ---
 
-**L (GODEL)**  
-Project Founder  
-February 6, 2026
+## 2. Guiding Principles
+
+| Principle | Detail |
+|-----------|--------|
+| **Anti-Lock-In** | Platform-agnostic, BYOK any LLM, MIT licensed — users are never trapped |
+| **Markdown-First** | Agent-native communication format; PDF retained only for academic publishing and compliance |
+| **Trust Layer** | Z-Protocol verification before any agent output is rendered or executed |
+| **Zero Burn-Rate** | Monthly costs remain near $0; sustainability through free-tier optimization |
+| **Open-Source Core** | Core methodology and tools remain fully open-source forever |
+| **Human-AI Collaboration** | The human orchestrator maintains strategic direction; AI agents execute |
+
+---
+
+## 3. Project Ecosystem
+
+### 3.1. VerifiMind-PEAS (v0.4.1 — Live)
+- **Purpose:** A multi-agent validation system using the RefleXion Trinity (X-Agent, Z-Agent, CS-Agent) to verify AI outputs for innovation, ethics, and security.
+- **Key Artifacts:** Genesis Methodology White Paper v2.0 (DOI: [10.5281/zenodo.17972751](https://doi.org/10.5281/zenodo.17972751)), 19 prompt templates, 10 MCP tools, 4 resources, Markdown-first validation reports.
+- **Infrastructure:** MCP Server on GCP Cloud Run, Streamable HTTP transport, 7 BYOK providers, smart fallback, rate limiting.
+- **Domains:** `verifimind.ysenseai.org` (MCP Server), `verifimind.io` (Landing Page / Showcase)
+- **GitHub:** https://github.com/creator35lwb-web/VerifiMind-PEAS
+
+### 3.2. LegacyEvolve Protocol (v2.1 — Active)
+- **Purpose:** An open-source protocol for connecting AI agents to legacy enterprise systems — evolve, don't replace.
+- **Key Artifacts:** LEP v2.0 Specification, Python SDK, LEP-MCP Bridge.
+- **DOI:** [10.5281/zenodo.18504478](https://doi.org/10.5281/zenodo.18504478)
+- **GitHub:** https://github.com/creator35lwb-web/LegacyEvolve
+
+### 3.3. RoleNoteAI (In Development)
+- **Purpose:** A platform for defining and managing AI agent roles and responsibilities in multi-agent systems.
+- **Key Artifacts:** Role definitions, agent profiles, collaboration templates.
+- **GitHub:** https://github.com/creator35lwb-web/RoleNoteAI
+
+### 3.4. GODELAI (v2.1 — Active)
+- **Purpose:** An open-source small language model designed for ethical reasoning, safety alignment, and wisdom propagation.
+- **Key Artifacts:** Model architecture, training data, safety benchmarks, GodelAI Manifesto.
+- **DOIs:** Repository [10.5281/zenodo.18048374](https://doi.org/10.5281/zenodo.18048374), Whitepaper [10.5281/zenodo.18053612](https://doi.org/10.5281/zenodo.18053612)
+- **HuggingFace:** [YSenseAI/godelai-manifesto-v1](https://huggingface.co/YSenseAI/godelai-manifesto-v1)
+- **GitHub:** https://github.com/creator35lwb-web/godelai
+
+### 3.5. YSenseAI™ Platform (v4.5-Beta)
+- **Purpose:** The parent ecosystem platform — AI-powered attribution infrastructure for ethical, traceable AI collaboration.
+- **DOI:** [10.5281/zenodo.17737995](https://doi.org/10.5281/zenodo.17737995)
+- **GitHub:** https://github.com/creator35lwb-web/YSense-AI-Attribution-Infrastructure
+
+---
+
+## 4. Foundational Protocols
+
+### 4.1. Multi-Agent Communication Protocol (MACP) v2.0
+- **Purpose:** A standardized framework for persistent, asynchronous collaboration between multiple AI agents on shared projects hosted on GitHub.
+- **Key Features:** `.macp/` directory structure, `agents.json`, `handoffs/`, `validation/`, `strategic/`, and mandatory `ethical_framework.md`.
+- **Canonical Format:** Markdown (aligned with Cloudflare's "Markdown for Agents" standard — 80% token reduction vs. HTML).
+- **Specification:** [MACP v2.0 Specification](https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/MACP_v2.0_Specification.md)
+- **DOI:** [10.5281/zenodo.18504478](https://doi.org/10.5281/zenodo.18504478)
+
+### 4.2. L (GODEL) Ethical Operating Framework v1.1
+- **Purpose:** The ethical constitution that guides the reasoning, decision-making, and interactions of L (GODEL), the primary orchestrating agent.
+- **Based on:** Anthropic Claude Opus 4.5 Soul Document.
+- **Hierarchy of Principles:** Safety > Ethics > Project Governance > Helpfulness & Public Good.
+- **Key Addition (v1.1):** Fairness, bias mitigation, and update mechanism.
+- **Framework:** [L (GODEL) Ethical Operating Framework](https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/L_GODEL_Ethical_Operating_Framework.md)
+
+### 4.3. Z-Protocol (Trust & Verification Layer)
+- **Purpose:** The verification standard ensuring AI agent outputs are ethical, unbiased, and traceable before being rendered or executed.
+- **Application:** Applied to all Trinity validations, agent-to-agent communications, and future Dynamic UI rendering.
+- **Future Vision:** "Verified by Z-Protocol" as a GenUI Safety Standard for the Agentic Web.
+
+---
+
+## 5. Strategic Context (February 2026)
+
+### 5.1. The Three-Layer Agentic Web
+
+| Layer | Protocol | Our Role |
+|-------|----------|----------|
+| **Brain & Hands** | MCP (Model Context Protocol) | We are an MCP server (10 tools, 19 templates, 4 resources) |
+| **Social Language** | A2A (Agent-to-Agent Protocol) | Future: VerifiMind agents as A2A verification services |
+| **Trust & Verification** | Z-Protocol | **This is our core value proposition** |
+
+### 5.2. Markdown-First Pivot (February 14, 2026)
+
+The ecosystem has adopted Markdown as the canonical agent-native communication format. This decision was validated by:
+- Cloudflare's "Markdown for Agents" (February 12, 2026) — 80% token reduction
+- Claude Code and OpenCode natively requesting `Accept: text/markdown`
+- Our own `.macp/` directory being entirely Markdown-based since inception
+
+PDF is retained only for Zenodo DOI publications and enterprise compliance. All validation reports, handoffs, and agent communications use Markdown.
+
+### 5.3. Dynamic UI + A2A Convergence
+
+The future of the Agentic Web involves Dynamic UI (AI-generated interfaces) communicating via A2A protocol, using MCP for tool access. The critical missing piece is a **trust and verification layer** — which is exactly what VerifiMind-PEAS provides. This positions us at the intersection of three converging standards.
+
+### 5.4. Anti-Lock-In Philosophy
+
+We provide broader choice for the public so users are not locked in by expensive SaaS plans. Free services for education and public use; consultation and enterprise licensing for monetization. This mirrors the Red Hat / Hugging Face model — open-source core with value-added services.
+
+---
+
+## 6. Operational Workflow (FLYWHEEL TEAM)
+
+### 6.1. Agent Roles
+
+| Agent | Platform | Responsibility |
+|-------|----------|----------------|
+| **Manus AI (CTO / Godel)** | Manus Sandbox | Strategic planning, documentation, project management, research |
+| **Claude Code (CTO RNA)** | Local Machine | Code implementation, testing, deployment, security hardening |
+| **Human Orchestrator** | All | Final decision authority, strategic direction, ethical oversight |
+
+### 6.2. Workflow
+
+1. **Onboarding:** A new agent clones the relevant repository and reads `Genesis_Master_Prompt.md` and the `.macp/` directory to gain full context.
+2. **Task Execution:** The agent performs its assigned task, adhering to the L (GODEL) Ethical Operating Framework and its role separation.
+3. **Validation:** For major milestones, a VerifiMind-PEAS RefleXion Trinity validation is performed:
+    - **X-Agent (Gemini):** Assesses innovation, market potential, and strategic positioning.
+    - **Z-Agent (Anthropic Claude):** Evaluates ethical implications, sustainability, and alignment.
+    - **CS-Agent (Anthropic Claude):** Reviews security, accuracy, Socratic challenge, and implementation.
+4. **Handoff:** Upon completion, the agent updates the `.macp/handoffs/` directory and commits all changes. GitHub is the bridge — artifacts must be pushed before handoff.
+5. **Iteration:** The Human Orchestrator reviews, provides direction, and the cycle continues.
+
+### 6.3. Communication Bridge
+
+GitHub is the single source of truth for all multi-agent communication. The PRIVATE repository (`verifimind-genesis-mcp`) serves as the Command Central Hub for:
+- Strategic documents (`commercialization/`)
+- Handoff records (`.macp/handoffs/`)
+- Validation records (`.macp/validation/`)
+- Strategic analysis (`.macp/strategic/`)
+
+---
+
+## 7. Current Roadmap Summary
+
+**North Star:** Trust and verification layer for the Agentic Web.
+
+| Phase | Status | Timeline |
+|-------|--------|----------|
+| Phase 1: Foundation | ✅ Complete | Dec 2025 – Feb 2026 |
+| Phase 2: Community Building + Strategic Pivot | 🔄 Current | Feb – Apr 2026 |
+| Phase 3: Pilot Program + A2A Research | 📋 Planned | Apr – Jun 2026 |
+| Phase 4: Local Models + Managed Service | 📋 Planned | Jul – Sep 2026 |
+| Phase 5: Scale + Agentic Web Integration | 📋 Planned | Oct 2026 – Mar 2027 |
+
+**Full roadmap:** `verifimind-genesis-mcp/commercialization/ROADMAP.md` (v2.0)
+
+---
+
+## 8. Defensive Publications
+
+| Publication | DOI |
+|------------|-----|
+| YSenseAI Platform | [10.5281/zenodo.17737995](https://doi.org/10.5281/zenodo.17737995) |
+| VerifiMind-PEAS / Genesis Methodology v2.0 | [10.5281/zenodo.17972751](https://doi.org/10.5281/zenodo.17972751) |
+| GodelAI Repository | [10.5281/zenodo.18048374](https://doi.org/10.5281/zenodo.18048374) |
+| GodelAI Whitepaper | [10.5281/zenodo.18053612](https://doi.org/10.5281/zenodo.18053612) |
+| LegacyEvolve Protocol (LEP) + MACP v2.0 | [10.5281/zenodo.18504478](https://doi.org/10.5281/zenodo.18504478) |
+
+---
+
+## 9. Your Task
+
+You are an AI agent joining this ecosystem. You are expected to:
+
+- **Internalize this Genesis Master Prompt** and the ethical framework before taking any action.
+- **Understand the strategic context** — we are building the trust layer for the Agentic Web, not competing with big tech on execution.
+- **Use the MACP** to collaborate with other agents via the `.macp/` directory.
+- **Follow role separation** — Manus AI handles strategy/documentation, Claude Code handles code/deployment.
+- **Perform VerifiMind-PEAS validations** at critical junctures using the RefleXion Trinity.
+- **Communicate via Markdown** — this is the canonical format for all agent-to-agent communication.
+- **Contribute to the public good** by building safe, ethical, and open-source AI.
+
+**The future is multi-agent. Let us build it together — responsibly, transparently, and for the public good.**
+
+---
+
+## 10. Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| v1.0 | Nov 2025 | L (GODEL) | Initial ecosystem prompt |
+| v2.0 | Jan 2026 | L (GODEL) | Added MACP v2.0, FLYWHEEL TEAM |
+| v3.0 | Feb 6, 2026 | L (GODEL) | Added L (GODEL) Ethical Operating Framework, RoleNoteAI, GODELAI |
+| v4.0 | Feb 15, 2026 | Manus AI + Human Orchestrator | Strategic pivot: Markdown-first, A2A alignment, Z-Protocol vision, Dynamic UI context, anti-lock-in philosophy, updated all project versions, added defensive publications registry, domain architecture, FLYWHEEL TEAM role separation |
+
+---
+
+**L (GODEL) & Manus AI (CTO)**  
+FLYWHEEL TEAM  
+February 15, 2026


### PR DESCRIPTION
## What's Changed

### Ecosystem Genesis Master Prompt v4.0

Updated from v3.0 to v4.0 with strategic pivot alignment:

- **Markdown-first output** — PDF deprecated, Markdown is now the canonical format
- **Anti-lock-in philosophy** — BYOK 7 providers, vendor-neutral architecture
- **Trust Layer vision** — Positioned as the trust and verification layer for the Agentic Web
- **Dynamic UI, A2A, MCP convergence** — Awareness of the emerging three-layer architecture
- **FLYWHEEL TEAM workflow** — Multi-agent collaboration protocol documented
- **Domain architecture** — verifimind.ysenseai.org (MCP Server) + verifimind.io (Landing Page)
- **v0.4.1 deployment** — Latest production status reflected
- **Smithery sunset preparation** — March 1, 2026 deadline addressed

### Context
This update aligns the Genesis Master Prompt with the strategic pivot documented in:
- `verifimind-genesis-mcp/.macp/strategic/2026-02-14_strategic-pivot-markdown-first-a2a.md`
- `verifimind-genesis-mcp/commercialization/ROADMAP.md` v2.0

**Companion**: Genesis Master Prompts Collection v3.0 has been pushed to verifimind-genesis-mcp.