### PR TITLE
docs: Update README to v0.4.4 — Multi-Model Trinity, 1,750+ hours, 662 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
   Transform your vision into validated, ethical, secure applications through systematic multi-model AI orchestration — from concept to deployment, with human-centered wisdom validation.
 
-  [![Version](https://img.shields.io/badge/version-v0.4.1-blue.svg)](CHANGELOG.md)
+  [![Version](https://img.shields.io/badge/version-v0.4.4-blue.svg)](CHANGELOG.md)
   [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
   [![Status](https://img.shields.io/badge/status-Operational-success.svg)](SERVER_STATUS.md)
   [![Genesis v2.0 DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17972751.svg)](https://doi.org/10.5281/zenodo.17972751)
@@ -26,7 +26,7 @@
 
 ## MCP Server: Production Deployed
 
-> **v0.4.1 Live** — 1,190+ verified consultation hours delivered | 85%+ MCP integration rate | Markdown-first output with content negotiation, Unified Prompt Templates with 19 pre-built templates, 10 MCP tools, input sanitization, and CI/CD pipeline. Trinity validation fully operational with Gemini 2.5-flash. [Health Check](https://verifimind.ysenseai.org/health)
+> **v0.4.4 Live** — 1,750+ verified consultation hours delivered | 662 users | 80%+ MCP integration rate | **Multi-Model Trinity: X=Gemini, Z=Groq/Llama, CS=Groq/Llama** | `_overall_quality: "full"` — all agents returning real inference | C-S-P methodology pipeline | 10 MCP tools, 19 templates, input sanitization, and CI/CD pipeline. [Health Check](https://verifimind.ysenseai.org/health)
 
 VerifiMind PEAS is now **live and accessible** across multiple platforms:
 
@@ -181,10 +181,12 @@ Automated testing and security scanning runs on every push to `main` via GitHub 
 
 | Metric | Value | Methodology |
 |--------|-------|-------------|
-| **Verified Consultation Hours** | **1,190+** (all-time) | Session duration: first-to-last request per user per day. Scrapers excluded via User-Agent audit classification. |
-| **MCP Integration Rate** | **85%+** | Programmatic (Node.js + Python) vs. browser traffic by User-Agent header |
+| **Verified Consultation Hours** | **1,750+** (all-time) | Session duration: first-to-last request per user per day. Scrapers excluded via User-Agent audit classification. |
+| **Total Users** | **662** | Unique users across all platforms |
+| **MCP Integration Rate** | **80%+** | Programmatic (Node.js + Python) vs. browser traffic by User-Agent header |
 | **MCP Tools Available** | **10** (4 core + 6 template) | Core: consult_agent_x, consult_agent_z, consult_agent_cs, run_full_trinity |
-| **LLM Providers** | **7** | Gemini, Claude, Perplexity, OpenAI, Mistral, Grok, DeepSeek |
+| **Multi-Model Providers** | **X=Gemini, Z=Groq, CS=Groq** | Per-agent provider routing for optimal structured output |
+| **Trinity Quality** | **`_overall_quality: "full"`** | All 3 agents returning real inference (v0.4.4+) |
 
 ### Adoption Trajectory (Flying Hours ✈️)
 
@@ -196,15 +198,17 @@ Automated testing and security scanning runs on every push to `main` via GitHub 
 | W05 | Jan 27–Feb 02 | 309.6h | 725h | 105 |
 | W06 | Feb 03–09 | 425.4h | 1,151h | 117 |
 | W07 | Feb 10–16 | 409.0h | 1,198h | 172 |
+| W08 | Feb 16–22 | 404.8h | 1,556h | 143 |
+| W09 | Feb 23–Mar 1 | 198.5h | 1,755h | 46 |
 
 ### Traffic Classification Breakdown
 
 | Category | Share | Hours | Description |
 |----------|-------|-------|-------------|
-| **MCP Client** | 84.5% | 1,047h | Tool users via Node.js/Python MCP clients |
-| **Human Browser** | 6.2% | 77h | Direct web visitors (HuggingFace, landing page) |
-| **API Integration** | 6.0% | 74h | Programmatic API consumers |
-| **Scraper** | 3.4% | 42h | Excluded from verified total |
+| **MCP Client** | 80.3% | 1,409.5h | Tool users via Node.js/Python MCP clients |
+| **Human Browser** | 4.7% | 82.9h | Direct web visitors (HuggingFace, landing page) |
+| **API Integration** | 15.0% | 262.3h | Programmatic API consumers |
+| **Scraper** | — | Excluded | Excluded from verified total |
 
 > **Verified Total** = MCP + Browser + API. Scrapers excluded. Owner/Bot excluded.
 
@@ -220,7 +224,7 @@ Automated testing and security scanning runs on every push to `main` via GitHub 
 
 > **Key Insight:** Over 85% of all traffic is machine-to-machine MCP integration, confirming VerifiMind PEAS is used as an integrated tool in developer workflows — not merely visited as a web demo. This traffic is invisible to traditional web analytics platforms like SimilarWeb.
 
-> **Data Source:** GCP Cloud Run HTTP Load Balancer logs. Audit classification via User-Agent analysis. Owner traffic excluded. Scraper traffic excluded via conservative classification. Full methodology documented in internal reports (Report 016). Last updated: 2026-02-17.
+> **Data Source:** GCP Cloud Run HTTP Load Balancer logs. Audit classification via User-Agent analysis. Owner traffic excluded. Scraper traffic excluded via conservative classification. Full methodology documented in internal reports (Report 024). Last updated: 2026-02-26.
 
 ---
 
@@ -264,6 +268,18 @@ We provide a systematic approach to **multi-model AI validation** that ensures y
 
 ## 🎯 Latest Achievements
 
+### v0.4.4 — Multi-Model Trinity: Full Quality (February 27, 2026)
+
+The v0.4.4 release achieves **`_overall_quality: "full"`** — all three Trinity agents now return real AI inference with zero fallback defaults. Agent X (Innovator) runs on Gemini 2.5 Flash for creative analysis, while Agent Z (Guardian) and Agent CS (Validator) are routed to Groq/Llama-3.3-70b for reliable structured JSON output. The GroqProvider was upgraded with the full C-S-P extraction pipeline: `strip_markdown_code_fences()`, `_extract_best_json()` with field-overlap scoring, `_merge_json_objects()`, and `_fill_schema_defaults()`. Quality markers (`_inference_quality`, `_agent_chain_status`, `_overall_quality`) are embedded in every response for full transparency. 16 PRs merged (#33–#48), all CI passed. 12 new unit tests added.
+
+### v0.4.3 — C-S-P Pipeline & System Notice (February 27, 2026)
+
+The v0.4.3 release implements the **C-S-P (Compression–State–Propagation) methodology** from the GodelAI framework, applied directly to the Trinity pipeline. Robust JSON extraction with `raw_decode()` and field-overlap scoring replaces brittle regex parsing. State validation checkpoints between Trinity stages prevent garbage propagation. System notice (`_system_notice`) field added to all tool responses for transparent user communication. Gemini JSON mode (`response_mime_type: "application/json"`) tested and integrated.
+
+### v0.4.2 — Mock Mode Resolved & Transparent Disclosure (February 26, 2026)
+
+The v0.4.2 release resolves the **mock mode issue** that affected all Trinity consultations from v0.4.0–v0.4.1. The root cause was a deprecated Gemini model endpoint (`gemini-2.0-flash` → `gemini-2.5-flash`). A transparent disclosure was published ([Discussion #31](https://github.com/creator35lwb-web/VerifiMind-PEAS/discussions/31)) acknowledging the issue and explaining the "Structural Scaffolding Value" thesis — even in mock mode, the framework provided value by forcing structured multi-perspective reasoning. CodeQL security alerts reduced from 13 to 0.
+
 ### Genesis v3.1 — CS Agent Multi-Stage Verification Protocol (February 2026)
 
 Genesis v3.1 introduces a **4-Stage Security Verification Protocol** for the CS Agent: Detection → Self-Examination (MANDATORY) → Severity Rating → Human Review. Self-examination is mandatory — every finding must be proven AND disproven before escalation. No auto-fixes. Human oversight is always the final stage. This is a workflow enhancement only — zero code changes to the server foundation. Inspired by [Claude Code Security](https://docs.anthropic.com/en/docs/claude-code/security) principles. Full protocol documentation: [`docs/security/`](docs/security/).
@@ -295,11 +311,17 @@ The standardization phase generated **57 complete Trinity validation reports** a
 | **Cost per Validation** | ~$0.003 | Sustainable for solo developers |
 | **Veto Rate** | 65% | Strong ethical safeguards working |
 | **LLM Providers** | 7 | Gemini, OpenAI, Anthropic, Groq, Mistral, Ollama, Perplexity |
+| **Multi-Model Routing** | X=Gemini, Z=Groq, CS=Groq | Per-agent provider optimization |
+| **Trinity Quality** | `_overall_quality: "full"` | All agents returning real inference (v0.4.4+) |
+| **Total Users** | 662 | Unique users across all platforms |
 
 ### **Version History**
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.4.4** | Feb 27, 2026 | Multi-Model Trinity (`_overall_quality: "full"`), X=Gemini, Z/CS=Groq |
+| **v0.4.3** | Feb 27, 2026 | C-S-P pipeline, system notice, robust JSON extraction |
+| **v0.4.2** | Feb 26, 2026 | Mock mode resolved, transparent disclosure, CodeQL 13→0 |
 | **Genesis v3.1** | Feb 2026 | CS Agent 4-Stage Verification Protocol, zero code changes |
 | **v0.4.1** | Feb 14, 2026 | Markdown-first output, Smithery URL removal, PDF deprecated |
 | **v0.4.0** | Jan 30, 2026 | Unified Prompt Templates, 6 new tools, MACP v2.0 |


### PR DESCRIPTION
## Summary

Updates the README to reflect the v0.4.4 Multi-Model Trinity milestone and latest W09 metrics from COO AY.

### Changes
- **Version badge:** v0.4.1 → v0.4.4
- **MCP Server section:** Multi-Model Trinity with quality markers
- **Metrics:** 1,750+ hours, 662 users, 80%+ MCP rate (W09 data)
- **Adoption trajectory:** Added W08, W09 data
- **Traffic classification:** Updated with latest breakdown
- **Latest Achievements:** Added v0.4.2, v0.4.3, v0.4.4 milestones
- **Version History:** Added v0.4.2–v0.4.4 entries
- **Key Metrics:** Added Multi-Model Routing, Trinity Quality, Total Users

### FLYWHEEL TEAM
Session 8 — CTO T (Manus AI)