### PR TITLE
fix: remove McpPathNormalization — restores startup (container crash hotfix)

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -1098,31 +1098,9 @@ app = Starlette(
 )
 
 
-class McpPathNormalization:
-    """ASGI middleware: silently rewrite POST /mcp → /mcp/ before routing.
-
-    Without this, Starlette's Mount('/mcp') sends a 307 redirect to /mcp/
-    with Location: http://... (HTTPS→HTTP downgrade). MCP clients then
-    convert POST→GET on the redirect, producing a 400 Bad Request loop.
-
-    This middleware rewrites the path internally — no 3xx response is ever
-    sent to the client, so the POST body and method are fully preserved.
-    Compatible with all Starlette versions.
-    """
-
-    def __init__(self, app):
-        self.app = app
-
-    async def __call__(self, scope, receive, send):
-        if scope.get("type") == "http" and scope.get("path") == "/mcp":
-            scope = dict(scope)
-            scope["path"] = "/mcp/"
-            scope["raw_path"] = b"/mcp/"
-        await self.app(scope, receive, send)
-
-
-# Wrap app with MCP path normalization (outermost layer — runs before routing)
-app = McpPathNormalization(app)
+# Disable trailing-slash redirects so POST /mcp works like POST /mcp/
+# (Starlette default redirect_slashes=True causes 307 HTTPS→HTTP downgrade for MCP clients)
+app.router.redirect_slashes = False
 
 # IMPORTANT: Add middleware in correct order
 # 1. Rate limiting (first, to block before any processing)

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -1061,7 +1061,6 @@ async def polar_webhook_handler(request):
 
 # Create Starlette app with proper lifespan from MCP app
 app = Starlette(
-    redirect_slashes=False,  # Prevent 307 trailing-slash redirect on /mcp → /mcp/ (MCP clients convert POST→GET on redirect)
     routes=[
         Route("/health", health_handler),
         Route("/", root_handler, methods=["GET", "HEAD"]),
@@ -1091,6 +1090,9 @@ app = Starlette(
     lifespan=mcp_app.lifespan,  # CRITICAL: Pass lifespan for session initialization
     exception_handlers={404: http_exception_handler, 400: http_exception_handler, 405: http_exception_handler, 406: http_exception_handler},
 )
+# Disable trailing-slash redirects so POST /mcp works like POST /mcp/
+# (Router.redirect_slashes is available on all Starlette versions)
+app.router.redirect_slashes = False
 
 # IMPORTANT: Add middleware in correct order
 # 1. Rate limiting (first, to block before any processing)


### PR DESCRIPTION
## Summary

- The squash merge of PR #147 reintroduced `McpPathNormalization` (from closed PR #146) into `http_server.py`
- This class wraps `app`, replacing the Starlette instance with a plain ASGI callable — so `app.add_middleware()` raises `AttributeError` and the container crashes on startup
- Revisions `00332-tdx` and `00333-8mr` both failed with this error
- Fix: remove `McpPathNormalization` class entirely, restore `app.router.redirect_slashes = False` (the PR #145 fix)

## Root Cause

PR #146 (closed) was never reverted from the working directory before PR #147 was branched. GitHub's squash merge preserved the broken state. The fix commit (`fc7846f`) was pushed after the squash merge completed, so it was never included.

## Test plan

- [ ] CI passes
- [ ] Container starts, `/health` returns 200
- [ ] 399 unit tests pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)