### PR TITLE
fix: force Gemini JSON mode for reliable structured output

### DIFF
--- a/mcp-server/src/verifimind_mcp/llm/provider.py
+++ b/mcp-server/src/verifimind_mcp/llm/provider.py
@@ -545,6 +545,12 @@ class GeminiProvider(LLMProvider):
             # Create model instance
             model = self.genai.GenerativeModel(self.model)
 
+            # v0.4.3.1: Force JSON output mode (no schema constraints).
+            # response_mime_type alone constrains Gemini to output valid JSON
+            # without the $ref/$defs issues that response_schema causes.
+            if output_schema:
+                gen_config["response_mime_type"] = "application/json"
+
             # Generate response
             response = model.generate_content(
                 prompt,


### PR DESCRIPTION
## Summary
- Add `response_mime_type: "application/json"` to Gemini generation config
- No `response_schema` (avoids `$ref/$defs` issues from Pydantic models)
- Combined with prompt-level schema guidance = reliable single JSON output
- Fixes: Gemini returning individual reasoning steps as separate objects

## Test plan
- [ ] X Agent returns full model (not individual reasoning steps)
- [ ] Full Trinity completes all 3 stages with real inference
- [ ] `_agent_chain_status` shows "real" for all agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)