### PR TITLE
feat: v0.5.16 P1-B — Trinity History Persistence

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -58,7 +58,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.15"
+SERVER_VERSION = "0.5.16"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -33,13 +33,14 @@ from fastmcp import FastMCP, Context
 from pydantic import BaseModel, Field
 
 from verifimind_mcp.utils.uuid_tracer import emit_tracer
+from verifimind_mcp.utils.trinity_history import persist_trinity_result
 
 # Initialize logger for security events
 logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.15"
+SERVER_VERSION = "0.5.16"
 
 # Track C — SYSTEM_NOTICE sanitization constants
 _NOTICE_MAX_LEN = 280
@@ -412,7 +413,7 @@ def _create_mcp_instance():
             agent = XAgent(llm_provider=provider)
             result = await agent.analyze(concept)
 
-            return wrap_response({
+            payload = {
                 "agent": "X Intelligent",
                 "concept": concept_name,
                 "reasoning_steps": [
@@ -428,7 +429,9 @@ def _create_mcp_instance():
                 "_inference_quality": getattr(result, '_inference_quality', 'unknown'),
                 "_provider_used": provider.get_model_name(),
                 "_byok": byok_used
-            })
+            }
+            persist_trinity_result(user_uuid, "consult_agent_x", payload)
+            return wrap_response(payload)
 
         except Exception as e:
             return wrap_response({
@@ -528,7 +531,7 @@ def _create_mcp_instance():
             agent = ZAgent(llm_provider=provider)
             result = await agent.analyze(concept, prior)
 
-            return wrap_response({
+            payload = {
                 "agent": "Z Guardian",
                 "concept": concept_name,
                 "reasoning_steps": [
@@ -545,7 +548,9 @@ def _create_mcp_instance():
                 "_inference_quality": getattr(result, '_inference_quality', 'unknown'),
                 "_provider_used": provider.get_model_name(),
                 "_byok": byok_used
-            })
+            }
+            persist_trinity_result(user_uuid, "consult_agent_z", payload)
+            return wrap_response(payload)
 
         except Exception as e:
             return wrap_response({
@@ -641,7 +646,7 @@ def _create_mcp_instance():
             agent = CSAgent(llm_provider=provider)
             result = await agent.analyze(concept, prior)
 
-            return wrap_response({
+            payload = {
                 "agent": "CS Security",
                 "concept": concept_name,
                 "reasoning_steps": [
@@ -658,7 +663,9 @@ def _create_mcp_instance():
                 "_inference_quality": getattr(result, '_inference_quality', 'unknown'),
                 "_provider_used": provider.get_model_name(),
                 "_byok": byok_used
-            })
+            }
+            persist_trinity_result(user_uuid, "consult_agent_cs", payload)
+            return wrap_response(payload)
 
         except Exception as e:
             return wrap_response({
@@ -882,7 +889,7 @@ def _create_mcp_instance():
             # Return result — Markdown-first if requested (v0.4.1)
             if output_format == "markdown":
                 from .reporting import generate_markdown_report
-                return wrap_response({
+                md_payload = {
                     "format": "markdown",
                     "content": generate_markdown_report(trinity_result),
                     "validation_id": trinity_result.validation_id,
@@ -892,9 +899,11 @@ def _create_mcp_instance():
                     "_z_token_monitor": z_token_monitor,
                     **_byok_meta,
                     **session.to_metadata(),
-                })
+                }
+                persist_trinity_result(user_uuid, "run_full_trinity", md_payload)
+                return wrap_response(md_payload)
 
-            return wrap_response({
+            payload = {
                 "validation_id": trinity_result.validation_id,
                 "concept_name": concept_name,
                 "x_analysis": {
@@ -933,7 +942,9 @@ def _create_mcp_instance():
                 "_z_token_monitor": z_token_monitor,
                 **_byok_meta,
                 **session.to_metadata(),
-            })
+            }
+            persist_trinity_result(user_uuid, "run_full_trinity", payload)
+            return wrap_response(payload)
 
         except Exception as e:
             err_str = str(e).lower()

--- a/mcp-server/src/verifimind_mcp/utils/trinity_history.py
+++ b/mcp-server/src/verifimind_mcp/utils/trinity_history.py
@@ -1,0 +1,103 @@
+"""
+P1-B: Fire-and-forget Firestore persistence for Scholar Trinity history.
+
+Writes validation metadata to:
+  trinity_history/{uuid}/validations/{validation_id}
+
+Privacy invariants (consistent with Privacy Policy v2.1):
+  - NO concept names or descriptions stored
+  - NO agent response content stored
+  - Only scores, recommendations, timestamps, session IDs
+  - Only written when user_uuid is explicitly provided (opt-in)
+  - Silently skipped if Firestore unavailable (non-blocking)
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from verifimind_mcp.utils.uuid_tracer import is_valid_uuid
+
+logger = logging.getLogger(__name__)
+
+
+def _get_firestore_async():
+    try:
+        from google.cloud import firestore
+        return firestore.AsyncClient()
+    except Exception:
+        return None
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_record(uuid: str, tool: str, raw_result: dict) -> dict:
+    """Extract metadata-only record — no concept content."""
+    record: dict = {
+        "uuid": uuid,
+        "tool": tool,
+        "timestamp": _ts(),
+        "validation_id": raw_result.get("validation_id", _ts()),
+    }
+    if tool == "run_full_trinity":
+        synthesis = raw_result.get("synthesis", {})
+        record.update({
+            "overall_score": synthesis.get("overall_score"),
+            "recommendation": synthesis.get("recommendation"),
+            "veto_triggered": synthesis.get("veto_triggered", False),
+            "session_id": raw_result.get("_session_id", ""),
+            "agents_completed": raw_result.get("_agents_completed", []),
+            "quality": raw_result.get("_overall_quality", ""),
+        })
+    elif tool == "consult_agent_x":
+        record["score"] = raw_result.get("innovation_score")
+        record["recommendation"] = raw_result.get("recommendation", "")
+    elif tool == "consult_agent_z":
+        record["score"] = raw_result.get("ethics_score")
+        record["recommendation"] = raw_result.get("recommendation", "")
+        record["veto_triggered"] = raw_result.get("veto_triggered", False)
+    elif tool == "consult_agent_cs":
+        record["score"] = raw_result.get("security_score")
+        record["recommendation"] = raw_result.get("recommendation", "")
+    return record
+
+
+async def _write_to_firestore(uuid: str, record: dict) -> None:
+    """Async Firestore write — runs as background task."""
+    try:
+        db = _get_firestore_async()
+        if db is None:
+            return
+        validation_id = record.get("validation_id", _ts())
+        doc_ref = (
+            db.collection("trinity_history")
+            .document(uuid)
+            .collection("validations")
+            .document(validation_id)
+        )
+        await doc_ref.set(record)
+        logger.debug("trinity_history written: uuid=%s tool=%s", uuid[:8], record["tool"])
+    except Exception as exc:
+        logger.warning("trinity_history write skipped (non-critical): %s", type(exc).__name__)
+
+
+def persist_trinity_result(uuid: str | None, tool: str, raw_result: dict) -> None:
+    """
+    Fire-and-forget: schedule Firestore write for Scholar validation history.
+
+    - Skips silently if uuid is invalid or result is an error response.
+    - Non-blocking: schedules as asyncio task, does not await.
+    - Firestore failures are caught and logged — never raise to caller.
+    """
+    if not is_valid_uuid(uuid):
+        return
+    if raw_result.get("status") == "error":
+        return
+    record = _build_record(uuid, tool, raw_result)
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_write_to_firestore(uuid, record))
+    except RuntimeError:
+        pass

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -65,10 +65,10 @@ class TestSmitheryRemoval:
         assert "@smithery.server" not in content
 
     def test_server_version_is_0513(self):
-        """SERVER_VERSION must be bumped to 0.5.15 (Scholar Incentives — P1-A/P1-C)."""
+        """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.15", (
-            f"Expected 0.5.15, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.16", (
+            f"Expected 0.5.16, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.15"
+        assert SERVER_VERSION == "0.5.16"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.15"
+        assert SERVER_VERSION == "0.5.16"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -1,0 +1,162 @@
+"""
+Tests for v0.5.16 P1-B — Trinity History Persistence
+
+Coverage:
+  - _build_record: correct field extraction per tool, no concept content
+  - persist_trinity_result: skips on invalid UUID, skips on error result
+  - Server version assertion
+  - server.py imports persist_trinity_result
+  - persist wired into all 4 Trinity tool return paths
+"""
+
+import inspect
+
+import verifimind_mcp.server as _srv_module
+
+_SERVER_SOURCE = inspect.getsource(_srv_module)
+
+
+# ---------------------------------------------------------------------------
+# _build_record: metadata extraction, privacy invariants
+# ---------------------------------------------------------------------------
+
+class TestBuildRecord:
+
+    def _build(self, tool: str, raw: dict):
+        from verifimind_mcp.utils.trinity_history import _build_record
+        return _build_record("019d40d6-9e84-7738-9c0c-fa85b2930600", tool, raw)
+
+    def test_run_full_trinity_extracts_overall_score(self):
+        raw = {
+            "validation_id": "v-001",
+            "synthesis": {"overall_score": 8.2, "recommendation": "PROCEED", "veto_triggered": False},
+            "_session_id": "abc12345",
+            "_agents_completed": ["X", "Z", "CS"],
+            "_overall_quality": "full",
+        }
+        rec = self._build("run_full_trinity", raw)
+        assert rec["overall_score"] == 8.2
+        assert rec["recommendation"] == "PROCEED"
+        assert rec["veto_triggered"] is False
+        assert rec["session_id"] == "abc12345"
+        assert rec["agents_completed"] == ["X", "Z", "CS"]
+        assert rec["quality"] == "full"
+        assert rec["validation_id"] == "v-001"
+
+    def test_run_full_trinity_no_concept_name(self):
+        raw = {
+            "validation_id": "v-001",
+            "concept_name": "My Secret Concept",
+            "synthesis": {"overall_score": 7.0, "recommendation": "REVISE"},
+        }
+        rec = self._build("run_full_trinity", raw)
+        assert "concept_name" not in rec
+        assert "My Secret Concept" not in str(rec)
+
+    def test_consult_agent_x_extracts_score(self):
+        raw = {"innovation_score": 7.5, "recommendation": "PROCEED"}
+        rec = self._build("consult_agent_x", raw)
+        assert rec["score"] == 7.5
+        assert rec["recommendation"] == "PROCEED"
+        assert rec["tool"] == "consult_agent_x"
+
+    def test_consult_agent_x_no_concept(self):
+        raw = {"concept": "Secret Idea", "innovation_score": 7.5, "recommendation": "PROCEED"}
+        rec = self._build("consult_agent_x", raw)
+        assert "concept" not in rec
+        assert "Secret Idea" not in str(rec)
+
+    def test_consult_agent_z_extracts_ethics_score(self):
+        raw = {"ethics_score": 8.0, "recommendation": "PROCEED", "veto_triggered": False}
+        rec = self._build("consult_agent_z", raw)
+        assert rec["score"] == 8.0
+        assert rec["veto_triggered"] is False
+
+    def test_consult_agent_cs_extracts_security_score(self):
+        raw = {"security_score": 6.5, "recommendation": "REVISE"}
+        rec = self._build("consult_agent_cs", raw)
+        assert rec["score"] == 6.5
+        assert rec["tool"] == "consult_agent_cs"
+
+    def test_record_always_has_uuid_tool_timestamp(self):
+        raw = {"synthesis": {}, "_overall_quality": "full"}
+        rec = self._build("run_full_trinity", raw)
+        assert rec["uuid"] == "019d40d6-9e84-7738-9c0c-fa85b2930600"
+        assert rec["tool"] == "run_full_trinity"
+        assert "timestamp" in rec
+        assert "T" in rec["timestamp"]  # ISO format check
+
+
+# ---------------------------------------------------------------------------
+# persist_trinity_result: guard conditions
+# ---------------------------------------------------------------------------
+
+class TestPersistGuards:
+
+    def test_invalid_uuid_skips_silently(self):
+        from verifimind_mcp.utils.trinity_history import persist_trinity_result
+        # Should not raise even with invalid UUID
+        persist_trinity_result("not-a-uuid", "run_full_trinity", {"synthesis": {}})
+
+    def test_none_uuid_skips_silently(self):
+        from verifimind_mcp.utils.trinity_history import persist_trinity_result
+        persist_trinity_result(None, "consult_agent_x", {"innovation_score": 7.5})  # type: ignore
+
+    def test_error_result_skips_silently(self):
+        from verifimind_mcp.utils.trinity_history import persist_trinity_result
+        persist_trinity_result(
+            "019d40d6-9e84-7738-9c0c-fa85b2930600",
+            "run_full_trinity",
+            {"status": "error", "error": "something failed"},
+        )
+
+    def test_valid_uuid_success_result_does_not_raise(self):
+        from verifimind_mcp.utils.trinity_history import persist_trinity_result
+        persist_trinity_result(
+            "019d40d6-9e84-7738-9c0c-fa85b2930600",
+            "run_full_trinity",
+            {"validation_id": "v-001", "synthesis": {"overall_score": 8.0, "recommendation": "PROCEED"}},
+        )
+
+    def test_injection_attempt_uuid_skips(self):
+        from verifimind_mcp.utils.trinity_history import persist_trinity_result
+        persist_trinity_result(
+            "uuid\nevil=payload",
+            "run_full_trinity",
+            {"synthesis": {"overall_score": 8.0}},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Server wiring: persist_trinity_result in all 4 tool return paths
+# ---------------------------------------------------------------------------
+
+class TestServerWiring:
+
+    def test_server_imports_persist_trinity_result(self):
+        assert "persist_trinity_result" in _SERVER_SOURCE
+
+    def test_consult_agent_x_calls_persist(self):
+        snippet = _SERVER_SOURCE[_SERVER_SOURCE.index("async def consult_agent_x("):
+                                 _SERVER_SOURCE.index("async def consult_agent_z(")]
+        assert "persist_trinity_result" in snippet
+        assert 'user_uuid, "consult_agent_x"' in snippet
+
+    def test_consult_agent_z_calls_persist(self):
+        snippet = _SERVER_SOURCE[_SERVER_SOURCE.index("async def consult_agent_z("):
+                                 _SERVER_SOURCE.index("async def consult_agent_cs(")]
+        assert "persist_trinity_result" in snippet
+        assert 'user_uuid, "consult_agent_z"' in snippet
+
+    def test_consult_agent_cs_calls_persist(self):
+        snippet = _SERVER_SOURCE[_SERVER_SOURCE.index("async def consult_agent_cs("):
+                                 _SERVER_SOURCE.index("async def run_full_trinity(")]
+        assert "persist_trinity_result" in snippet
+        assert 'user_uuid, "consult_agent_cs"' in snippet
+
+    def test_run_full_trinity_calls_persist(self):
+        assert 'persist_trinity_result(user_uuid, "run_full_trinity"' in _SERVER_SOURCE
+
+    def test_server_version_is_0516(self):
+        from verifimind_mcp.server import SERVER_VERSION
+        assert SERVER_VERSION == "0.5.16", f"Expected 0.5.16, got {SERVER_VERSION}"


### PR DESCRIPTION
## Summary

Implements **P1-B** from T's Phase 82 PIN: Scholar Trinity history persistence to Firestore.

- **New `utils/trinity_history.py`** — `persist_trinity_result(uuid, tool, raw)` fire-and-forget
  - Path: `trinity_history/{uuid}/validations/{validation_id}`
  - Privacy: metadata only — scores, recommendations, timestamps, session_id, quality. **No concept names, no agent response content** (consistent with Privacy Policy v2.1)
  - Guards: invalid/None UUID skipped, error results skipped, Firestore failures caught, no-loop safe
  - `asyncio.get_running_loop()` (deprecation-safe, no DeprecationWarning)

- **Wired into all 4 Trinity tools** in `server.py`: `consult_agent_x`, `consult_agent_z`, `consult_agent_cs`, `run_full_trinity` (both JSON + Markdown paths)

- **Version bump:** 0.5.15 → 0.5.16

## Testing

18 new tests in `test_v0516_trinity_history.py`:
- `_build_record`: correct field extraction per tool, no concept content leakage
- `persist_trinity_result`: UUID validation guards, error result guard, injection attempt guard
- Server wiring: import + call site verified for all 4 tools + version assertion

## Next Sprint

P0-B: `GET /early-adopters/dashboard/{uuid}` — reads from `trinity_history/{uuid}/validations/`

## Test plan
- [ ] All CI checks green
- [ ] 18 new tests pass
- [ ] No concept names stored (privacy invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)