### PR TITLE
v0.4.2: Fix Trinity crash, Gemini model update, version alignment

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -31,7 +31,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.4.1"
+SERVER_VERSION = "0.4.2"
 
 # Custom route handlers
 async def health_handler(request):

--- a/mcp-server/src/verifimind_mcp/config/standard_config.py
+++ b/mcp-server/src/verifimind_mcp/config/standard_config.py
@@ -20,7 +20,7 @@ class LLMConfig:
     """Standard LLM configuration for consistent results."""
     
     # Model Selection (Pinned Versions)
-    x_agent_model: str = "gemini-2.0-flash-exp"  # Google Gemini 2.0 Flash (creative, free tier)
+    x_agent_model: str = "gemini-2.5-flash"  # Google Gemini 2.5 Flash (creative, free tier)
     z_agent_model: str = "claude-3-haiku-20240307"  # Anthropic Claude Haiku (pinned)
     cs_agent_model: str = "claude-3-haiku-20240307"  # Anthropic Claude Haiku (pinned)
     

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -18,7 +18,7 @@ Tools Exposed:
 - run_full_trinity - Run complete X → Z → CS validation
 
 Author: Alton Lee
-Version: 0.4.0 (Unified Prompt Templates)
+Version: 0.4.2 (Gemini 2.5-flash, Trinity fix, transparent mock)
 """
 
 import json
@@ -167,7 +167,7 @@ def get_project_info() -> dict[str, Any]:
         "methodology": "Genesis Methodology",
         "version": "2.0.1",
         "architecture": "RefleXion Trinity (X-Z-CS)",
-        "mcp_server_version": "0.4.0",
+        "mcp_server_version": "0.4.2",
         "agents": {
             "X": {
                 "name": "X Intelligent",
@@ -577,9 +577,15 @@ def _create_mcp_instance():
         # Check Accept header for markdown content negotiation
         output_format = "json"
         if ctx and hasattr(ctx, 'request_context'):
-            req_ctx = ctx.request_context or {}
-            accept = req_ctx.get('accept', '')
-            if 'text/markdown' in accept:
+            req_ctx = ctx.request_context
+            # RequestContext may be a dict or object — handle both safely
+            if isinstance(req_ctx, dict):
+                accept = req_ctx.get('accept', '')
+            elif hasattr(req_ctx, 'get'):
+                accept = req_ctx.get('accept', '')
+            else:
+                accept = getattr(req_ctx, 'accept', '')
+            if 'text/markdown' in str(accept):
                 output_format = "markdown"
         try:
             from .models import Concept, PriorReasoning

--- a/mcp-server/src/verifimind_mcp/utils/metrics.py
+++ b/mcp-server/src/verifimind_mcp/utils/metrics.py
@@ -79,7 +79,7 @@ class AgentMetrics:
                 },
             },
             "gemini": {
-                "gemini-2.0-flash-exp": {
+                "gemini-2.5-flash": {
                     "input": 0.0,  # FREE (within limits)
                     "output": 0.0,  # FREE (within limits)
                 },


### PR DESCRIPTION
## Summary
- Fix `run_full_trinity` crash: `RequestContext` object has no attribute `get`
- Update stale `gemini-2.0-flash-exp` to `gemini-2.5-flash` in standard config
- Update metrics pricing table for `gemini-2.5-flash`
- Bump version to 0.4.2 across http_server, server.py, project_info

## Root Cause
The `ctx.request_context` in FastMCP is not always a dict — when it's a `RequestContext` object, calling `.get()` crashes. Fixed by checking type before access.

## Test plan
- [ ] `run_full_trinity` completes without crash
- [ ] `consult_agent_x/z/cs` return real Gemini analysis
- [ ] Health endpoint reports v0.4.2
- [ ] Deploy to GCP Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)