### PR TITLE
fix: resolve 15 CodeQL notes + root cause fix for 50% connection failure rate

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -1061,6 +1061,7 @@ async def polar_webhook_handler(request):
 
 # Create Starlette app with proper lifespan from MCP app
 app = Starlette(
+    redirect_slashes=False,  # Prevent 307 trailing-slash redirect on /mcp → /mcp/ (MCP clients convert POST→GET on redirect)
     routes=[
         Route("/health", health_handler),
         Route("/", root_handler, methods=["GET", "HEAD"]),

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -393,21 +393,19 @@ class TestCoordinationToolsIntegration:
     @pytest.mark.asyncio
     async def test_create_returns_success(self):
         from verifimind_mcp.server import _create_mcp_instance
-        # Import tools directly from server module scope
-        import verifimind_mcp.server as srv
         # Rebuild instance to pick up fresh store
         _create_mcp_instance()
         # Call the tool function directly via the coordination module
-        from verifimind_mcp.middleware.tier_gate import check_tier, tier_gate_error, sanitize_handoff_content
+        import verifimind_mcp.middleware.tier_gate as tg
         from verifimind_mcp.coordination import get_store, format_handoff_markdown
         from verifimind_mcp.coordination.handoff_store import build_handoff_record
 
-        allowed, tier = await check_tier(VALID_KEY)
+        allowed, tier = await tg.check_tier(VALID_KEY)
         assert allowed is True
 
         record = build_handoff_record("RNA", "development", ["done"], ["dec"], ["art.py"], ["todo"], [], "XV")
         content = format_handoff_markdown(record)
-        content = sanitize_handoff_content(content)
+        content = tg.sanitize_handoff_content(content)
         record["content"] = content
         store = get_store()
         store.add(VALID_KEY, record)
@@ -416,10 +414,10 @@ class TestCoordinationToolsIntegration:
 
     @pytest.mark.asyncio
     async def test_create_scholar_blocked(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier, tier_gate_error
-        allowed, tier = await check_tier(INVALID_KEY)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, tier = await tg.check_tier(INVALID_KEY)
         assert allowed is False
-        err = tier_gate_error()
+        err = tg.tier_gate_error()
         assert err["error_code"] == "PIONEER_TIER_REQUIRED"
 
     @pytest.mark.asyncio
@@ -479,8 +477,8 @@ class TestCoordinationToolsIntegration:
 
     @pytest.mark.asyncio
     async def test_read_scholar_key_blocked(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, _ = await check_tier(INVALID_KEY)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, _ = await tg.check_tier(INVALID_KEY)
         assert allowed is False
 
     # -- coordination_team_status --
@@ -488,8 +486,8 @@ class TestCoordinationToolsIntegration:
     @pytest.mark.asyncio
     async def test_status_empty_store(self):
         from verifimind_mcp.coordination import get_store
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, tier = await check_tier(VALID_KEY)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, tier = await tg.check_tier(VALID_KEY)
         assert allowed is True
         records = get_store().get_all(VALID_KEY)
         assert records == []
@@ -528,8 +526,8 @@ class TestCoordinationToolsIntegration:
 
     @pytest.mark.asyncio
     async def test_status_scholar_blocked(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, _ = await check_tier(INVALID_KEY)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, _ = await tg.check_tier(INVALID_KEY)
         assert allowed is False
 
 
@@ -550,31 +548,31 @@ class TestTierEnforcement:
         importlib.reload(tg)
 
     async def test_scholar_cannot_access_coordination_create(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, tier = await check_tier(INVALID_KEY)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, tier = await tg.check_tier(INVALID_KEY)
         assert allowed is False
         assert tier == "scholar"
 
     async def test_scholar_cannot_access_coordination_read(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, _ = await check_tier("")
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, _ = await tg.check_tier("")
         assert allowed is False
 
     async def test_scholar_cannot_access_team_status(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, _ = await check_tier(None)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, _ = await tg.check_tier(None)
         assert allowed is False
 
     async def test_pioneer_can_access_all_coordination_tools(self):
-        from verifimind_mcp.middleware.tier_gate import check_tier
+        import verifimind_mcp.middleware.tier_gate as tg
         for tool in ["coordination_handoff_create", "coordination_handoff_read", "coordination_team_status"]:
-            allowed, tier = await check_tier(VALID_KEY)
+            allowed, tier = await tg.check_tier(VALID_KEY)
             assert allowed is True, f"{tool} should be allowed for Pioneer"
             assert tier == "pioneer"
 
     def test_tier_gate_error_structure(self):
-        from verifimind_mcp.middleware.tier_gate import tier_gate_error
-        err = tier_gate_error()
+        import verifimind_mcp.middleware.tier_gate as tg
+        err = tg.tier_gate_error()
         assert err["status"] == "error"
         assert err["tier_required"] == "pioneer"
         assert "upgrade_url" in err

--- a/mcp-server/tests/unit/test_v0513_fortify.py
+++ b/mcp-server/tests/unit/test_v0513_fortify.py
@@ -149,14 +149,14 @@ class TestTierGatePhase2:
         assert tier == "scholar"
 
     async def test_none_key_always_scholar(self, monkeypatch):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, tier = await check_tier(None)
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, tier = await tg.check_tier(None)
         assert allowed is False
         assert tier == "scholar"
 
     async def test_empty_key_always_scholar(self, monkeypatch):
-        from verifimind_mcp.middleware.tier_gate import check_tier
-        allowed, tier = await check_tier("")
+        import verifimind_mcp.middleware.tier_gate as tg
+        allowed, tier = await tg.check_tier("")
         assert allowed is False
         assert tier == "scholar"
 
@@ -190,8 +190,8 @@ class TestSanitizeHandoffContent:
     """sanitize_handoff_content() is now ACTIVE — strips real secrets."""
 
     def _sanitize(self, content: str) -> str:
-        from verifimind_mcp.middleware.tier_gate import sanitize_handoff_content
-        return sanitize_handoff_content(content)
+        import verifimind_mcp.middleware.tier_gate as tg
+        return tg.sanitize_handoff_content(content)
 
     def test_openai_key_redacted(self):
         result = self._sanitize("key: sk-abc123def456ghi789jkl012345678901234567890")
@@ -275,8 +275,8 @@ class TestSanitizeHandoffContentProviders:
     """
 
     def _s(self, content: str) -> str:
-        from verifimind_mcp.middleware.tier_gate import sanitize_handoff_content
-        return sanitize_handoff_content(content)
+        import verifimind_mcp.middleware.tier_gate as tg
+        return tg.sanitize_handoff_content(content)
 
     # --- OpenAI ---
     def test_openai_sk_proj_redacted(self):
@@ -510,10 +510,10 @@ class TestPolarCircuitBreaker:
     def _make_adapter(self):
         """Create an adapter with a mock PolarClient."""
         from unittest.mock import MagicMock
-        from verifimind_mcp.middleware.polar_adapter import PolarAdapter
+        import verifimind_mcp.middleware.polar_adapter as pa
         mock_client = MagicMock()
         mock_client.has_pioneer_access.return_value = True
-        adapter = PolarAdapter(mock_client, cache_ttl=300)
+        adapter = pa.PolarAdapter(mock_client, cache_ttl=300)
         return adapter, mock_client
 
     async def test_timeout_raises_and_tier_gate_denies(self, monkeypatch):
@@ -540,7 +540,7 @@ class TestPolarCircuitBreaker:
         """Polar 500 → PolarAdapter retries _RETRY_MAX_ATTEMPTS times, then fails."""
         import httpx
         from unittest.mock import AsyncMock, MagicMock
-        from verifimind_mcp.middleware.polar_adapter import PolarAdapter, _RETRY_MAX_ATTEMPTS
+        import verifimind_mcp.middleware.polar_adapter as pa
 
         adapter, mock_client = self._make_adapter()
 
@@ -558,15 +558,13 @@ class TestPolarCircuitBreaker:
             await adapter.check_pioneer_access("test-uuid-500-scenario-000001")
 
         # Should have attempted _RETRY_MAX_ATTEMPTS times
-        assert mock_client.get_customer_state.call_count == _RETRY_MAX_ATTEMPTS
+        assert mock_client.get_customer_state.call_count == pa._RETRY_MAX_ATTEMPTS
 
     async def test_circuit_breaker_opens_after_threshold(self, monkeypatch):
         """5 consecutive failures → circuit opens → CircuitOpenError raised."""
         import httpx
         from unittest.mock import AsyncMock, MagicMock
-        from verifimind_mcp.middleware.polar_adapter import (
-            PolarAdapter, CircuitOpenError, _CIRCUIT_FAILURE_THRESHOLD
-        )
+        import verifimind_mcp.middleware.polar_adapter as pa
 
         adapter, mock_client = self._make_adapter()
         mock_response = MagicMock()
@@ -577,18 +575,18 @@ class TestPolarCircuitBreaker:
         monkeypatch.setattr("asyncio.sleep", AsyncMock())
 
         # Trip the circuit by exhausting failures
-        for _ in range(_CIRCUIT_FAILURE_THRESHOLD):
+        for _ in range(pa._CIRCUIT_FAILURE_THRESHOLD):
             try:
                 await adapter.check_pioneer_access(f"uuid-trip-{_:04d}-AABBCC")
             except Exception:
                 pass  # expected — failures accumulate
 
         assert adapter._circuit_open is True
-        assert adapter._consecutive_failures >= _CIRCUIT_FAILURE_THRESHOLD
+        assert adapter._consecutive_failures >= pa._CIRCUIT_FAILURE_THRESHOLD
 
         # Next call should raise CircuitOpenError immediately (no network call)
         call_count_before = mock_client.get_customer_state.call_count
-        with pytest.raises(CircuitOpenError):
+        with pytest.raises(pa.CircuitOpenError):
             await adapter.check_pioneer_access("uuid-after-circuit-open-1234")
         # No additional Polar API calls when circuit is open
         assert mock_client.get_customer_state.call_count == call_count_before
@@ -596,9 +594,6 @@ class TestPolarCircuitBreaker:
     async def test_circuit_breaker_fail_closed_in_tier_gate(self, monkeypatch):
         """Circuit open → tier_gate returns (False, 'scholar') without env-var fallback."""
         from unittest.mock import AsyncMock, MagicMock
-        from verifimind_mcp.middleware.polar_adapter import (
-            PolarAdapter, CircuitOpenError
-        )
         import verifimind_mcp.middleware.polar_adapter as pa
         import verifimind_mcp.middleware.tier_gate as tg
 
@@ -621,9 +616,7 @@ class TestPolarCircuitBreaker:
     async def test_circuit_breaker_resets_after_window(self, monkeypatch):
         """After _CIRCUIT_RESET_SECONDS, circuit enters half-open → success closes it."""
         from unittest.mock import AsyncMock
-        from verifimind_mcp.middleware.polar_adapter import (
-            PolarAdapter, _CIRCUIT_RESET_SECONDS
-        )
+        import verifimind_mcp.middleware.polar_adapter as pa
 
         adapter, mock_client = self._make_adapter()
         mock_client.get_customer_state = AsyncMock(return_value={"benefit_grants": []})
@@ -632,7 +625,7 @@ class TestPolarCircuitBreaker:
         # Manually open the circuit with an old timestamp (beyond reset window)
         adapter._circuit_open = True
         adapter._consecutive_failures = 5
-        adapter._circuit_opened_at = __import__("time").time() - _CIRCUIT_RESET_SECONDS - 1
+        adapter._circuit_opened_at = __import__("time").time() - pa._CIRCUIT_RESET_SECONDS - 1
 
         # Next call: circuit should enter half-open, Polar succeeds → circuit closed
         result = await adapter.check_pioneer_access("uuid-recovery-test-12345678")


### PR DESCRIPTION
## Summary

Two independent fixes:

### Fix 1 — CodeQL import style (15 of 16 notes resolved)
- `test_v0513_fortify.py`: standardize `tier_gate` → `import ... as tg`, `polar_adapter` → `import ... as pa`
- `test_v0511_coordination.py`: same for `tier_gate`; remove unused `import verifimind_mcp.server as srv`
- Remaining 1 note (`py/cyclic-import` in `z_agent.py:18`) is intentional — cycle broken at runtime by lazy import in `base_agent.py:240`. Recommend dismissing via GitHub UI.

### Fix 2 — Root cause of 50% Connection Success Rate (AY Phase 76 SEV-1)

**AY's diagnosis**: 307 Auth Loop due to missing UUID payload.  
**Actual root cause** (confirmed from GCP logs):

```
POST /mcp         → 307 Location: http://verifimind.ysenseai.org/mcp/
GET  /mcp/        → 400 Bad Request (clients convert POST→GET on redirect)
```

Starlette's `redirect_slashes=True` (default) redirects `/mcp` to `/mcp/`. The redirect:
1. Downgrades HTTPS → HTTP in the Location header
2. MCP clients (Claude Desktop, node) convert POST → GET when following

Fix: `redirect_slashes=False` on the Starlette app. One line.

**AY's Patch A (throw 400 for missing UUID) is NOT needed** — the 400 errors are MCP protocol violations (wrong Accept header or method), not UUID-related.  
**AY's Patch B (stdout TRACER_UUID) is already implemented and confirmed** — see Option B results below.

## Option B — Pioneer Coordination Test ✅ COMPLETE

All 3 coordination tools tested with key `vm-pioneer-test1-2026`. GCP Log Explorer confirms:
```
2026-04-14T20:49:13Z  TRACER_UUID: vm-pioneer-test1-2026 tool=coordination_team_status
2026-04-14T20:49:13Z  TRACER_UUID: vm-pioneer-test1-2026 tool=coordination_handoff_read  
2026-04-14T20:49:09Z  TRACER_UUID: vm-pioneer-test1-2026 tool=coordination_handoff_create
```
All 3 tools return `"tier":"pioneer"` and `"status":"success"`. TRACER_UUID fires correctly.

## Test plan
- [x] 399 unit tests pass
- [x] Option B live test: all 3 coordination tools ✅
- [x] TRACER_UUID confirmed in GCP Log Explorer ✅
- [x] POLAR_ACCESS_TOKEN restored to production ✅
- [ ] CI Bandit + pytest full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)