### PR TITLE
fix(tracer): AZ UUID bridge — TRACER_UUID stdout in coordination tools

### DIFF
--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -1371,6 +1371,9 @@ def _create_mcp_instance():
         if not allowed:
             return wrap_response(tier_gate_error())
 
+        # AZ UUID Bridge: emit pioneer_key to stdout for AY analytics ingestion (v0.5.12)
+        print(f"TRACER_UUID: {pioneer_key} tool=coordination_handoff_create", flush=True)
+
         try:
             record = build_handoff_record(
                 agent_id=agent_id,
@@ -1442,6 +1445,9 @@ def _create_mcp_instance():
         if not allowed:
             return wrap_response(tier_gate_error())
 
+        # AZ UUID Bridge: emit pioneer_key to stdout for AY analytics ingestion (v0.5.12)
+        print(f"TRACER_UUID: {pioneer_key} tool=coordination_handoff_read", flush=True)
+
         try:
             count = max(1, min(int(count), 50))
             store = get_store()
@@ -1506,6 +1512,9 @@ def _create_mcp_instance():
         allowed, tier = check_tier(pioneer_key)
         if not allowed:
             return wrap_response(tier_gate_error())
+
+        # AZ UUID Bridge: emit pioneer_key to stdout for AY analytics ingestion (v0.5.12)
+        print(f"TRACER_UUID: {pioneer_key} tool=coordination_team_status", flush=True)
 
         try:
             store = get_store()


### PR DESCRIPTION
## Summary

- AZ Tracer Bullet #1 (2026-04-08) confirmed: GCP Cloud Run silently discards HTTP POST JSON payloads from all log streams
- Pioneer UUIDs never reached GCP logs → AY analytics pipeline blind to Pioneer users → commercialization blocked
- Adds \`print(f"TRACER_UUID: {pioneer_key} tool=...")\` with \`flush=True\` to all 3 coordination tool handlers post tier-gate
- AZ can now run Tracer Bullet #2 to confirm UUID bridge is operational

**Handlers patched:** \`coordination_handoff_create\`, \`coordination_handoff_read\`, \`coordination_team_status\`

**Per:** \`20260408_AZ_pioneer_tracer_handoff.md\` + T deploy clearance \`20260408_T_polar_deploy_clearance_v0512.md\`

## Test plan

- [ ] CI passes
- [ ] Deploy v0.5.12 with 3 Polar env vars
- [ ] AZ fires Tracer Bullet #2 with Pioneer UUID \`019d40d6\`
- [ ] Confirm \`TRACER_UUID:\` line appears in GCP Log Explorer stdout stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)