### PR TITLE
chore: server.json v2.5.0 — MCP Registry update for v0.5.17

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation with X-Z-CS RefleXion Trinity. BYOK. Pioneer $9/mo. v0.5.13 Fortify.",
-  "version": "2.4.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. BYOK. Scholar UUID history. Pioneer $9/mo. v0.5.17",
+  "version": "2.5.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary
- `server.json` description updated: `v0.5.13 Fortify` → `v0.5.17` + Scholar UUID history mention
- `server.json` version bumped: `2.4.0` → `2.5.0`
- Triggers fresh MCP Registry publish on release (workflow: `publish-mcp-registry.yml`)

## Why
Registry listing was 4 versions stale (last published at v0.5.13, April 11). Current live server is v0.5.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)