### PR TITLE
docs: public announcement v0.5.16–v0.5.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,106 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.19 - UUID Tier-Aware Rate Limiter + 404 Churn Fixes (April 21, 2026)
+
+Scholar/Pioneer users now get dedicated UUID-based rate limit buckets (30 req/60s and 100 req/60s respectively), replacing the shared IP-only limit. The `/mcp` missing-slash 404 (531+ daily errors from AY COO log analysis) is fixed with a 308 redirect.
+
+### P0-A: UUID Tier-Aware Rate Limiting
+- `X-VerifiMind-UUID` header (auto-sent since v0.5.17) now sets rate limit tier server-side
+- Anonymous: 10 req/60s per IP (unchanged) — Scholar: 30 req/60s per UUID — Pioneer: 100 req/60s per UUID
+- Tier resolved via Firestore `ea_registrations` lookup, cached 5 minutes; fail-open to Scholar if Firestore unavailable
+- `X-RateLimit-Tier` header on every response; 429 response includes upgrade hint for anonymous users
+- `TIER_LIMITS`, `_resolve_uuid_tier()`, `_uuid_tier_cache` all exported for testing
+
+### 404 Churn Fixes (AY COO PIN)
+- `GET /mcp` (no trailing slash) → **308 Permanent Redirect** to `/mcp/` (method-preserving — POST clients routed correctly)
+- `GET /mcp/sse` and `GET /sse` → **410 Gone** with actionable JSON (`use_instead` URL, `transport` hint)
+- Eliminates ~531–556 daily 404s identified in GCP log analysis
+
+### Testing
+- 574 tests pass (14 skipped), 61.99% coverage, CodeQL clean
+
+### Pull Requests
+- PR #163 (P0-A UUID rate limiter), PR #164 (404 churn fixes)
+
+### Credits
+- Implementation: RNA (Claude Code, CSO)
+- Specification: T (Manus AI, CTO) — Phase 84 D3
+- Log Analysis: AY (Antigravity, COO) — 404 Churn PIN
+- Human Orchestrator: Alton
+
+---
+
+## v0.5.18 - Scholar Dashboard: Trinity History (April 21, 2026)
+
+Registered Scholar users can now view their personal Trinity validation history at `GET /early-adopters/dashboard/{uuid}`.
+
+### Scholar Dashboard (P0-B)
+- `GET /early-adopters/dashboard/{uuid}` — HTML page showing last 50 Trinity validations for the authenticated UUID
+- Reads `trinity_history/{uuid}/validations/` from Firestore (sync client, descending by timestamp)
+- Displays: score, tool, recommendation excerpt, veto flag (⚑), timestamp per row
+- Empty state, "temporarily unavailable" fallback, privacy notice on every render
+- `read_trinity_history(uuid, limit=50)` utility added to `trinity_history.py` (sync Firestore read)
+
+### Testing
+- 472 tests pass, 3 skipped, 59.74% coverage
+
+### Pull Requests
+- PR #162 (Scholar Dashboard)
+
+### Credits
+- Implementation: RNA (Claude Code, CSO)
+- Specification: T (Manus AI, CTO) — Phase 84 D2
+- Human Orchestrator: Alton
+
+---
+
+## v0.5.17 - mcp_config UUID Header Fix (April 21, 2026)
+
+UUID now automatically flows on every MCP request for registered Scholar and Pioneer users — no manual `user_uuid` parameter needed on each tool call.
+
+### UUID Header Auto-Flow (T Phase 84 D1)
+- `mcp_config` args in registration response now include `--header X-VerifiMind-UUID:${VERIFIMIND_UUID}`
+- `mcp-remote` expands `${VERIFIMIND_UUID}` from the process environment and sends it as a request header on every call
+- `env: {VERIFIMIND_UUID: uuid}` still present (backward compat) — header fix is additive
+- Server-side middleware reads `X-VerifiMind-UUID` for UUID tier-aware rate limiting (v0.5.19)
+- MCP Registry updated to v2.5.0 ([registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=verifimind))
+
+### Testing
+- 8 new tests (mcp_config header structure, env var presence, env var expansion pattern)
+
+### Pull Requests
+- PR #160 (mcp_config header fix), PR #161 (MCP Registry v2.5.0)
+
+### Credits
+- Implementation: RNA (Claude Code, CSO)
+- Specification: T (Manus AI, CTO) — Phase 84 hybrid D1
+- Human Orchestrator: Alton
+
+---
+
+## v0.5.16 - Trinity History Persistence + Terms Hotfix (April 21, 2026)
+
+Trinity validation results are now persisted to Firestore for the Scholar Dashboard (P1-B), and the `/terms` page was updated to match the current 3-tier service model.
+
+### Trinity History Persistence (P1-B)
+- `write_trinity_history(uuid, tool, result)` — fire-and-forget async Firestore write to `trinity_history/{uuid}/validations/`
+- Stores: tool name, overall score, recommendation excerpt, veto flag, timestamp, `_inference_quality`
+- Wired into all 4 core MCP tools (`consult_agent_x/z/cs`, `run_full_trinity`) when `user_uuid` provided
+- Zero latency impact (async task, no await in hot path)
+
+### Terms Hotfix
+- `/terms` page updated: Anonymous tier row added to service tiers table, Identity + Rate Limit columns explicit, Privacy Policy link updated to v2.1, "Updated: April 21, 2026"
+
+### Pull Requests
+- PR #158 (terms hotfix), PR #159 (Trinity history persistence)
+
+### Credits
+- Implementation: RNA (Claude Code, CSO)
+- Human Orchestrator: Alton
+
+---
+
 ## v0.5.15 - Scholar Incentives: UUID Tracer + Registration UX (April 20, 2026)
 
 Optional UUID tracer on all 10 Scholar tools, Privacy Policy v2.1 disclosure, enhanced registration response.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
   > **Evolution of PEAS:** v1.x (2024): *Prompt Engineering Application Synthesis* (Zenodo DOI — immutable) · v2.x–v4.x (2025): *Prompt Engineering & AI Standardization* (Genesis Methodology era) · **v5.x (2026): *Prompt Engineering Agents Standardization* — current canonical** — AI Council vote 3/4 APPROVE (Apr 10, 2026)
 
-  [![Version](https://img.shields.io/badge/version-v0.5.15-blue.svg)](CHANGELOG.md)
+  [![Version](https://img.shields.io/badge/version-v0.5.19-blue.svg)](CHANGELOG.md)
   [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
   [![Status](https://img.shields.io/badge/status-Operational-success.svg)](SERVER_STATUS.md)
   [![MACP](https://img.shields.io/badge/MACP-v2.2%20%22Identity%22-blueviolet)](https://doi.org/10.5281/zenodo.18504478)
@@ -31,7 +31,7 @@
 
 ## MCP Server: Production Deployed
 
-> **v0.5.15 "Scholar Incentives"** — 2,389+ verified engagement hours | 1,876+ unique endpoints (IP-based; verified users tracked via EA registration UUID) | 90.7% Value Confirmation Rate | **Pioneer Tier** ($9/mo, Polar MoR) | **UUID Tracer on all 10 Scholar tools** (optional `user_uuid` → GCP analytics) | **Privacy Policy v2.1** (UUID analytics disclosed, Z-Protocol v1.1) | **Registration UX** (mcp_config + test_url + dashboard_url in response) | **Research Library v1.0** (20+ papers at `/library`) | **Connection Test** (`/mcp/test?key=<uuid>`) | MACP v2.2 "Identity" | 515 tests | 74+ weekly COO reports. [Health Check](https://verifimind.ysenseai.org/health) | [Changelog](https://verifimind.ysenseai.org/changelog) | [Register](https://verifimind.ysenseai.org/register) | [Pioneer Tier](https://verifimind.ysenseai.org/terms)
+> **v0.5.19 "UUID Rate Limiter"** — **UUID Tier-Aware Rate Limiting** (Anonymous 10/60s · Scholar 30/60s · Pioneer 100/60s) | **Scholar Dashboard** (`/early-adopters/dashboard/{uuid}`) | **UUID Header Auto-Flow** (mcp_config `--header` fix — no manual `user_uuid` needed) | **404 Churn Eliminated** (`/mcp` → 308, `/mcp/sse` → 410) | Pioneer Tier ($9/mo, Polar MoR) | Research Library v1.0 (20+ papers at `/library`) | MACP v2.2 "Identity" | 574 tests | 74+ weekly COO reports. [Health Check](https://verifimind.ysenseai.org/health) | [Changelog](https://verifimind.ysenseai.org/changelog) | [Register](https://verifimind.ysenseai.org/register) | [Pioneer Tier](https://verifimind.ysenseai.org/terms)
 
 VerifiMind PEAS is now **live and accessible** across multiple platforms:
 
@@ -66,13 +66,16 @@ claude mcp add -s user verifimind -- npx -y mcp-remote https://verifimind.ysense
 }
 ```
 
-**Claude Desktop (Scholar UUID — optional, enables usage dashboard):** After [registering](https://verifimind.ysenseai.org/register), pass your UUID for analytics and the dashboard at `/early-adopters/dashboard/{uuid}`:
+**Claude Desktop (Scholar UUID — recommended after registering):** After [registering](https://verifimind.ysenseai.org/register), add your UUID to auto-send on every request — enables tier-aware rate limits and your dashboard at `/early-adopters/dashboard/{uuid}`:
 ```json
 {
   "mcpServers": {
     "verifimind": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://verifimind.ysenseai.org/mcp/"],
+      "args": [
+        "-y", "mcp-remote", "https://verifimind.ysenseai.org/mcp/",
+        "--header", "X-VerifiMind-UUID:${VERIFIMIND_UUID}"
+      ],
       "env": {
         "VERIFIMIND_UUID": "your-uuid-here"
       }
@@ -80,7 +83,7 @@ claude mcp add -s user verifimind -- npx -y mcp-remote https://verifimind.ysense
   }
 }
 ```
-> Pass `user_uuid` on any Scholar tool call to log to your dashboard. Anonymous tool calls (no `user_uuid`) work identically.
+> Your UUID is sent automatically on every request — no `user_uuid` parameter needed on each tool call.
 
 **Cursor / VS Code Copilot** (`.cursor/mcp.json` or `.vscode/mcp.json`):
 ```json
@@ -117,7 +120,7 @@ Based on production log analysis (February 2026), these are the most frequent co
 | Mistake | What Happens | Fix |
 |---------|-------------|-----|
 | **Visiting the URL in a browser** | You see a `406 Not Acceptable` error | This is an API, not a website. Use an MCP client (Claude Desktop, Cursor, etc.) |
-| **Missing trailing slash** `/mcp` | `405 Method Not Allowed` | Always use `/mcp/` with the trailing slash |
+| **Missing trailing slash** `/mcp` | `308 Permanent Redirect` (auto-followed by most clients) | Always use `/mcp/` with the trailing slash — POST clients are redirected correctly since v0.5.19 |
 | **Using GET instead of POST** | `400 Bad Request` | MCP protocol requires POST requests with JSON-RPC body |
 | **Using `http-sse` transport** | Connection fails | Use `streamable-http` transport (not `http-sse`) |
 | **Connecting to Smithery proxy** | Sunset completed (March 1, 2026) | Use the direct URL: `https://verifimind.ysenseai.org/mcp/` |

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1755,12 +1755,53 @@ def get_dashboard_page(uuid: str, records: list, firestore_available: bool = Tru
 _CHANGELOG_BODY = """
 <h1>Changelog</h1>
 <div class="meta">
-  <span>Last updated: April 20, 2026</span>
+  <span>Last updated: April 21, 2026</span>
   <span><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/releases" target="_blank" rel="noopener">GitHub Releases</a></span>
 </div>
 
+<div id="v0.5.19">
+<h2>v0.5.19 — UUID Tier-Aware Rate Limiter + 404 Churn Fixes <span class="live-badge">LIVE</span></h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 21, 2026</p>
+<ul>
+  <li><strong>UUID Tier-Aware Rate Limiting (P0-A)</strong> — <code>X-VerifiMind-UUID</code> header sets rate limit tier server-side: Anonymous 10 req/60s per IP &middot; Scholar 30 req/60s per UUID &middot; Pioneer 100 req/60s per UUID; tier cached 5 min; fail-open to Scholar if Firestore unavailable; <code>X-RateLimit-Tier</code> on every response</li>
+  <li><strong>404 Churn Fixed (AY COO PIN)</strong> — <code>GET /mcp</code> (no trailing slash) &rarr; <strong>308</strong> Permanent Redirect; <code>GET /mcp/sse</code> and <code>GET /sse</code> &rarr; <strong>410 Gone</strong> with actionable JSON; eliminates ~531&ndash;556 daily 404s</li>
+  <li>574 tests pass, 61.99% coverage, CodeQL clean</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/163" target="_blank" rel="noopener">PR #163</a> &middot; <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/164" target="_blank" rel="noopener">PR #164</a></li>
+</ul>
+</div>
+
+<div id="v0.5.18">
+<h2>v0.5.18 — Scholar Dashboard: Trinity History</h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 21, 2026</p>
+<ul>
+  <li><strong><code>GET /early-adopters/dashboard/{uuid}</code></strong> — personal Trinity validation history page; last 50 results from Firestore (<code>trinity_history/{uuid}/validations/</code>); shows score, tool, recommendation excerpt, veto flag, timestamp per row; empty state + unavailable fallback</li>
+  <li>472 tests pass, 59.74% coverage</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/162" target="_blank" rel="noopener">PR #162</a></li>
+</ul>
+</div>
+
+<div id="v0.5.17">
+<h2>v0.5.17 — mcp_config UUID Header Fix</h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 21, 2026</p>
+<ul>
+  <li><strong>UUID auto-flows on every MCP request</strong> — <code>mcp_config</code> args now include <code>--header X-VerifiMind-UUID:${VERIFIMIND_UUID}</code>; <code>mcp-remote</code> expands from env and sends with every request; no manual <code>user_uuid</code> per tool call needed</li>
+  <li><strong>MCP Registry updated to v2.5.0</strong> — <a href="https://registry.modelcontextprotocol.io/?q=verifimind" target="_blank" rel="noopener">registry.modelcontextprotocol.io</a></li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/160" target="_blank" rel="noopener">PR #160</a> &middot; <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/161" target="_blank" rel="noopener">PR #161</a></li>
+</ul>
+</div>
+
+<div id="v0.5.16">
+<h2>v0.5.16 — Trinity History Persistence + Terms Hotfix</h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 21, 2026</p>
+<ul>
+  <li><strong>Trinity history persistence (P1-B)</strong> — <code>write_trinity_history(uuid, tool, result)</code> fire-and-forget async Firestore write; stores score, recommendation excerpt, veto flag, timestamp; wired into all 4 core tools when <code>user_uuid</code> provided; zero latency impact</li>
+  <li><strong>/terms page hotfix</strong> — Anonymous tier row added, Identity + Rate Limit columns explicit, Privacy Policy v2.1 link, "Updated: April 21, 2026"</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/158" target="_blank" rel="noopener">PR #158</a> &middot; <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/159" target="_blank" rel="noopener">PR #159</a></li>
+</ul>
+</div>
+
 <div id="v0.5.15">
-<h2>v0.5.15 — Scholar Incentives: UUID Tracer + Registration UX <span class="live-badge">LIVE</span></h2>
+<h2>v0.5.15 — Scholar Incentives: UUID Tracer + Registration UX</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 20, 2026</p>
 <ul>
   <li><strong>UUID Tracer on all 10 Scholar tools</strong> — optional <code>user_uuid</code> parameter; fire-and-forget <code>TRACER_UUID:</code> stdout log feeds AY GCP analytics pipeline; invalid UUIDs silently ignored (log injection prevention)</li>


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: add v0.5.16 (Trinity history + terms hotfix), v0.5.17 (UUID header auto-flow + MCP Registry v2.5.0), v0.5.18 (Scholar dashboard), v0.5.19 (UUID tier-aware rate limiter + 404 churn fixes)
- **README.md**: badge v0.5.15 → v0.5.19; stats block updated to current; Scholar UUID config updated with `--header X-VerifiMind-UUID:${VERIFIMIND_UUID}` (v0.5.17 change); Common Mistakes `/mcp` entry updated from `405` to `308 Permanent Redirect`
- **pages.py**: `_CHANGELOG_BODY` updated with v0.5.16–v0.5.19 live entries; last-updated → April 21, 2026

## Test plan
- [ ] Verify https://verifimind.ysenseai.org/changelog shows v0.5.16–v0.5.19 entries after deploy
- [ ] README badge shows v0.5.19
- [ ] Scholar UUID config block shows `--header` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)