### PR TITLE
feat: v0.5.19 — UUID tier rate limiter (P0-A) + 404 churn fixes (AY PIN)

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -60,7 +60,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.18"
+SERVER_VERSION = "0.5.19"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()
@@ -1314,6 +1314,29 @@ async def polar_webhook_handler(request):
         return JSONResponse({"status": "error", "detail": "verification_failed"}, status_code=400)
 
 
+async def mcp_no_slash_redirect(request):
+    """GET|POST /mcp → 308 to /mcp/ — fixes #1 404 churn source (AY PIN 2026-04-21)."""
+    url = str(request.url).rstrip("/") + "/"
+    return RedirectResponse(url=url, status_code=308)
+
+
+async def mcp_sse_deprecated_handler(request):
+    """GET /mcp/sse, /sse — SSE transport removed. Return actionable JSON."""
+    return JSONResponse(
+        status_code=410,
+        content={
+            "error": "transport_deprecated",
+            "message": (
+                "SSE transport (/mcp/sse) is no longer supported. "
+                "VerifiMind uses Streamable HTTP transport."
+            ),
+            "mcp_endpoint": "https://verifimind.ysenseai.org/mcp/",
+            "quick_start": "claude mcp add -s user verifimind -- npx -y mcp-remote https://verifimind.ysenseai.org/mcp/",
+            "help": "https://github.com/creator35lwb-web/VerifiMind-PEAS#setup",
+        },
+    )
+
+
 # Create Starlette app with proper lifespan from MCP app
 app = Starlette(
     routes=[
@@ -1347,6 +1370,10 @@ app = Starlette(
         Route("/optout", optout_page_handler, methods=["GET"]),
         # v0.5.12 Polar: subscription lifecycle webhook
         Route("/api/webhooks/polar", polar_webhook_handler, methods=["POST"]),
+        # v0.5.19: 404 churn fixes (AY PIN — /mcp no-slash + SSE deprecated paths)
+        Route("/mcp", mcp_no_slash_redirect, methods=["GET", "POST", "HEAD"]),
+        Route("/mcp/sse", mcp_sse_deprecated_handler),
+        Route("/sse", mcp_sse_deprecated_handler),
         Mount("/mcp", app=mcp_app),
     ],
     lifespan=mcp_app.lifespan,  # CRITICAL: Pass lifespan for session initialization

--- a/mcp-server/src/verifimind_mcp/middleware/rate_limiter.py
+++ b/mcp-server/src/verifimind_mcp/middleware/rate_limiter.py
@@ -1,23 +1,19 @@
 """
 Rate Limiting Middleware for VerifiMind MCP Server.
 
-v0.3.1 - EDoS Protection (Economic Denial of Sustainability)
+v0.5.19 - UUID Tier-Aware Rate Limiting (P0-A)
 
-Provides IP-based and global rate limiting to prevent:
-- DDoS attacks causing auto-scale cost explosion
-- API abuse from single users
-- Wallet drain attacks
+Tiers (per 60s window):
+  Anonymous  — no valid UUID header → 10 req/60s per IP
+  Scholar    — valid UUID, not in ea_registrations → 30 req/60s per UUID
+  EA/Pioneer — valid UUID, in ea_registrations → 100 req/60s per UUID
 
-Design Considerations for Cloud Run:
-- In-memory storage (no external dependencies like Redis)
-- Works per-instance (with max 3 instances, worst case is 3x limit)
-- Automatic cleanup of old entries to prevent memory leak
-- Configurable via environment variables
+UUID is read from the X-VerifiMind-UUID header (auto-sent by mcp-remote
+after v0.5.17 mcp_config header fix). Falls back to IP-based limit when
+header is absent or UUID is invalid.
 
-Rate Limits:
-- Per IP: 10 requests/minute (configurable)
-- Global: 100 requests/minute per instance (configurable)
-- Burst: Allow short bursts up to 2x limit
+Tier resolution uses a 5-minute in-memory cache to avoid per-request
+Firestore reads. Firestore unavailable → Scholar limit (fail-open, generous).
 """
 
 import os
@@ -32,123 +28,151 @@ from starlette.responses import JSONResponse
 logger = logging.getLogger(__name__)
 
 # Configuration from environment variables
-RATE_LIMIT_PER_IP = int(os.getenv("RATE_LIMIT_PER_IP", "10"))  # requests per minute
-RATE_LIMIT_GLOBAL = int(os.getenv("RATE_LIMIT_GLOBAL", "100"))  # requests per minute per instance
-RATE_LIMIT_BURST_MULTIPLIER = float(os.getenv("RATE_LIMIT_BURST", "2.0"))  # allow 2x burst
-RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))  # seconds (1 minute)
-RATE_LIMIT_CLEANUP_INTERVAL = int(os.getenv("RATE_LIMIT_CLEANUP", "300"))  # cleanup every 5 minutes
+RATE_LIMIT_PER_IP = int(os.getenv("RATE_LIMIT_PER_IP", "10"))
+RATE_LIMIT_GLOBAL = int(os.getenv("RATE_LIMIT_GLOBAL", "100"))
+RATE_LIMIT_BURST_MULTIPLIER = float(os.getenv("RATE_LIMIT_BURST", "2.0"))
+RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
+RATE_LIMIT_CLEANUP_INTERVAL = int(os.getenv("RATE_LIMIT_CLEANUP", "300"))
+
+# Tier rate limits (requests per RATE_LIMIT_WINDOW)
+TIER_LIMITS: Dict[str, int] = {
+    "anonymous": RATE_LIMIT_PER_IP,   # 10/60s — IP-based
+    "scholar":   30,                   # 30/60s — UUID-based
+    "pioneer":   100,                  # 100/60s — UUID-based (EA + Pioneer)
+}
+
+# UUID → tier cache: {uuid: (tier, expires_at)}
+_uuid_tier_cache: Dict[str, Tuple[str, float]] = {}
+UUID_TIER_CACHE_TTL = 300  # 5 minutes — matches Firestore session TTL
 
 # Exempt paths from rate limiting
 EXEMPT_PATHS = {"/health", "/", "/.well-known/mcp-config", "/setup", "/register", "/optout", "/privacy", "/terms", "/robots.txt", "/favicon.ico", "/early-adopters/register"}
 
 
-class RateLimitStore:
-    """
-    In-memory rate limit tracking with automatic cleanup.
+def _resolve_uuid_tier(uuid: str) -> str:
+    """Return tier for a valid UUID. Cached for UUID_TIER_CACHE_TTL seconds.
 
-    Uses sliding window algorithm for fair rate limiting.
+    Checks ea_registrations Firestore collection:
+      - found → "pioneer"  (EA + Pioneer both get 100/60s)
+      - not found → "scholar" (valid UUID, free tier, 30/60s)
+      - Firestore unavailable → "scholar" (fail-open, generous)
     """
+    now = time.time()
+    cached = _uuid_tier_cache.get(uuid)
+    if cached and now < cached[1]:
+        return cached[0]
+    try:
+        from verifimind_mcp.registration import _get_firestore, COLLECTION_REGISTRATIONS
+        db = _get_firestore()
+        if db is not None:
+            doc = db.collection(COLLECTION_REGISTRATIONS).document(uuid).get()
+            tier = "pioneer" if doc.exists else "scholar"
+        else:
+            tier = "scholar"
+    except Exception:
+        tier = "scholar"
+    _uuid_tier_cache[uuid] = (tier, now + UUID_TIER_CACHE_TTL)
+    return tier
+
+
+class RateLimitStore:
+    """In-memory rate limit tracking with automatic cleanup. Sliding window."""
 
     def __init__(self):
-        # {ip: [(timestamp, count), ...]}
         self.ip_requests: Dict[str, list] = defaultdict(list)
+        self.uuid_requests: Dict[str, list] = defaultdict(list)
         self.global_requests: list = []
         self.last_cleanup = time.time()
 
     def _cleanup_old_entries(self, entries: list, window: int) -> list:
-        """Remove entries older than the window."""
         cutoff = time.time() - window
         return [e for e in entries if e[0] > cutoff]
 
     def _maybe_global_cleanup(self):
-        """Periodically clean up all old entries to prevent memory leak."""
         now = time.time()
         if now - self.last_cleanup > RATE_LIMIT_CLEANUP_INTERVAL:
-            # Clean up IP entries
-            ips_to_remove = []
-            for ip, entries in self.ip_requests.items():
-                self.ip_requests[ip] = self._cleanup_old_entries(entries, RATE_LIMIT_WINDOW)
-                if not self.ip_requests[ip]:
-                    ips_to_remove.append(ip)
-
-            for ip in ips_to_remove:
-                del self.ip_requests[ip]
-
-            # Clean up global entries
-            self.global_requests = self._cleanup_old_entries(self.global_requests, RATE_LIMIT_WINDOW)
-
+            for bucket in (self.ip_requests, self.uuid_requests):
+                dead = [k for k, v in bucket.items()
+                        if not self._cleanup_old_entries(v, RATE_LIMIT_WINDOW)]
+                for k in dead:
+                    del bucket[k]
+                for k in list(bucket):
+                    bucket[k] = self._cleanup_old_entries(bucket[k], RATE_LIMIT_WINDOW)
+            self.global_requests = self._cleanup_old_entries(
+                self.global_requests, RATE_LIMIT_WINDOW
+            )
             self.last_cleanup = now
-            logger.debug(f"Rate limiter cleanup: {len(self.ip_requests)} IPs tracked")
+            logger.debug("Rate limiter cleanup: %d IPs, %d UUIDs tracked",
+                         len(self.ip_requests), len(self.uuid_requests))
 
-    def check_and_record(self, ip: str) -> Tuple[bool, Optional[int], str]:
-        """
-        Check if request is allowed and record it.
-
-        Returns:
-            Tuple of (allowed, retry_after_seconds, limit_type)
-        """
+    def _check_bucket(self, bucket: dict, key: str, limit: int,
+                      label: str) -> Tuple[bool, Optional[int], str]:
+        """Sliding-window check on a named bucket. Records on pass."""
         now = time.time()
-        self._maybe_global_cleanup()
-
-        # Clean current IP's entries
-        self.ip_requests[ip] = self._cleanup_old_entries(
-            self.ip_requests[ip], RATE_LIMIT_WINDOW
-        )
-
-        # Clean global entries
-        self.global_requests = self._cleanup_old_entries(
-            self.global_requests, RATE_LIMIT_WINDOW
-        )
-
-        # Count requests in current window
-        ip_count = len(self.ip_requests[ip])
-        global_count = len(self.global_requests)
-
-        # Check IP limit (with burst allowance)
-        ip_limit = int(RATE_LIMIT_PER_IP * RATE_LIMIT_BURST_MULTIPLIER)
-        if ip_count >= ip_limit:
-            # Calculate retry after
-            oldest = min(e[0] for e in self.ip_requests[ip])
+        bucket[key] = self._cleanup_old_entries(bucket[key], RATE_LIMIT_WINDOW)
+        count = len(bucket[key])
+        effective_limit = int(limit * RATE_LIMIT_BURST_MULTIPLIER)
+        if count >= effective_limit:
+            oldest = min(e[0] for e in bucket[key])
             retry_after = int(RATE_LIMIT_WINDOW - (now - oldest)) + 1
-            logger.warning(f"Rate limit exceeded for IP {ip}: {ip_count}/{ip_limit}")
-            return False, retry_after, "ip"
-
-        # Check global limit (with burst allowance)
-        global_limit = int(RATE_LIMIT_GLOBAL * RATE_LIMIT_BURST_MULTIPLIER)
-        if global_count >= global_limit:
-            oldest = min(e[0] for e in self.global_requests)
-            retry_after = int(RATE_LIMIT_WINDOW - (now - oldest)) + 1
-            logger.warning(f"Global rate limit exceeded: {global_count}/{global_limit}")
-            return False, retry_after, "global"
-
-        # Record request
-        self.ip_requests[ip].append((now, 1))
-        self.global_requests.append((now, 1))
-
+            logger.warning("Rate limit exceeded [%s=%s]: %d/%d", label, key[:8], count, effective_limit)
+            return False, retry_after, label
+        bucket[key].append((now, 1))
         return True, None, "ok"
 
-    def get_stats(self) -> Dict:
-        """Get current rate limiting statistics."""
-        now = time.time()
+    def check_and_record(self, ip: str) -> Tuple[bool, Optional[int], str]:
+        """Anonymous path: IP-based, RATE_LIMIT_PER_IP limit."""
+        self._maybe_global_cleanup()
+        # Global guard
+        self.global_requests = self._cleanup_old_entries(self.global_requests, RATE_LIMIT_WINDOW)
+        global_limit = int(RATE_LIMIT_GLOBAL * RATE_LIMIT_BURST_MULTIPLIER)
+        if len(self.global_requests) >= global_limit:
+            oldest = min(e[0] for e in self.global_requests)
+            retry_after = int(RATE_LIMIT_WINDOW - (time.time() - oldest)) + 1
+            return False, retry_after, "global"
+        allowed, retry_after, limit_type = self._check_bucket(
+            self.ip_requests, ip, RATE_LIMIT_PER_IP, "ip"
+        )
+        if allowed:
+            self.global_requests.append((time.time(), 1))
+        return allowed, retry_after, limit_type
 
-        # Count active requests in window
+    def check_and_record_uuid(self, uuid: str, limit: int) -> Tuple[bool, Optional[int], str]:
+        """Scholar/Pioneer path: UUID-based with tier limit."""
+        self._maybe_global_cleanup()
+        # Global guard
+        self.global_requests = self._cleanup_old_entries(self.global_requests, RATE_LIMIT_WINDOW)
+        global_limit = int(RATE_LIMIT_GLOBAL * RATE_LIMIT_BURST_MULTIPLIER)
+        if len(self.global_requests) >= global_limit:
+            oldest = min(e[0] for e in self.global_requests)
+            retry_after = int(RATE_LIMIT_WINDOW - (time.time() - oldest)) + 1
+            return False, retry_after, "global"
+        allowed, retry_after, limit_type = self._check_bucket(
+            self.uuid_requests, uuid, limit, "uuid"
+        )
+        if allowed:
+            self.global_requests.append((time.time(), 1))
+        return allowed, retry_after, limit_type
+
+    def get_stats(self) -> Dict:
+        now = time.time()
         active_ips = sum(
             1 for entries in self.ip_requests.values()
             if any(e[0] > now - RATE_LIMIT_WINDOW for e in entries)
         )
-
-        global_count = len([
-            e for e in self.global_requests
-            if e[0] > now - RATE_LIMIT_WINDOW
-        ])
-
+        active_uuids = sum(
+            1 for entries in self.uuid_requests.values()
+            if any(e[0] > now - RATE_LIMIT_WINDOW for e in entries)
+        )
+        global_count = len([e for e in self.global_requests if e[0] > now - RATE_LIMIT_WINDOW])
         return {
             "active_ips": active_ips,
+            "active_uuids": active_uuids,
             "global_requests_in_window": global_count,
             "global_limit": RATE_LIMIT_GLOBAL,
             "ip_limit": RATE_LIMIT_PER_IP,
             "window_seconds": RATE_LIMIT_WINDOW,
-            "burst_multiplier": RATE_LIMIT_BURST_MULTIPLIER
+            "burst_multiplier": RATE_LIMIT_BURST_MULTIPLIER,
         }
 
 
@@ -181,61 +205,71 @@ def get_client_ip(request: Request) -> str:
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """
-    Rate limiting middleware for Starlette/FastAPI.
-
-    Protects against:
-    - EDoS (Economic Denial of Sustainability)
-    - API abuse
-    - Wallet drain attacks on auto-scaling infrastructure
-    """
+    """UUID tier-aware rate limiting. Anonymous→IP, Scholar/Pioneer→UUID."""
 
     async def dispatch(self, request: Request, call_next):
-        # Skip rate limiting for exempt paths
         if request.url.path in EXEMPT_PATHS:
             return await call_next(request)
-
-        # Skip OPTIONS requests (CORS preflight)
         if request.method == "OPTIONS":
             return await call_next(request)
 
-        # Get client IP
         client_ip = get_client_ip(request)
 
-        # Check rate limit
-        allowed, retry_after, limit_type = _rate_limit_store.check_and_record(client_ip)
+        # Resolve tier from X-VerifiMind-UUID header
+        uuid_header = request.headers.get("x-verifimind-uuid", "").strip()
+        tier = "anonymous"
+        active_limit = TIER_LIMITS["anonymous"]
+
+        if uuid_header:
+            try:
+                from verifimind_mcp.utils.uuid_tracer import is_valid_uuid
+                if is_valid_uuid(uuid_header):
+                    tier = _resolve_uuid_tier(uuid_header)
+                    active_limit = TIER_LIMITS[tier]
+            except Exception:
+                pass  # invalid header → fall back to anonymous
+
+        if tier == "anonymous":
+            allowed, retry_after, limit_type = _rate_limit_store.check_and_record(client_ip)
+        else:
+            allowed, retry_after, limit_type = _rate_limit_store.check_and_record_uuid(
+                uuid_header, active_limit
+            )
 
         if not allowed:
             logger.warning(
-                f"Rate limited: IP={client_ip}, type={limit_type}, "
-                f"path={request.url.path}, retry_after={retry_after}s"
+                "Rate limited: tier=%s key=%s type=%s path=%s retry_after=%ss",
+                tier, (uuid_header[:8] if uuid_header else client_ip), limit_type,
+                request.url.path, retry_after,
             )
-
             return JSONResponse(
                 status_code=429,
                 content={
                     "error": "rate_limit_exceeded",
                     "message": f"Too many requests. Please try again in {retry_after} seconds.",
+                    "tier": tier,
+                    "limit": active_limit,
                     "limit_type": limit_type,
                     "retry_after": retry_after,
-                    "documentation": "https://github.com/creator35lwb-web/VerifiMind-PEAS#rate-limits"
+                    "upgrade_hint": (
+                        "Register at verifimind.ysenseai.org/register for Scholar tier (30 req/60s). "
+                        "Pioneer tier: 100 req/60s."
+                    ) if tier == "anonymous" else None,
+                    "documentation": "https://github.com/creator35lwb-web/VerifiMind-PEAS#rate-limits",
                 },
                 headers={
                     "Retry-After": str(retry_after),
-                    "X-RateLimit-Limit": str(RATE_LIMIT_PER_IP),
+                    "X-RateLimit-Limit": str(active_limit),
                     "X-RateLimit-Remaining": "0",
-                    "X-RateLimit-Reset": str(int(time.time()) + retry_after)
-                }
+                    "X-RateLimit-Reset": str(int(time.time()) + retry_after),
+                    "X-RateLimit-Tier": tier,
+                },
             )
 
-        # Add rate limit headers to response
         response = await call_next(request)
-
-        # Add informational headers
-        _rate_limit_store.get_stats()
-        response.headers["X-RateLimit-Limit"] = str(RATE_LIMIT_PER_IP)
+        response.headers["X-RateLimit-Limit"] = str(active_limit)
         response.headers["X-RateLimit-Window"] = str(RATE_LIMIT_WINDOW)
-
+        response.headers["X-RateLimit-Tier"] = tier
         return response
 
 

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.18"
+SERVER_VERSION = "0.5.19"
 
 # Track C — SYSTEM_NOTICE sanitization constants
 _NOTICE_MAX_LEN = 280

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.18", (
+        assert SERVER_VERSION == "0.5.19", (
             f"Expected 0.5.16, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.18"
+        assert SERVER_VERSION == "0.5.19"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.18"
+        assert SERVER_VERSION == "0.5.19"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.18", f"Expected 0.5.16, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.19", f"Expected 0.5.16, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -47,8 +47,9 @@ class TestMcpConfigHeader:
         assert "mcp-remote" in args
 
     def test_server_url_still_in_args(self):
+        from urllib.parse import urlparse
         args = self._extras()["mcp_config"]["mcpServers"]["verifimind"]["args"]
-        assert any("verifimind.ysenseai.org" in a for a in args)
+        assert any(urlparse(a).hostname == "verifimind.ysenseai.org" for a in args if a.startswith("http"))
 
     def test_different_uuids_produce_same_header_template(self):
         uuid_a = "019d40d6-9e84-7738-9c0c-fa85b2930600"
@@ -71,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.18", f"Expected 0.5.17, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.19", f"Expected 0.5.17, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -1,0 +1,180 @@
+"""
+Tests for v0.5.19 P0-A — UUID Tier-Aware Rate Limiter
+
+Coverage:
+  - TIER_LIMITS constants correct
+  - RateLimitStore.check_and_record_uuid: allows up to limit, blocks on limit+1
+  - RateLimitStore.check_and_record: IP path unchanged
+  - _resolve_uuid_tier: invalid UUID / no Firestore → "scholar"
+  - _uuid_tier_cache: populated on first call, reused on second
+  - Middleware response headers include X-RateLimit-Tier
+  - get_stats includes active_uuids
+  - Server version 0.5.19
+"""
+
+import time
+from collections import defaultdict
+
+from verifimind_mcp.middleware.rate_limiter import (
+    TIER_LIMITS,
+    RateLimitStore,
+    _resolve_uuid_tier,
+    _uuid_tier_cache,
+    UUID_TIER_CACHE_TTL,
+)
+
+VALID_UUID = "019d40d6-9e84-7738-9c0c-fa85b2930600"
+VALID_UUID_2 = "019e1234-abcd-7000-beef-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# TIER_LIMITS constants
+# ---------------------------------------------------------------------------
+
+class TestTierLimitsConstants:
+
+    def test_anonymous_is_10(self):
+        assert TIER_LIMITS["anonymous"] == 10
+
+    def test_scholar_is_30(self):
+        assert TIER_LIMITS["scholar"] == 30
+
+    def test_pioneer_is_100(self):
+        assert TIER_LIMITS["pioneer"] == 100
+
+    def test_scholar_greater_than_anonymous(self):
+        assert TIER_LIMITS["scholar"] > TIER_LIMITS["anonymous"]
+
+    def test_pioneer_greater_than_scholar(self):
+        assert TIER_LIMITS["pioneer"] > TIER_LIMITS["scholar"]
+
+
+# ---------------------------------------------------------------------------
+# RateLimitStore.check_and_record_uuid
+# ---------------------------------------------------------------------------
+
+class TestCheckAndRecordUuid:
+
+    def _fresh_store(self):
+        store = RateLimitStore()
+        return store
+
+    def test_allows_requests_up_to_limit(self):
+        store = self._fresh_store()
+        # burst multiplier is 2x, so effective = limit * 2
+        # With limit=5 and burst=2, we can do 10 before hitting cap
+        for _ in range(5):
+            allowed, _, _ = store.check_and_record_uuid(VALID_UUID, 5)
+            assert allowed is True
+
+    def test_blocks_after_burst_limit(self):
+        store = self._fresh_store()
+        from verifimind_mcp.middleware.rate_limiter import RATE_LIMIT_BURST_MULTIPLIER
+        burst_cap = int(5 * RATE_LIMIT_BURST_MULTIPLIER)
+        for _ in range(burst_cap):
+            store.check_and_record_uuid(VALID_UUID, 5)
+        allowed, retry_after, limit_type = store.check_and_record_uuid(VALID_UUID, 5)
+        assert allowed is False
+        assert retry_after is not None and retry_after > 0
+        assert limit_type == "uuid"
+
+    def test_different_uuids_have_separate_buckets(self):
+        store = self._fresh_store()
+        from verifimind_mcp.middleware.rate_limiter import RATE_LIMIT_BURST_MULTIPLIER
+        burst_cap = int(3 * RATE_LIMIT_BURST_MULTIPLIER)
+        for _ in range(burst_cap):
+            store.check_and_record_uuid(VALID_UUID, 3)
+        # UUID_2 should still be allowed
+        allowed, _, _ = store.check_and_record_uuid(VALID_UUID_2, 3)
+        assert allowed is True
+
+    def test_returns_ok_on_allow(self):
+        store = self._fresh_store()
+        allowed, retry_after, limit_type = store.check_and_record_uuid(VALID_UUID, 100)
+        assert allowed is True
+        assert retry_after is None
+        assert limit_type == "ok"
+
+
+# ---------------------------------------------------------------------------
+# RateLimitStore.check_and_record (IP path — backward compat)
+# ---------------------------------------------------------------------------
+
+class TestCheckAndRecordIp:
+
+    def test_ip_path_still_works(self):
+        store = RateLimitStore()
+        allowed, _, _ = store.check_and_record("1.2.3.4")
+        assert allowed is True
+
+    def test_ip_and_uuid_tracked_separately(self):
+        store = RateLimitStore()
+        store.check_and_record("1.2.3.4")
+        store.check_and_record_uuid(VALID_UUID, 30)
+        stats = store.get_stats()
+        assert stats["active_ips"] >= 1
+        assert stats["active_uuids"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# get_stats includes active_uuids
+# ---------------------------------------------------------------------------
+
+class TestGetStatsUuid:
+
+    def test_active_uuids_in_stats(self):
+        store = RateLimitStore()
+        store.check_and_record_uuid(VALID_UUID, 30)
+        stats = store.get_stats()
+        assert "active_uuids" in stats
+        assert stats["active_uuids"] >= 1
+
+    def test_active_uuids_zero_when_no_uuid_requests(self):
+        store = RateLimitStore()
+        store.check_and_record("10.0.0.1")
+        stats = store.get_stats()
+        assert stats["active_uuids"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_uuid_tier: no Firestore in test env
+# ---------------------------------------------------------------------------
+
+class TestResolveUuidTier:
+
+    def test_valid_uuid_no_firestore_returns_scholar(self):
+        # Clear cache entry if present
+        _uuid_tier_cache.pop(VALID_UUID_2, None)
+        tier = _resolve_uuid_tier(VALID_UUID_2)
+        assert tier in ("scholar", "pioneer")  # scholar when no Firestore
+
+    def test_result_is_cached(self):
+        test_uuid = "019aaaaa-0000-7000-0000-000000000001"
+        _uuid_tier_cache.pop(test_uuid, None)
+        tier1 = _resolve_uuid_tier(test_uuid)
+        # Inject fake cache entry to prove it's used
+        _uuid_tier_cache[test_uuid] = ("pioneer", time.time() + 9999)
+        tier2 = _resolve_uuid_tier(test_uuid)
+        assert tier2 == "pioneer"
+        # Cleanup
+        _uuid_tier_cache.pop(test_uuid, None)
+
+    def test_expired_cache_triggers_fresh_lookup(self):
+        test_uuid = "019bbbbb-0000-7000-0000-000000000002"
+        # Inject expired cache entry
+        _uuid_tier_cache[test_uuid] = ("pioneer", time.time() - 1)
+        tier = _resolve_uuid_tier(test_uuid)
+        # After expiry, fresh lookup → scholar (no Firestore in tests)
+        assert tier in ("scholar", "pioneer")
+        _uuid_tier_cache.pop(test_uuid, None)
+
+
+# ---------------------------------------------------------------------------
+# Server version
+# ---------------------------------------------------------------------------
+
+class TestServerVersion:
+
+    def test_server_version_is_0519(self):
+        from verifimind_mcp.server import SERVER_VERSION
+        assert SERVER_VERSION == "0.5.19", f"Expected 0.5.19, got {SERVER_VERSION}"


### PR DESCRIPTION
## Summary

Two independent fixes bundled:

### 1. P0-A UUID Tier-Aware Rate Limiter (T Phase 84 D1)
Reads `X-VerifiMind-UUID` header (auto-sent since v0.5.17 mcp_config fix) and applies tier-based limits:

| Tier | Identity | Limit |
|------|----------|-------|
| Anonymous | No header / invalid UUID | 10 req/60s per IP |
| Scholar | Valid UUID, not registered EA | 30 req/60s per UUID |
| Pioneer/EA | Valid UUID, in ea_registrations | 100 req/60s per UUID |

- 5-minute in-memory tier cache (avoids per-request Firestore reads)
- Firestore unavailable → Scholar limit (fail-open)
- Response headers: `X-RateLimit-Tier`, `X-RateLimit-Limit`
- 429 response includes `upgrade_hint` for anonymous users

### 2. 404 Churn Fixes (AY COO PIN — 531-556 HTTP 404s/day)
- **`/mcp` (no trailing slash) → 308 redirect to `/mcp/`** — confirmed live: `GET /mcp → 404` before this fix. Primary churn driver for clients dropping the trailing slash.
- **`/mcp/sse` + `/sse` → 410 Gone** with actionable JSON (quick_start command included). SSE was deprecated; old clients hitting these paths now get a clear migration path.

### 3. CodeQL False Positive Fix
`test_v0517_mcp_config_header.py` line 51: URL check now uses `urlparse().hostname` instead of substring match. Resolves alert #162.

## Test plan
- [x] 489 unit tests pass, 3 skipped, 60.43% coverage
- [ ] After deploy: `curl -I https://verifimind.ysenseai.org/mcp` should return 308
- [ ] After deploy: `curl https://verifimind.ysenseai.org/mcp/sse` should return 410

🤖 Generated with [Claude Code](https://claude.com/claude-code)