### PR TITLE
feat: v0.5.18 P0-B — Scholar Dashboard GET /early-adopters/dashboard/{uuid}

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -48,7 +48,9 @@ from verifimind_mcp.registration import (
     register_user,
 )
 from verifimind_mcp.policies import PRIVACY_POLICY, TERMS_AND_CONDITIONS
-from verifimind_mcp.pages import get_register_page, get_optout_page, get_privacy_page, get_terms_page, get_changelog_page, get_research_page, get_library_page
+from verifimind_mcp.pages import get_register_page, get_optout_page, get_privacy_page, get_terms_page, get_changelog_page, get_research_page, get_library_page, get_dashboard_page
+from verifimind_mcp.utils.trinity_history import read_trinity_history
+from verifimind_mcp.registration import _get_firestore
 
 # Create MCP server instance
 mcp_server = create_http_server()
@@ -58,7 +60,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.17"
+SERVER_VERSION = "0.5.18"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()
@@ -943,6 +945,20 @@ async def ea_status_handler(request):
     return JSONResponse(status.model_dump())
 
 
+async def ea_dashboard_handler(request):
+    """GET /early-adopters/dashboard/{uuid} — Scholar validation history dashboard (P0-B)."""
+    from verifimind_mcp.utils.uuid_tracer import is_valid_uuid
+    uuid = request.path_params.get("uuid", "")
+    if not is_valid_uuid(uuid):
+        return HTMLResponse(
+            get_dashboard_page("invalid", [], firestore_available=False),
+            status_code=404,
+        )
+    firestore_available = _get_firestore() is not None
+    records = read_trinity_history(uuid, limit=50)
+    return HTMLResponse(get_dashboard_page(uuid, records, firestore_available=firestore_available))
+
+
 async def ea_feedback_handler(request):
     """POST /early-adopters/feedback — submit feedback, issue, or recommendation.
 
@@ -1314,6 +1330,7 @@ app = Starlette(
         # v0.5.6 Gateway: EA registration + feedback + policy
         Route("/early-adopters/register", ea_register_handler, methods=["POST"]),
         Route("/early-adopters/status/{uuid}", ea_status_handler, methods=["GET"]),
+        Route("/early-adopters/dashboard/{uuid}", ea_dashboard_handler, methods=["GET"]),
         Route("/early-adopters/feedback", ea_feedback_handler, methods=["POST"]),
         Route("/early-adopters/optout/{uuid}", ea_optout_handler, methods=["POST"]),
         Route("/privacy", privacy_handler, methods=["GET"]),

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1638,6 +1638,118 @@ def get_terms_page() -> str:
     return _legal_shell(title="Terms &amp; Conditions", body=_TERMS_BODY)
 
 
+# ── Scholar Dashboard page ─────────────────────────────────────────────────────
+
+_TOOL_LABELS = {
+    "run_full_trinity": "Full Trinity",
+    "consult_agent_x": "Agent X (Innovation)",
+    "consult_agent_z": "Agent Z (Ethics)",
+    "consult_agent_cs": "Agent CS (Security)",
+}
+
+_REC_CLASS = {
+    "PROCEED": "rec-proceed",
+    "REVISE": "rec-revise",
+    "REJECT": "rec-reject",
+}
+
+
+def _dashboard_row(rec: dict) -> str:
+    ts = rec.get("timestamp", "")
+    tool = _TOOL_LABELS.get(rec.get("tool", ""), rec.get("tool", "—"))
+    score = rec.get("overall_score") or rec.get("score")
+    score_str = f"{score:.1f}/10" if score is not None else "—"
+    recommendation = rec.get("recommendation", "—") or "—"
+    # Trim long recommendation text
+    rec_short = recommendation[:60] + "…" if len(recommendation) > 60 else recommendation
+    rec_word = recommendation.split()[0].rstrip(".,—-") if recommendation != "—" else ""
+    rec_cls = _REC_CLASS.get(rec_word.upper(), "")
+    quality = rec.get("quality", "") or ""
+    veto = " ⚑" if rec.get("veto_triggered") else ""
+    # Format timestamp: 2026-04-21T01:23:45.000000+00:00 → Apr 21, 2026 01:23 UTC
+    try:
+        from datetime import datetime, timezone
+        dt = datetime.fromisoformat(ts)
+        ts_fmt = dt.astimezone(timezone.utc).strftime("%b %d, %Y %H:%M UTC")
+    except Exception:
+        ts_fmt = ts[:19].replace("T", " ") if ts else "—"
+    quality_badge = f'<span class="quality-badge">{quality}</span>' if quality else ""
+    return (
+        f"<tr>"
+        f"<td>{ts_fmt}</td>"
+        f"<td>{tool}{quality_badge}</td>"
+        f"<td class='score'>{score_str}</td>"
+        f'<td class="{rec_cls}">{rec_short}{veto}</td>'
+        f"</tr>"
+    )
+
+
+def get_dashboard_page(uuid: str, records: list, firestore_available: bool = True) -> str:
+    """Render Scholar validation history dashboard for GET /early-adopters/dashboard/{uuid}."""
+    uuid_display = uuid[:8] + "…" + uuid[-4:] if len(uuid) > 12 else uuid
+    total = len(records)
+
+    if not firestore_available:
+        status_block = '<div class="notice-box">History temporarily unavailable — Firestore is not reachable. Try again shortly.</div>'
+    elif total == 0:
+        status_block = (
+            '<div class="notice-box">'
+            "No validations recorded yet. Run any Trinity tool with your <code>user_uuid</code> parameter "
+            "to start building your history."
+            "</div>"
+        )
+    else:
+        last_ts = records[0].get("timestamp", "")[:10] if records else ""
+        status_block = (
+            f'<div class="meta">'
+            f"<span>{total} validation{'s' if total != 1 else ''} recorded</span>"
+            f"<span>Last: {last_ts}</span>"
+            f"</div>"
+        )
+
+    rows_html = "\n".join(_dashboard_row(r) for r in records) if records else (
+        "<tr><td colspan='4' style='text-align:center;color:var(--muted);'>No records yet</td></tr>"
+    )
+
+    body = f"""
+<h1>Scholar Dashboard</h1>
+<div class="meta">
+  <span>UUID: <code>{uuid_display}</code></span>
+  <span><a href="/register">Register / update</a></span>
+</div>
+
+{status_block}
+
+<h2>Validation History</h2>
+<table class="legal-table">
+  <thead>
+    <tr><th>Date (UTC)</th><th>Tool</th><th>Score</th><th>Recommendation</th></tr>
+  </thead>
+  <tbody>
+    {rows_html}
+  </tbody>
+</table>
+
+<div class="notice-box" style="margin-top:2rem;">
+  <strong>Privacy:</strong> No concept names or descriptions are stored — only scores,
+  recommendations, and timestamps. See <a href="/privacy">Privacy Policy v2.1</a>.
+</div>
+
+<style>
+  .score {{ font-weight:600; text-align:center; }}
+  .rec-proceed {{ color:#16a34a; }}
+  .rec-revise {{ color:#d97706; }}
+  .rec-reject {{ color:#dc2626; }}
+  .quality-badge {{
+    display:inline-block; margin-left:0.4rem; font-size:0.7rem;
+    padding:0.1rem 0.35rem; border-radius:3px;
+    background:var(--border); color:var(--muted); vertical-align:middle;
+  }}
+</style>
+"""
+    return _legal_shell(title=f"Scholar Dashboard — {uuid_display}", body=body)
+
+
 # ── Changelog page ────────────────────────────────────────────────────────────
 
 _CHANGELOG_BODY = """

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.17"
+SERVER_VERSION = "0.5.18"
 
 # Track C — SYSTEM_NOTICE sanitization constants
 _NOTICE_MAX_LEN = 280

--- a/mcp-server/src/verifimind_mcp/utils/trinity_history.py
+++ b/mcp-server/src/verifimind_mcp/utils/trinity_history.py
@@ -83,6 +83,35 @@ async def _write_to_firestore(uuid: str, record: dict) -> None:
         logger.warning("trinity_history write skipped (non-critical): %s", type(exc).__name__)
 
 
+def read_trinity_history(uuid: str, limit: int = 50) -> list[dict]:
+    """
+    Read validation history for a Scholar UUID from Firestore.
+
+    Returns list of record dicts sorted by timestamp descending.
+    Returns [] if Firestore unavailable, UUID invalid, or no records exist.
+    """
+    if not is_valid_uuid(uuid):
+        return []
+    try:
+        from verifimind_mcp.registration import _get_firestore
+        db = _get_firestore()
+        if db is None:
+            return []
+        from google.cloud.firestore_v1 import Query  # type: ignore
+        docs = (
+            db.collection("trinity_history")
+            .document(uuid)
+            .collection("validations")
+            .order_by("timestamp", direction=Query.DESCENDING)
+            .limit(limit)
+            .get()
+        )
+        return [doc.to_dict() for doc in docs if doc.exists]
+    except Exception as exc:
+        logger.warning("trinity_history read failed (non-critical): %s", type(exc).__name__)
+        return []
+
+
 def persist_trinity_result(uuid: str | None, tool: str, raw_result: dict) -> None:
     """
     Fire-and-forget: schedule Firestore write for Scholar validation history.

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.17", (
+        assert SERVER_VERSION == "0.5.18", (
             f"Expected 0.5.16, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.17"
+        assert SERVER_VERSION == "0.5.18"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.17"
+        assert SERVER_VERSION == "0.5.18"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.17", f"Expected 0.5.16, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.18", f"Expected 0.5.16, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -71,4 +71,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.17", f"Expected 0.5.17, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.18", f"Expected 0.5.17, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0518_scholar_dashboard.py
+++ b/mcp-server/tests/unit/test_v0518_scholar_dashboard.py
@@ -1,0 +1,163 @@
+"""
+Tests for v0.5.18 P0-B — Scholar Dashboard
+
+Coverage:
+  - read_trinity_history: invalid UUID returns []
+  - get_dashboard_page: renders UUID, table, empty state, privacy notice
+  - get_dashboard_page: score/recommendation formatting per tool
+  - get_dashboard_page: firestore_available=False shows unavailable notice
+  - server.py route wired: /early-adopters/dashboard/{uuid} in http_server source
+"""
+
+import inspect
+
+from verifimind_mcp.pages import get_dashboard_page
+from verifimind_mcp.utils.trinity_history import read_trinity_history
+
+import http_server as _http_module
+
+_HTTP_SOURCE = inspect.getsource(_http_module)
+
+VALID_UUID = "019d40d6-9e84-7738-9c0c-fa85b2930600"
+
+
+# ---------------------------------------------------------------------------
+# read_trinity_history: guard conditions
+# ---------------------------------------------------------------------------
+
+class TestReadTrinityHistoryGuards:
+
+    def test_invalid_uuid_returns_empty_list(self):
+        result = read_trinity_history("not-a-uuid")
+        assert result == []
+
+    def test_none_uuid_returns_empty_list(self):
+        result = read_trinity_history(None)  # type: ignore
+        assert result == []
+
+    def test_valid_uuid_no_firestore_returns_empty_list(self):
+        # Firestore not configured in test env — should return [] silently
+        result = read_trinity_history(VALID_UUID)
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# get_dashboard_page: HTML rendering
+# ---------------------------------------------------------------------------
+
+class TestDashboardPageRendering:
+
+    def test_renders_uuid_truncated(self):
+        html = get_dashboard_page(VALID_UUID, [])
+        assert "019d40d6" in html
+        assert VALID_UUID not in html  # Should be truncated, not full UUID
+
+    def test_empty_state_shows_no_validations_message(self):
+        html = get_dashboard_page(VALID_UUID, [])
+        assert "No validations recorded yet" in html
+
+    def test_firestore_unavailable_shows_notice(self):
+        html = get_dashboard_page(VALID_UUID, [], firestore_available=False)
+        assert "temporarily unavailable" in html.lower()
+
+    def test_records_render_table_rows(self):
+        records = [
+            {
+                "timestamp": "2026-04-21T01:00:00+00:00",
+                "tool": "run_full_trinity",
+                "overall_score": 8.2,
+                "recommendation": "PROCEED",
+                "quality": "full",
+                "veto_triggered": False,
+            }
+        ]
+        html = get_dashboard_page(VALID_UUID, records)
+        assert "Full Trinity" in html
+        assert "8.2/10" in html
+        assert "PROCEED" in html
+        assert "Apr 21, 2026" in html
+
+    def test_agent_x_record_renders_score(self):
+        records = [
+            {
+                "timestamp": "2026-04-21T02:00:00+00:00",
+                "tool": "consult_agent_x",
+                "score": 7.5,
+                "recommendation": "REVISE — needs more work",
+            }
+        ]
+        html = get_dashboard_page(VALID_UUID, records)
+        assert "Agent X" in html
+        assert "7.5/10" in html
+
+    def test_agent_z_veto_shows_flag(self):
+        records = [
+            {
+                "timestamp": "2026-04-21T03:00:00+00:00",
+                "tool": "consult_agent_z",
+                "score": 3.0,
+                "recommendation": "REJECT",
+                "veto_triggered": True,
+            }
+        ]
+        html = get_dashboard_page(VALID_UUID, records)
+        assert "⚑" in html
+
+    def test_null_score_renders_dash(self):
+        records = [
+            {
+                "timestamp": "2026-04-21T04:00:00+00:00",
+                "tool": "consult_agent_cs",
+                "score": None,
+                "recommendation": "REVISE",
+            }
+        ]
+        html = get_dashboard_page(VALID_UUID, records)
+        assert "—" in html
+
+    def test_privacy_notice_present(self):
+        html = get_dashboard_page(VALID_UUID, [])
+        assert "Privacy" in html
+        assert "Privacy Policy v2.1" in html
+
+    def test_record_count_shown(self):
+        records = [
+            {"timestamp": "2026-04-21T01:00:00+00:00", "tool": "consult_agent_x",
+             "score": 7.0, "recommendation": "PROCEED"},
+            {"timestamp": "2026-04-21T02:00:00+00:00", "tool": "consult_agent_z",
+             "score": 8.0, "recommendation": "PROCEED"},
+        ]
+        html = get_dashboard_page(VALID_UUID, records)
+        assert "2 validations" in html
+
+    def test_long_recommendation_truncated(self):
+        long_rec = "REVISE — " + "x" * 80
+        records = [
+            {
+                "timestamp": "2026-04-21T01:00:00+00:00",
+                "tool": "consult_agent_x",
+                "score": 5.0,
+                "recommendation": long_rec,
+            }
+        ]
+        html = get_dashboard_page(VALID_UUID, records)
+        assert "…" in html
+
+
+# ---------------------------------------------------------------------------
+# Route wiring in http_server.py
+# ---------------------------------------------------------------------------
+
+class TestHttpServerWiring:
+
+    def test_dashboard_route_present(self):
+        assert "/early-adopters/dashboard/{uuid}" in _HTTP_SOURCE
+
+    def test_ea_dashboard_handler_defined(self):
+        assert "ea_dashboard_handler" in _HTTP_SOURCE
+
+    def test_get_dashboard_page_imported(self):
+        assert "get_dashboard_page" in _HTTP_SOURCE
+
+    def test_read_trinity_history_imported(self):
+        assert "read_trinity_history" in _HTTP_SOURCE


### PR DESCRIPTION
## Summary
P0-B Scholar Dashboard — Scholars can now view their Trinity validation history at:
`GET /early-adopters/dashboard/{uuid}`

## Changes
- `trinity_history.py`: `read_trinity_history(uuid, limit=50)` — sync Firestore subcollection read
- `pages.py`: `get_dashboard_page()` — renders score table, empty state, "temporarily unavailable" fallback, privacy notice
- `http_server.py`: `ea_dashboard_handler` + route wired
- 17 new tests in `test_v0518_scholar_dashboard.py`
- SERVER_VERSION: 0.5.17 → 0.5.18

## What the dashboard shows
| Column | Source |
|--------|--------|
| Date (UTC) | `timestamp` field |
| Tool | Human label (Full Trinity / Agent X / Z / CS) |
| Score | `overall_score` or `score` |
| Recommendation | First 60 chars + `…` |

Privacy: no concept names stored (P1-B invariant). ⚑ flag shown on Z veto.

## Test plan
- [x] 472 unit tests pass, 3 skipped, 59.74% coverage
- [ ] After deploy: `curl https://verifimind.ysenseai.org/early-adopters/dashboard/{valid-uuid}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)