### PR TITLE
feat: v0.5.17 — mcp_config UUID header auto-forwarding (T Phase 84 D1)

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -58,7 +58,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.16"
+SERVER_VERSION = "0.5.17"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()

--- a/mcp-server/src/verifimind_mcp/registration.py
+++ b/mcp-server/src/verifimind_mcp/registration.py
@@ -492,7 +492,10 @@ def _build_registration_extras(uuid: str, checkout: str) -> dict:
             "mcpServers": {
                 "verifimind": {
                     "command": "npx",
-                    "args": ["-y", "mcp-remote", f"{_SERVER_BASE_URL}/mcp/"],
+                    "args": [
+                        "-y", "mcp-remote", f"{_SERVER_BASE_URL}/mcp/",
+                        "--header", "X-VerifiMind-UUID:${VERIFIMIND_UUID}",
+                    ],
                     "env": {"VERIFIMIND_UUID": uuid},
                 }
             }

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.16"
+SERVER_VERSION = "0.5.17"
 
 # Track C — SYSTEM_NOTICE sanitization constants
 _NOTICE_MAX_LEN = 280

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.16", (
+        assert SERVER_VERSION == "0.5.17", (
             f"Expected 0.5.16, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.16"
+        assert SERVER_VERSION == "0.5.17"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.16"
+        assert SERVER_VERSION == "0.5.17"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.16", f"Expected 0.5.16, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.17", f"Expected 0.5.16, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -1,0 +1,74 @@
+"""
+Tests for v0.5.17 — mcp_config UUID header fix (T Phase 84 hybrid D1)
+
+Coverage:
+  - mcp_config args include --header flag with X-VerifiMind-UUID:${VERIFIMIND_UUID}
+  - VERIFIMIND_UUID env var still present (backward compat)
+  - Header value uses ${VERIFIMIND_UUID} expansion pattern (not hardcoded uuid)
+  - Server version assertion
+"""
+
+import inspect
+
+import verifimind_mcp.server as _srv_module
+
+_SERVER_SOURCE = inspect.getsource(_srv_module)
+
+
+class TestMcpConfigHeader:
+
+    def _extras(self, uuid: str = "019d40d6-9e84-7738-9c0c-fa85b2930600"):
+        from verifimind_mcp.registration import _build_registration_extras
+        return _build_registration_extras(uuid, "https://polar.sh/checkout/x")
+
+    def test_args_include_header_flag(self):
+        args = self._extras()["mcp_config"]["mcpServers"]["verifimind"]["args"]
+        assert "--header" in args
+
+    def test_header_value_is_x_verifimind_uuid(self):
+        args = self._extras()["mcp_config"]["mcpServers"]["verifimind"]["args"]
+        idx = args.index("--header")
+        header_value = args[idx + 1]
+        assert header_value.startswith("X-VerifiMind-UUID:")
+
+    def test_header_uses_env_var_expansion_not_hardcoded_uuid(self):
+        args = self._extras()["mcp_config"]["mcpServers"]["verifimind"]["args"]
+        idx = args.index("--header")
+        header_value = args[idx + 1]
+        assert "${VERIFIMIND_UUID}" in header_value
+        assert "019d40d6" not in header_value
+
+    def test_env_var_still_present(self):
+        server = self._extras()["mcp_config"]["mcpServers"]["verifimind"]
+        assert server["env"]["VERIFIMIND_UUID"] == "019d40d6-9e84-7738-9c0c-fa85b2930600"
+
+    def test_mcp_remote_still_in_args(self):
+        args = self._extras()["mcp_config"]["mcpServers"]["verifimind"]["args"]
+        assert "mcp-remote" in args
+
+    def test_server_url_still_in_args(self):
+        args = self._extras()["mcp_config"]["mcpServers"]["verifimind"]["args"]
+        assert any("verifimind.ysenseai.org" in a for a in args)
+
+    def test_different_uuids_produce_same_header_template(self):
+        uuid_a = "019d40d6-9e84-7738-9c0c-fa85b2930600"
+        uuid_b = "019e1234-abcd-7000-beef-000000000001"
+        args_a = _build_args(uuid_a)
+        args_b = _build_args(uuid_b)
+        # The --header arg should be identical regardless of uuid (uses env var)
+        header_a = args_a[args_a.index("--header") + 1]
+        header_b = args_b[args_b.index("--header") + 1]
+        assert header_a == header_b == "X-VerifiMind-UUID:${VERIFIMIND_UUID}"
+
+
+def _build_args(uuid: str) -> list:
+    from verifimind_mcp.registration import _build_registration_extras
+    extras = _build_registration_extras(uuid, "https://polar.sh/checkout/x")
+    return extras["mcp_config"]["mcpServers"]["verifimind"]["args"]
+
+
+class TestServerVersion:
+
+    def test_server_version_is_0517(self):
+        from verifimind_mcp.server import SERVER_VERSION
+        assert SERVER_VERSION == "0.5.17", f"Expected 0.5.17, got {SERVER_VERSION}"


### PR DESCRIPTION
## Summary
- Scholar/EA/Pioneer users who copy their `mcp_config` now automatically send their UUID as `X-VerifiMind-UUID` header on every MCP request — no manual `user_uuid` parameter needed per call
- Implements T's Phase 84 hybrid D1 ruling
- UUID env var `VERIFIMIND_UUID` retained for backward compatibility

## Changes
- `registration.py`: `--header X-VerifiMind-UUID:\${VERIFIMIND_UUID}` added to `mcp_config` args
- `server.py` + `http_server.py`: SERVER_VERSION → 0.5.17
- 8 new tests in `test_v0517_mcp_config_header.py`

## Test plan
- [x] 455 unit tests pass, 3 skipped, 58.74% coverage
- [ ] After deploy: verify Scholar registration response contains updated `mcp_config` args

## Next
- P0-B: Scholar dashboard `GET /early-adopters/dashboard/{uuid}` (reads trinity_history Firestore)
- P0-A: In-handler UUID rate limiter (reads `X-VerifiMind-UUID` header from middleware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)