### PR TITLE
revert: remove Gemini JSON mode causing silent failures

### DIFF
--- a/mcp-server/src/verifimind_mcp/llm/provider.py
+++ b/mcp-server/src/verifimind_mcp/llm/provider.py
@@ -545,12 +545,6 @@ class GeminiProvider(LLMProvider):
             # Create model instance
             model = self.genai.GenerativeModel(self.model)
 
-            # v0.4.3.1: Force JSON output mode (no schema constraints).
-            # response_mime_type alone constrains Gemini to output valid JSON
-            # without the $ref/$defs issues that response_schema causes.
-            if output_schema:
-                gen_config["response_mime_type"] = "application/json"
-
             # Generate response
             response = model.generate_content(
                 prompt,


### PR DESCRIPTION
## Summary
- Reverts `response_mime_type: "application/json"` from PR #42
- Gemini JSON mode causes silent failures on Cloud Run (empty 200 response)
- Keeps all other v0.4.3.1 fixes: strong prompt guidance, code fence stripping, C-S-P chain status

## Test plan
- [ ] Trinity no longer returns empty responses
- [ ] All 3 agents produce structured output via prompt guidance alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)