### PR TITLE
fix: use correct JSON Schema keys in defaults

### DIFF
--- a/mcp-server/src/verifimind_mcp/llm/provider.py
+++ b/mcp-server/src/verifimind_mcp/llm/provider.py
@@ -524,12 +524,13 @@ class GeminiProvider(LLMProvider):
 
             if field_type == "number" or field_type == "integer":
                 # Score fields (0-10) get neutral 5.0, confidence (0-1) gets 0.5
-                ge = prop.get("ge", 0)
-                le = prop.get("le", 10)
-                if le <= 1.0:
+                # JSON Schema uses "minimum"/"maximum" (Pydantic ge/le map to these)
+                lo = prop.get("minimum", prop.get("exclusiveMinimum", 0))
+                hi = prop.get("maximum", prop.get("exclusiveMaximum", 10))
+                if hi <= 1.0:
                     data[field] = 0.5
                 else:
-                    data[field] = round((ge + le) / 2, 1)
+                    data[field] = round((lo + hi) / 2, 1)
             elif field_type == "boolean":
                 # Conservative default
                 data[field] = False


### PR DESCRIPTION
## Summary
- Fixes `_fill_schema_defaults` to read `minimum`/`maximum` (JSON Schema standard) instead of `ge`/`le` (Pydantic internal)
- Without this, all numeric fields got default 5.0 even when they should be 0.5 (confidence)

## Test plan
- [ ] Deploy and verify confidence defaults are 0.5 not 5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)