### PR TITLE
fix: resolve all 13 open CodeQL code scanning alerts

### DIFF
--- a/examples/demo_iterative_generation.py
+++ b/examples/demo_iterative_generation.py
@@ -231,7 +231,7 @@ Press Enter to start...
 
     # Run iterative generation
     try:
-        generated_app, history = await generator.generate_with_iterations(
+        _generated_app, _history = await generator.generate_with_iterations(
             spec=app_spec,
             output_dir="output"
         )

--- a/examples/interactive_generation.py
+++ b/examples/interactive_generation.py
@@ -64,7 +64,7 @@ async def interactive_app_generation():
 
     if not user_idea.strip():
         print("\n[ERROR] No app idea provided. Exiting.")
-        return
+        return None
 
     print()
     print("[Received] Your app idea:")
@@ -178,7 +178,7 @@ async def interactive_app_generation():
     if decision['decision'] == 'REJECT':
         print("\n[ERROR] Your app idea was rejected by the validation agents.")
         print("Please review the recommendations and try again.")
-        return
+        return None
 
     print()
 

--- a/examples/interactive_generation_with_attribution.py
+++ b/examples/interactive_generation_with_attribution.py
@@ -54,14 +54,14 @@ async def interactive_app_generation_with_attribution():
         if not creator:
             print(f"\n[ERROR] No creator found with email: {email}")
             print("Please register as a new creator.")
-            return
+            return None
 
         # Find private key file
         key_file = Path(f"./data/attribution/keys/{creator.creator_id}_private.key")
         if not key_file.exists():
             print(f"\n[ERROR] Private key file not found.")
             print(f"Expected: {key_file}")
-            return
+            return None
 
         with open(key_file, 'r', encoding='utf-8') as f:
             lines = f.readlines()
@@ -73,7 +73,7 @@ async def interactive_app_generation_with_attribution():
             print(f"\n[SUCCESS] Welcome back, {session.creator.name}!")
         except Exception as e:
             print(f"\n[ERROR] Login failed: {e}")
-            return
+            return None
     else:
         # Register new creator
         print("Let's register you as a new creator!")
@@ -116,7 +116,7 @@ async def interactive_app_generation_with_attribution():
 
     if not user_idea.strip():
         print("\n[ERROR] No app idea provided. Exiting.")
-        return
+        return None
 
     print()
     print("[Received] Your app idea:")
@@ -231,7 +231,7 @@ async def interactive_app_generation_with_attribution():
     if decision['decision'] == 'REJECT':
         print("\n[ERROR] Your app idea was rejected by the validation agents.")
         print("Please review the recommendations and try again.")
-        return
+        return None
 
     print()
 

--- a/mcp-server/src/verifimind_mcp/config_helper.py
+++ b/mcp-server/src/verifimind_mcp/config_helper.py
@@ -183,7 +183,7 @@ def _get_provider_from_session_config(ctx: Any, agent_id: str):
                 return provider_class(api_key=api_key)
 
     except (AttributeError, TypeError):
-        pass
+        pass  # Session config doesn't have expected attributes — fall through
 
     return None
 

--- a/mcp-server/src/verifimind_mcp/reporting/markdown_reporter.py
+++ b/mcp-server/src/verifimind_mcp/reporting/markdown_reporter.py
@@ -8,8 +8,8 @@ and agent-native communication standards (Cloudflare, A2A, MCP).
 v0.4.1 — February 2026
 """
 
-from datetime import datetime, timezone
-from typing import List, Optional
+from datetime import timezone
+from typing import List
 
 from ..models.results import TrinityResult, TrinitySynthesis
 from ..models.reasoning import (

--- a/mcp-server/src/verifimind_mcp/templates/import_url.py
+++ b/mcp-server/src/verifimind_mcp/templates/import_url.py
@@ -176,14 +176,14 @@ def _parse_template_content(
     try:
         data = json.loads(content)
     except json.JSONDecodeError:
-        pass
+        pass  # Not JSON — fall through to try YAML
 
     # Try YAML if JSON failed
     if data is None:
         try:
             data = yaml.safe_load(content)
         except yaml.YAMLError:
-            pass
+            pass  # Not YAML either — will return error below
 
     if data is None:
         return None, warnings, "Content is not valid JSON or YAML"

--- a/mcp-server/tests/unit/reporting/test_markdown_reporter.py
+++ b/mcp-server/tests/unit/reporting/test_markdown_reporter.py
@@ -2,7 +2,6 @@
 Unit tests for Markdown report generation.
 """
 
-import pytest
 from datetime import datetime, timezone
 
 from verifimind_mcp.models.reasoning import (

--- a/src/core/concept_scrutinizer.py
+++ b/src/core/concept_scrutinizer.py
@@ -515,8 +515,8 @@ CRITICAL: Return ONLY valid JSON (no markdown, no explanation):
             if isinstance(result, list):
                 return [str(c).strip() for c in result if c and len(str(c).strip()) > 10]
         except (json.JSONDecodeError, TypeError):
-            pass
-        
+            pass  # Not a valid JSON array — fall through to line-based extraction
+
         # Fallback: Extract from various list formats
         lines = content.split('\n')
         challenges = []

--- a/src/core/markdown_reporter.py
+++ b/src/core/markdown_reporter.py
@@ -13,7 +13,7 @@ drop-in replacement in verifimind_complete.py.
 import os
 import re
 from datetime import datetime, timezone
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 from src.core.logging_config import get_logger
 

--- a/tests/test_enhanced_agents.py
+++ b/tests/test_enhanced_agents.py
@@ -307,7 +307,7 @@ async def test_enhanced_features():
 
     # Test 1: LLM fallback system
     print_subsection("1. Intelligent Fallback System")
-    provider = LLMProviderFactory.create_provider("openai", model="gpt-4")
+    _provider = LLMProviderFactory.create_provider("openai", model="gpt-4")
     print("[OK] Provider supports graceful fallback to mock data")
 
     # Test 2: Compliance framework coverage


### PR DESCRIPTION
## Summary
- Remove 4 unused imports (`Optional`, `datetime`, `pytest`) across 4 files
- Add explanatory comments to 4 empty `except` blocks (CodeQL `py/empty-except`)
- Fix 2 mixed implicit/explicit return issues with explicit `return None`
- Prefix 3 unused local variables with underscore (`_provider`, `_generated_app`, `_history`)

## Files Modified (10)
- `mcp-server/src/verifimind_mcp/reporting/markdown_reporter.py`
- `mcp-server/src/verifimind_mcp/templates/import_url.py`
- `mcp-server/src/verifimind_mcp/config_helper.py`
- `mcp-server/tests/unit/reporting/test_markdown_reporter.py`
- `src/core/markdown_reporter.py`
- `src/core/concept_scrutinizer.py`
- `examples/interactive_generation.py`
- `examples/interactive_generation_with_attribution.py`
- `examples/demo_iterative_generation.py`
- `tests/test_enhanced_agents.py`

## Test plan
- [ ] CI checks pass (Bandit SAST, CodeQL, Tests, Safety, Security)
- [ ] CodeQL re-scan shows 0 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)