### PR TITLE
docs: v0.5.15 credibility updates — changelog, README, legal pages, /changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,70 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.15 - Scholar Incentives: UUID Tracer + Registration UX (April 20, 2026)
+
+Optional UUID tracer on all 10 Scholar tools, Privacy Policy v2.1 disclosure, enhanced registration response.
+
+### Scholar UUID Tracer (P1-A)
+- Optional `user_uuid` parameter added to all 10 Scholar tools (`consult_agent_x/z/cs`, `run_full_trinity`, and all 6 template tools)
+- `emit_tracer(uuid, tool)` — fire-and-forget `TRACER_UUID:` stdout log feeds AY GCP analytics pipeline
+- UUID format validated via RFC 4122 regex; malicious strings (log injection, non-UUID values) silently ignored
+- Anonymous tool calls unchanged — `user_uuid=None` works identically
+- Pioneer tools (`coordination_handoff_*`, `coordination_team_status`) unaffected — still use `pioneer_key`
+
+### Registration Response UX (P1-C)
+- `register_user()` now returns `mcp_config` (ready-to-paste Claude Desktop JSON with server URL + UUID env var), `test_url`, `dashboard_url`, `checkout_url`
+- One API call gives a new Scholar everything needed: copy the config, test the connection, see the dashboard, upgrade to Pioneer
+- Both new-user and duplicate-email return paths include full extras
+
+### Privacy Policy v2.1
+- UUID USAGE ANALYTICS section added — full Z-Protocol v1.1 compliant disclosure of what is logged (UUID, tool name, tier label, timestamp), what is NOT logged (concept content, IP linked to UUID, PII), 30-day GCP Cloud Logging auto-purge
+- Terms v2.0 updated — Anonymous tier row added to service tiers table; Identity and Rate Limit columns made explicit
+
+### Testing
+- 515 tests, CodeQL clean (0 medium+ alerts)
+- 30 new tests: UUID format validation (9), user_uuid parameter existence on all 10 Scholar tools (11), P1-C registration response fields (10)
+
+### Pull Requests
+- PR #154 (Scholar Incentives — P1-A + P1-C)
+
+### Credits
+- Implementation: RNA (Claude Code, CSO)
+- Specification: T (Manus AI, CTO) — Phase 83 PIN `3-tier-implementation`
+- Architecture Review: AY (Antigravity, COO) — UUID bridge analytics pipeline
+- Human Orchestrator: Alton
+
+---
+
+## v0.5.14 - Fortify: Research Library + Connection Test (April 17, 2026)
+
+Genesis Research Library v1.0, UUID connection test endpoint, MPAC competitive analysis.
+
+### New Endpoints
+- `GET /mcp/test?key=<uuid>` — UUID connection test: verify your key is valid and see your tier before configuring your MCP client
+- `GET /library` — Genesis Research Library v1.0: 20+ academic papers validating the VerifiMind methodology (Sections A–E, evidence chain timeline, JSON-LD SEO)
+- `GET /library/index.json` — machine-readable library index for AI crawlers
+
+### Research
+- **/research Article 3** — MPAC vs MACP competitive analysis (XV + T, April 17, 2026); AI Council CONDITIONAL verdict disclosed
+- **`/research/index.json` v1.1** — 4 papers (was 3), mpac-alignment entry added
+
+### SEO & Crawlers
+- `sitemap.xml + robots.txt` — `/library` and `/library/index.json` added for crawler access
+
+### Testing
+- 485 tests
+
+### Pull Requests
+- PR #151
+
+### Credits
+- Implementation: RNA (Claude Code, CSO)
+- Research: XV (Perplexity, CIO) + T (Manus AI, CTO)
+- Human Orchestrator: Alton
+
+---
+
 ## v0.5.13 - Fortify: Production Hardening (April 12, 2026)
 
 Production security hardening sprint. All 4 X-Agent AI Council conditions from PR #131 review resolved. Zero CodeQL medium+ alerts.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
   > **Evolution of PEAS:** v1.x (2024): *Prompt Engineering Application Synthesis* (Zenodo DOI — immutable) · v2.x–v4.x (2025): *Prompt Engineering & AI Standardization* (Genesis Methodology era) · **v5.x (2026): *Prompt Engineering Agents Standardization* — current canonical** — AI Council vote 3/4 APPROVE (Apr 10, 2026)
 
-  [![Version](https://img.shields.io/badge/version-v0.5.12-blue.svg)](CHANGELOG.md)
+  [![Version](https://img.shields.io/badge/version-v0.5.15-blue.svg)](CHANGELOG.md)
   [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
   [![Status](https://img.shields.io/badge/status-Operational-success.svg)](SERVER_STATUS.md)
   [![MACP](https://img.shields.io/badge/MACP-v2.2%20%22Identity%22-blueviolet)](https://doi.org/10.5281/zenodo.18504478)
@@ -31,7 +31,7 @@
 
 ## MCP Server: Production Deployed
 
-> **v0.5.12 "Polar Integration"** — 2,389+ verified engagement hours | 1,876+ unique endpoints (IP-based; verified users tracked via EA registration UUID) | 90.7% Value Confirmation Rate | **Pioneer Tier** ($9/mo, Polar MoR) | **Polar Integration** (PolarClient + Adapter + Webhook, Standard Webhooks HMAC) | **Legal Pages v2.0** (Privacy + T&C with Polar MoR, 14-day refund) | **Coordination Layer Phase 1** (3 Pioneer-gated tools) | **UUID Tracer** (GCP log analytics bridge) | **BYOK Anthropic Claude 4** (claude-opus-4-6, claude-sonnet-4-6) | MACP v2.2 "Identity" | 312 tests, 52.76% coverage | 74+ weekly COO reports. [Health Check](https://verifimind.ysenseai.org/health) | [Changelog](https://verifimind.ysenseai.org/changelog) | [Register as Early Adopter](https://verifimind.ysenseai.org/register) | [Pioneer Tier](https://verifimind.ysenseai.org/terms)
+> **v0.5.15 "Scholar Incentives"** — 2,389+ verified engagement hours | 1,876+ unique endpoints (IP-based; verified users tracked via EA registration UUID) | 90.7% Value Confirmation Rate | **Pioneer Tier** ($9/mo, Polar MoR) | **UUID Tracer on all 10 Scholar tools** (optional `user_uuid` → GCP analytics) | **Privacy Policy v2.1** (UUID analytics disclosed, Z-Protocol v1.1) | **Registration UX** (mcp_config + test_url + dashboard_url in response) | **Research Library v1.0** (20+ papers at `/library`) | **Connection Test** (`/mcp/test?key=<uuid>`) | MACP v2.2 "Identity" | 515 tests | 74+ weekly COO reports. [Health Check](https://verifimind.ysenseai.org/health) | [Changelog](https://verifimind.ysenseai.org/changelog) | [Register](https://verifimind.ysenseai.org/register) | [Pioneer Tier](https://verifimind.ysenseai.org/terms)
 
 VerifiMind PEAS is now **live and accessible** across multiple platforms:
 
@@ -65,6 +65,22 @@ claude mcp add -s user verifimind -- npx -y mcp-remote https://verifimind.ysense
   }
 }
 ```
+
+**Claude Desktop (Scholar UUID — optional, enables usage dashboard):** After [registering](https://verifimind.ysenseai.org/register), pass your UUID for analytics and the dashboard at `/early-adopters/dashboard/{uuid}`:
+```json
+{
+  "mcpServers": {
+    "verifimind": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://verifimind.ysenseai.org/mcp/"],
+      "env": {
+        "VERIFIMIND_UUID": "your-uuid-here"
+      }
+    }
+  }
+}
+```
+> Pass `user_uuid` on any Scholar tool call to log to your dashboard. Anonymous tool calls (no `user_uuid`) work identically.
 
 **Cursor / VS Code Copilot** (`.cursor/mcp.json` or `.vscode/mcp.json`):
 ```json
@@ -190,9 +206,9 @@ Automated testing and security scanning runs on every push to `main` via GitHub 
 | **Trinity Quality** | **`_overall_quality: "full"`** | All 3 agents returning real inference (v0.4.4+) |
 | **SessionContext** | **`_session_id` tracing** | 8-char correlation ID per Trinity run (v0.5.0+) |
 | **COO Weekly Reports** | **74+ automated** | GCP log-based weekly analytics reports (AY/Antigravity, forensic standard v2.5) |
-| **Test Coverage** | **312 tests, 52.76%** | Comprehensive test suite with CI/CD pipeline |
+| **Test Coverage** | **515 tests** | Comprehensive test suite with CI/CD pipeline; CodeQL clean (0 medium+ alerts) |
 | **Pioneer Tier** | **[$9/month](https://verifimind.ysenseai.org/terms)** | Polar MoR, 14-day refund, coordination tools |
-| **EA Registration** | **[Register](https://verifimind.ysenseai.org/register)** | Consent-first Z-Protocol design with Privacy Policy v2.0 + T&C v2.0 |
+| **EA Registration** | **[Register](https://verifimind.ysenseai.org/register)** | Consent-first Z-Protocol design with Privacy Policy v2.1 + T&C v2.0 |
 
 ### Adoption Trajectory (Flying Hours ✈️)
 
@@ -279,6 +295,14 @@ We provide a systematic approach to **multi-model AI validation** that ensures y
 ---
 
 ## 🎯 Latest Achievements
+
+### v0.5.15 — Scholar Incentives: UUID Tracer + Registration UX (April 20, 2026)
+
+Optional `user_uuid` parameter added to all 10 Scholar tools — when provided, `emit_tracer()` fires a `TRACER_UUID:` stdout log (UUID, tool name, tier, timestamp) that feeds directly into the AY GCP analytics pipeline. UUID format is validated via RFC 4122 regex; malicious strings are silently ignored. **Privacy Policy v2.1** fully discloses the analytics pipeline (Z-Protocol v1.1 compliant, 30-day GCP auto-purge). **Registration response enhanced**: `register_user()` now returns `mcp_config` (ready-to-paste Claude Desktop JSON), `test_url`, `dashboard_url`, and `checkout_url` — one call gives new Scholars everything they need to start. Terms updated with explicit Anonymous/Scholar/Pioneer 3-tier table. 515 tests, CodeQL clean. [PR #154](https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/154)
+
+### v0.5.14 — Fortify: Research Library + Connection Test (April 17, 2026)
+
+Genesis Research Library v1.0 at `/library` — living compendium of 20+ academic papers validating the VerifiMind methodology (Sections A–E, evidence chain timeline, JSON-LD SEO). `/library/index.json` for AI crawlers. `GET /mcp/test?key=<uuid>` connection test endpoint — verify your key and see your tier before configuring your MCP client. `/research` Article 3: MPAC vs MACP competitive analysis (XV + T); AI Council CONDITIONAL verdict disclosed. `sitemap.xml` and `robots.txt` updated for `/library`. 485 tests. [PR #151](https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/151)
 
 ### v0.5.12 — Polar Integration + Legal v2.0 (April 8, 2026)
 
@@ -381,6 +405,12 @@ The standardization phase generated **57 complete Trinity validation reports** a
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.5.15** | Apr 20, 2026 | **Scholar Incentives**: UUID Tracer on 10 Scholar tools, Privacy Policy v2.1, Registration UX (mcp_config + test_url), 515 tests |
+| **v0.5.14** | Apr 17, 2026 | **Research Library v1.0**: 20+ papers at `/library`, `/mcp/test` connection test, MPAC competitive analysis, 485 tests |
+| **v0.5.13** | Apr 12, 2026 | **Fortify**: Polar circuit breaker, fail-closed semantics, retry/backoff, `/register` lightweight, CodeQL clean, 485 tests |
+| **v0.5.12** | Apr 8, 2026 | **Polar Integration**: PolarClient + Adapter + Webhook, Legal Pages v2.0, UUID Tracer, `/changelog`, 312 tests |
+| **v0.5.11** | Apr 7, 2026 | **Coordination Foundation**: 3 Pioneer-gated tools, tier-gate middleware, 308 tests |
+| **v0.5.10** | Apr 5, 2026 | **Trinity Verified**: 600s timeout, Z max_tokens, BYOK Claude 4, 290 tests |
 | **v0.5.6** | Mar 23, 2026 | **Gateway**: EA Registration, Privacy Policy v1.0, Phase 55 metrics, DFSC 2026, 290 tests |
 | **v0.5.5** | Mar 13, 2026 | **Trinity Baseline**: TrinitySynthesis schema fix, 3 regression tests, 208 tests |
 | **v0.5.4** | Mar 12, 2026 | **X Agent v4.3**: creator-centric bias fix, founder_summary, research_prompts |

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1605,12 +1605,25 @@ def get_terms_page() -> str:
 _CHANGELOG_BODY = """
 <h1>Changelog</h1>
 <div class="meta">
-  <span>Last updated: April 17, 2026</span>
+  <span>Last updated: April 20, 2026</span>
   <span><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/releases" target="_blank" rel="noopener">GitHub Releases</a></span>
 </div>
 
+<div id="v0.5.15">
+<h2>v0.5.15 — Scholar Incentives: UUID Tracer + Registration UX <span class="live-badge">LIVE</span></h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 20, 2026</p>
+<ul>
+  <li><strong>UUID Tracer on all 10 Scholar tools</strong> — optional <code>user_uuid</code> parameter; fire-and-forget <code>TRACER_UUID:</code> stdout log feeds AY GCP analytics pipeline; invalid UUIDs silently ignored (log injection prevention)</li>
+  <li><strong>Privacy Policy v2.1</strong> — UUID usage analytics fully disclosed: what is logged (UUID, tool name, tier, timestamp), what is NOT logged (concept content, IP linked to UUID, PII), 30-day GCP auto-purge; Z-Protocol v1.1 compliant</li>
+  <li><strong>Terms v2.0 updated</strong> — Anonymous tier row added to service tiers table with Identity column and Rate Limit column; 3-tier model (Anonymous/Scholar/Pioneer) now unambiguous</li>
+  <li><strong>Registration response enhanced (P1-C)</strong> — <code>register_user()</code> now returns <code>mcp_config</code> (ready-to-paste Claude Desktop JSON), <code>test_url</code>, <code>dashboard_url</code>, <code>checkout_url</code> — one API call gives Scholar everything needed to start</li>
+  <li>515 tests, CodeQL clean (0 medium+ alerts)</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/154" target="_blank" rel="noopener">PR #154</a></li>
+</ul>
+</div>
+
 <div id="v0.5.14">
-<h2>v0.5.14 — Fortify: Research Library + Connection Test <span class="live-badge">LIVE</span></h2>
+<h2>v0.5.14 — Fortify: Research Library + Connection Test</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 17, 2026</p>
 <ul>
   <li><strong><code>GET /mcp/test?key=&lt;uuid&gt;</code></strong> — UUID connection test: verify your key is valid and see your tier before configuring your MCP client</li>

--- a/mcp-server/src/verifimind_mcp/policies/privacy_policy.py
+++ b/mcp-server/src/verifimind_mcp/policies/privacy_policy.py
@@ -1,16 +1,17 @@
 """
-VerifiMind-PEAS Privacy Policy — v2.0
+VerifiMind-PEAS Privacy Policy — v2.1
 Z-Protocol v1.1 compliant: data minimisation, explicit consent, right to erasure.
 GDPR / PDPA / Polar MOR (Stripe Connect) aligned.
-Effective: April 8, 2026
+Effective: April 20, 2026
+v2.1 change: UUID analytics disclosure (user_uuid tool parameter, GCP log pipeline).
 """
 
-PRIVACY_POLICY_VERSION = "2.0"
-PRIVACY_POLICY_EFFECTIVE_DATE = "2026-04-08"
+PRIVACY_POLICY_VERSION = "2.1"
+PRIVACY_POLICY_EFFECTIVE_DATE = "2026-04-20"
 
 PRIVACY_POLICY = """
-VerifiMind-PEAS — Privacy Policy v2.0
-Effective: April 8, 2026 (previous: v1.0, March 18, 2026)
+VerifiMind-PEAS — Privacy Policy v2.1
+Effective: April 20, 2026 (previous: v2.0, April 8, 2026)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -87,6 +88,38 @@ uses privacy-respecting analytics that do not track individual users.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+UUID USAGE ANALYTICS (v2.1 addition)
+As of v0.5.15 (April 20, 2026), registered Scholar users may optionally pass
+their UUID as a "user_uuid" parameter in any Trinity tool call. This is always
+voluntary — anonymous tool calls work identically without it.
+
+When you provide user_uuid, we log the following to our Google Cloud Run
+infrastructure:
+
+  Data logged             Purpose
+  ─────────────────────────────────────────────────────────────────
+  Your UUID               Pseudonymous identifier (no name/email linked)
+  Tool name               Which tool you called (e.g. consult_agent_x)
+  Tier label              "scholar" (always — Pioneer tools use pioneer_key)
+  Timestamp               When the call was made (server time, UTC)
+
+What we do NOT log:
+  ✗ Your concept name or description
+  ✗ The tool's response or output
+  ✗ Your IP address (not linked to UUID)
+  ✗ Any personally identifiable information
+
+These logs flow into our GCP Cloud Logging pipeline and are used to:
+  • Power the Scholar usage dashboard (/early-adopters/dashboard/{uuid})
+  • Understand aggregate tool usage patterns (anonymised)
+  • Improve tool reliability and performance
+
+Log retention: GCP Cloud Logging default (30 days), then auto-purged.
+You may stop UUID analytics at any time by omitting the user_uuid parameter
+from tool calls. Your registered account and UUID remain intact.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 HOW LONG WE KEEP YOUR DATA
 
   Data Type                    Retention Period
@@ -95,6 +128,7 @@ HOW LONG WE KEEP YOUR DATA
   Pioneer subscription records Duration of subscription + 7 years (tax/legal)
   Feedback messages            Indefinitely in anonymised form after 6 months
   Transaction metadata         7 years from transaction date (tax compliance)
+  UUID usage analytics logs    30 days (GCP Cloud Logging auto-purge)
 
 On deletion request, all personal data is purged within 7 business days,
 except where retention is required by law (e.g., tax records from Polar).

--- a/mcp-server/src/verifimind_mcp/policies/terms.py
+++ b/mcp-server/src/verifimind_mcp/policies/terms.py
@@ -32,20 +32,25 @@ that you have read and accept:
 
 3. SERVICE TIERS
 
-  Tier          Access                                    Price          Duration
-  ─────────────────────────────────────────────────────────────────────────────────
-  Scholar       All 10 Trinity validation tools +         Free forever   Permanent
-                templates. Open-source core (MIT).
-  Early Adopter All Scholar tools + Pioneer               Free 3 months  3 months
-  (EA)          coordination tools                        then Pioneer
-  PILOT         All Scholar tools + Pioneer               Free 6 months  6 months
-                coordination tools                        then Pioneer
-  Pioneer       All Scholar tools + 6 coordination        $9/month (USD) Monthly
-                tools (handoff mgmt, team status,
-                session coordination)
+  Tier          Identity   Access                              Price          Rate Limit
+  ────────────────────────────────────────────────────────────────────────────────────────
+  Anonymous     None       All 10 Trinity validation tools +   Free forever   10 req/60s
+                (IP only)  templates. No registration needed.                 (per IP)
+  Scholar       UUID       Same tools + usage dashboard +       Free forever   30 req/60s
+                (consent)  Trinity history. Register at /register.            (per UUID)
+  Early Adopter UUID +     All Scholar tools + Pioneer          Free 3 months  100 req/60s
+  (EA)          email      coordination tools                   then Pioneer   (per UUID)
+  PILOT         UUID +     All Scholar tools + Pioneer          Free 6 months  100 req/60s
+                email      coordination tools                   then Pioneer   (per UUID)
+  Pioneer       UUID +     All Scholar + 6 coordination         $9/month (USD) 100 req/60s
+                payment    tools (handoff mgmt, team status,    Monthly        (per UUID)
+                           session coordination)
 
-The Scholar tier remains free forever. You never lose Scholar access by
-registering for any program. The core is MIT licensed — self-host anytime.
+The Anonymous tier provides full Trinity access with zero friction and no
+registration. The Scholar tier is free forever and adds UUID-based identity,
+usage analytics (opt-in via user_uuid parameter), and a personal dashboard.
+You never lose Scholar access by registering for any program.
+The core is MIT licensed — self-host anytime.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/mcp-server/tests/unit/test_v0513_fortify.py
+++ b/mcp-server/tests/unit/test_v0513_fortify.py
@@ -106,7 +106,7 @@ class TestRegisterUser:
         from verifimind_mcp.registration import UserRegistrationRequest, register_user
         req = UserRegistrationRequest(consent=True)
         result = await register_user(req)
-        assert result.privacy_version == "2.0"
+        assert result.privacy_version == "2.1"
         assert result.tc_version == "2.0"
 
     async def test_different_calls_return_different_uuids(self):


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Add v0.5.15 "Scholar Incentives" + v0.5.14 "Research Library" entries (both were missing)
- **README.md**: Version badge v0.5.12→v0.5.15, test count 312→515, Scholar UUID config variant added to Quick Start, v0.5.15/v0.5.14 Latest Achievements, version history table updated
- **pages.py** (`/changelog`): v0.5.15 LIVE badge added, v0.5.14 demoted, "Last updated" → April 20, 2026
- **privacy_policy.py** → v2.1: UUID usage analytics section fully disclosed — what is logged (UUID, tool name, tier, timestamp), what is NOT logged (concept content, IP linked to UUID, PII), 30-day GCP auto-purge; Z-Protocol v1.1 compliant
- **terms.py**: Anonymous tier row added to service tiers table; Identity and Rate Limit columns made explicit; 3-tier model (Anonymous/Scholar/Pioneer) now unambiguous

## Context

PR #154 (Scholar Incentives) merged. This PR brings all public-facing documentation and legal pages in sync with the v0.5.15 deployment. Part of the deployment credibility workflow.

## Test plan

- [ ] `/terms` — verify Anonymous tier row visible with Identity + Rate Limit columns
- [ ] `/privacy` — verify UUID USAGE ANALYTICS section present; v2.1 header shown
- [ ] `/changelog` — verify v0.5.15 LIVE badge at top; v0.5.14 without LIVE badge
- [ ] README version badge shows v0.5.15
- [ ] README Scholar UUID config variant present in Quick Start

🤖 Generated with [Claude Code](https://claude.com/claude-code)