### PR TITLE
fix: route CS Agent to Groq for reliable parsing

### DIFF
--- a/mcp-server/src/verifimind_mcp/config_helper.py
+++ b/mcp-server/src/verifimind_mcp/config_helper.py
@@ -49,7 +49,7 @@ AGENT_PROVIDER_DEFAULTS = {
     },
     "CS": {
         "default": "gemini",           # FREE tier
-        "recommended": "anthropic",    # Claude excels at code/security
+        "recommended": "groq",         # v0.4.4: Groq/Llama for reliable structured security output
         "fallback": "gemini"
     }
 }


### PR DESCRIPTION
## Summary
- Routes CS Agent to Groq/Llama (same as Z Agent) for reliable structured JSON output
- Gemini consistently produces `fallback` quality for CS Agent in Trinity pipeline due to long prior reasoning context
- Multi-model config: X=Gemini (creative), Z=Groq (ethics), CS=Groq (security)

## Test results
- X Agent (Gemini): `real` - innovation=8.5, strategic=9.0
- Z Agent (Groq): `real` - ethics=8.0, compliance=true  
- CS Agent (Gemini): `fallback` - consistently fails to produce complete JSON
- After routing CS to Groq: expecting `real` quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)