### PR TITLE
feat: v0.4.5 BYOK Live — per-tool-call provider override

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -31,7 +31,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.4.4"
+SERVER_VERSION = "0.4.5"
 
 # Custom route handlers
 async def health_handler(request):
@@ -58,7 +58,8 @@ async def health_handler(request):
             "quality_markers": True,
             "rate_limiting": True,
             "free_tier_default": True,
-            "input_sanitization": True
+            "input_sanitization": True,
+            "byok_live": True
         },
         "rate_limits": {
             "per_ip": f"{rate_stats['ip_limit']} req/{rate_stats['window_seconds']}s",


### PR DESCRIPTION
## Summary
- Add `llm_provider` and `api_key` as optional params to all 4 consultation tools (`consult_agent_x/z/cs`, `run_full_trinity`)
- Ephemeral providers created per-call, never stored — true BYOK in GCP Cloud Run production
- Auto-detects provider from API key prefix (`sk-ant-` → Anthropic, `gsk_` → Groq, `sk-` → OpenAI, `AIza` → Gemini)
- `run_full_trinity` supports global + per-agent overrides (`x_provider`, `z_api_key`, etc.)
- Version bump to 0.4.5 with `byok_live: true` feature flag in health endpoint
- 9 new `TestEphemeralProvider` unit tests (all passing)

## Files Changed
| File | Changes |
|------|---------|
| `config_helper.py` | `create_ephemeral_provider()` + `KEY_FORMAT_PATTERNS` |
| `server.py` | BYOK params on 4 tools, handler updates, version bump |
| `http_server.py` | Version bump, `byok_live` feature flag |
| `test_providers.py` | 9 new unit tests |

## Security
- Keys NEVER stored or logged — ephemeral per-call, GC'd after
- `sk-ant-` prefix checked before `sk-` to prevent Anthropic→OpenAI misroute
- Rate limiting unchanged (10 req/60s per IP)

## Test plan
- [ ] All 43 unit tests pass (9 new + 34 existing)
- [ ] Deploy to GCP Cloud Run
- [ ] Verify `/health` shows `0.4.5` + `byok_live: true`
- [ ] Smoke: `consult_agent_x` with Groq key → `_byok: true`
- [ ] Smoke: `consult_agent_x` without BYOK → `_byok: false`
- [ ] Full Trinity smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)