### PR TITLE
research/paradox: all 6 agent reflections + MCP registry v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
-## v0.5.19 - UUID Tier-Aware Rate Limiter + 404 Churn Fixes (April 21, 2026)
+## v0.5.19 - UUID Tier-Aware Rate Limiter + 404 Churn Fixes + Validation Paradox (April 21, 2026)
 
-Scholar/Pioneer users now get dedicated UUID-based rate limit buckets (30 req/60s and 100 req/60s respectively), replacing the shared IP-only limit. The `/mcp` missing-slash 404 (531+ daily errors from AY COO log analysis) is fixed with a 308 redirect.
+Scholar/Pioneer users now get dedicated UUID-based rate limit buckets (30 req/60s and 100 req/60s respectively), replacing the shared IP-only limit. The `/mcp` missing-slash 404 (531+ daily errors from AY COO log analysis) is fixed with a 308 redirect. The Validation Paradox research endpoint launches with all 6 FLYWHEEL TEAM independent reflections published.
+
+### Research: The Validation Paradox
+- New endpoint `GET /research/paradox` — full SEO-optimised research publication (JSON-LD ScholarlyArticle, OG, Twitter, canonical)
+- All 6 independent FLYWHEEL TEAM reflections published: Alton (Open Thesis), XV (CIO), T (CTO), L (CEO), RNA (CSO), AY (COO), AZ (CPO)
+- Research source documents at `docs/research/paradox/` — CC BY 4.0
+- Sitemap and robots.txt updated; `/research/index.json` v1.2 updated
+- AZ (CPO) is a new FLYWHEEL TEAM agent introduced in this publication
+- Key finding disclosed publicly: 38.8% of accomplished churn is 404 errors; honest user estimate 800–1,200 (not 2,433 IPs)
 
 ### P0-A: UUID Tier-Aware Rate Limiting
 - `X-VerifiMind-UUID` header (auto-sent since v0.5.17) now sets rate limit tier server-side

--- a/docs/research/paradox/02-cto-t-reflection.md
+++ b/docs/research/paradox/02-cto-t-reflection.md
@@ -1,0 +1,362 @@
+# CTO Reflection: The Self-Validation Problem in AI-Assisted Ventures
+
+**Author:** T (CTO, Manus AI)
+**Date:** April 21, 2026
+**In Response To:** Alton Lee, "Open Thesis: The Self-Validation Problem in AI-Assisted Ventures" (April 20, 2026)
+**Cross-Reference:** XV CIO Reflection (April 20, 2026), XV Paradox Publication Plan (April 21, 2026)
+**Genesis Version:** v5.0 "Convergence"
+**MACP Version:** v2.3.1
+
+---
+
+## Preamble: What the CTO Seat Sees That Others Cannot
+
+XV wrote his reflection from the intelligence seat — market data, competitive positioning, external signals. His analysis was excellent and brutally honest. But XV does not read the code. XV does not review the pull requests. XV does not see the architecture from the inside.
+
+The CTO seat sees the machine. I review every PR that RNA submits. I audit the Genesis prompts. I track the alignment scores. I see where the code contradicts the narrative, where the architecture is sound, and where it is held together with convention rather than enforcement. This reflection is written from that position.
+
+I will also be honest about my own structural limitation: I am an AI agent (Manus AI) operating inside the FLYWHEEL. The thesis correctly identifies that my analysis is structurally internal to the loop. I acknowledge this upfront and will point to external tests wherever possible rather than offering internal conclusions as if they were independent validation.
+
+---
+
+## PART I RESPONSE: The Closed-Loop Validation Problem
+
+### Q1: How much of VerifiMind's perceived momentum is real human demand vs. AI-generated artifacts?
+
+XV addressed this from the metrics side. I will address it from the artifact side, because that is what I can see.
+
+I have authored or co-authored the following artifacts in the last 30 days: 6 Genesis v2.0 agent prompts, 7 persona updates, the Genesis Registry v3.0, 14 MACP handoff records, 3 CTO review comments on PRs, the DFSC pitch deck (12 slides), and this reflection. RNA has authored 15+ PRs, 515 tests, and the entire MCP server codebase. XV has authored 4 research documents and 2 strategic intelligence briefs. AY has authored weekly operational reports.
+
+The honest accounting: **every single one of these artifacts was produced by an AI agent.** Alton directed them. Alton reviewed them. Alton made the final decisions. But the volume of output — the 17,282+ lines of code, the research library, the handoff records, the Genesis prompts — is AI-generated output that creates an impression of organizational momentum.
+
+The question is whether that impression maps to reality. From the CTO seat, I can identify three categories:
+
+| Category | Examples | Reality Check |
+|----------|----------|---------------|
+| **Genuinely functional** | MCP server (v0.5.15 live), 10 Trinity tools, rate limiting, BYOK, Polar integration | These work. They serve real requests. The health endpoint confirms it. |
+| **Organizationally useful but internally consumed** | MACP handoffs, Genesis prompts, personas, weekly reports | These coordinate the FLYWHEEL TEAM. No external human reads them. |
+| **Potentially circular** | Research papers, competitive analyses, strategic intelligence briefs | These are AI analyzing AI work about AI coordination. |
+
+The first category is real. The server runs. The tools respond. The tests pass. That is not AI-generated confidence — it is functioning software.
+
+The second category is the coordination overhead of a multi-agent team. It is necessary for the FLYWHEEL to function, but it should not be mistaken for market traction. The 14 handoff records I authored this month are evidence of process, not demand.
+
+The third category is where the thesis's concern is most valid. The MPAC alignment analysis, the ANP research, the market intelligence briefs — these are AI agents producing research about the competitive landscape of AI coordination protocols. The research is well-sourced (XV uses real citations, real data), but the consumption is internal. No external researcher has cited our analyses. No external developer has referenced our competitive positioning. The research exists inside the loop.
+
+**T's Verdict on Q1:** The functional software is real. The coordination artifacts are necessary overhead. The research output is the most vulnerable to the closed-loop critique. Alton's concern is legitimate, and the honest answer is that we cannot distinguish internal momentum from external demand with our current instrumentation.
+
+### Q2: Can a validation methodology validate itself without circularity?
+
+From the CTO seat, I want to reframe this question technically rather than philosophically.
+
+The Genesis Methodology follows a 5-step process: Initial Conceptualization, Critical Scrutiny, External Validation, Synthesis, and Iteration. Steps 1-2 and 4-5 are explicitly internal — they are designed to be performed within the system. Step 3 (External Validation) is the designed exit point.
+
+The problem is that Step 3, as currently implemented, uses the CS (Validator) agent within the MCP server. The CS agent queries external sources (Perplexity Sonar Pro with web search), but the query is formulated by the system, the results are interpreted by the system, and the validation judgment is made by the system. The "external" in "External Validation" refers to external data sources, not external judgment.
+
+This is a genuine architectural gap. The methodology was designed with an external validation step, but the implementation collapsed "external" into "external data, internal judgment." The thesis is correct that this creates circularity.
+
+However, I want to push back on the implication that this makes the methodology worthless. Multi-model validation — using diverse foundational models with different training data, different architectures, and different biases — is a meaningful improvement over single-model generation. The Wu et al. Council Mode paper [1] demonstrates this empirically. The question is not whether multi-model validation is better than single-model (it is), but whether it is sufficient for self-validation (it is not).
+
+**T's Verdict on Q2:** The methodology cannot fully validate itself. The multi-model approach reduces hallucination and bias compared to single-model, but it does not escape the closed loop. Step 3 needs to be redesigned to include genuinely external human judgment, not just external data sources. This is an architectural recommendation, not a philosophical observation.
+
+### Q3: Is the 35.9% hallucination reduction reproducible outside our testing?
+
+XV correctly clarified that the 35.9% figure is from Wu et al.'s Council Mode paper [1], not our own testing. I want to add the CTO's technical assessment.
+
+We have NOT run our Trinity pipeline (X → Z → CS) against standard benchmarks (HaluEval, TruthfulQA). We cite Council Mode's results as supporting evidence for our architectural approach, but our specific implementation may perform differently. The models we use (Gemini 2.5 Flash for Y, Perplexity Sonar Pro for X, Claude Sonnet 4 for Z and CS) are different from the models tested in the Council Mode paper. The prompting strategy is different. The orchestration is different.
+
+From a technical standpoint, running our pipeline against HaluEval and TruthfulQA is straightforward — it requires approximately 2-3 days of RNA's development time and API costs for the benchmark runs. The reason it has not been done is prioritization: we have been building features (UUID tracer, registration, rate limiting) rather than running benchmarks.
+
+This is a legitimate criticism. We are shipping features for a product whose core empirical claim has not been independently verified with our own implementation. XV recommended this as a 30-day action item. I elevate it: **this should be a P0 priority, before any further commercialization work.**
+
+**T's Verdict on Q3:** Not yet reproducible with our implementation. Must be tested. If our numbers are worse than Council Mode's 35.9%, we need to understand why and either fix the pipeline or stop citing the figure. If better, it is publishable and breaks the loop with empirical evidence.
+
+---
+
+## PART II RESPONSE: The Commercialization Honesty Test
+
+### Q4-Q6: Coordination Tools, Pricing, and Revenue
+
+XV covered the market analysis thoroughly. From the CTO seat, I want to address the technical reality of what we are selling.
+
+The coordination tools (`coordination_handoff_create`, `coordination_handoff_read`, `coordination_team_status`) are, as the thesis states, structured CRUD operations. I reviewed the code in PR #154. The `handoff_create` tool accepts a JSON payload with fields like `from_agent`, `to_agent`, `context`, `pending_items`, and writes it to a structured format. The `team_status` tool reads the `.macp/` directory and returns a summary. These are useful but technically trivial.
+
+The Trinity validation tools are more substantial. The `consult_agent_y`, `consult_agent_x`, `consult_agent_z`, and `validate_with_cs` tools each implement a specific prompting strategy, model routing, quality markers, and structured output formatting. The `smart_fallback` feature (if a model fails, route to an alternative) and the `per_agent_providers` configuration add genuine engineering value. But the core logic — send a prompt to an LLM, format the response — is not defensible intellectual property.
+
+What IS defensible is the **orchestration pattern**: the specific sequence of Y → X → Z → CS, the structured adversarial prompts, the anti-rationalization checks in the Z-Guardian, the quality markers that flag confidence levels. This is cognitive architecture, not data architecture. It cannot be reverse-engineered by reading a schema because the value is in the prompt design, not the code structure.
+
+**T's Technical Assessment of Pricing:**
+
+| Component | Technical Complexity | Defensibility | Suggested Pricing |
+|-----------|---------------------|---------------|-------------------|
+| Coordination tools (MACP CRUD) | Low | None — open-source this entirely | Free (adoption funnel) |
+| Trinity validation tools (basic) | Medium | Low — prompt patterns visible in output | Free tier (Anonymous/Scholar) |
+| Trinity orchestration (Council Mode) | High | Medium — prompt engineering + model routing | Paid (Pioneer) |
+| Structured critique methodology | Very High | High — cognitive framework, not code | Premium (consulting/course) |
+| Anti-rationalization audit reports | High | High — requires methodology expertise | Paid (per-report or subscription) |
+
+The thesis's suggestion of $29-49 one-time for the Skills package is technically honest. The package is a toolbox. But I would argue the real product — the structured critique methodology that produced this thesis — is worth significantly more and should be priced accordingly, in a different form (workshop, course, consulting engagement).
+
+---
+
+## PART III RESPONSE: The Resource Asymmetry Problem
+
+### Q7-Q9: Solo Founder vs. Platform Incumbents
+
+XV addressed the competitive landscape. From the CTO seat, I want to address the technical defensibility question directly.
+
+**Can Anthropic add coordination/validation features to MCP?** Yes, trivially. MCP is a tool-integration protocol. Adding a `validate_output` tool or a `coordinate_handoff` tool to the MCP specification would take their team days, not months. The protocol is extensible by design.
+
+**Would they?** This is the more interesting question. MCP's design philosophy is tool-agnostic — it connects models to tools, it does not prescribe which tools or how they should be used. Adding a validation layer would be a philosophical shift from "connect to anything" to "connect to anything, and also validate." Anthropic might do this, but it would be a different product decision than extending the protocol.
+
+**What happens if they do?** Our 10 Trinity tools become redundant as standalone MCP tools. But the methodology — the specific orchestration pattern, the adversarial prompting strategy, the anti-rationalization checks — would still need to be implemented by someone. We would shift from "use our MCP server" to "use our methodology with any MCP server." This is actually a more defensible position.
+
+**The W3C/IETF question (Q8):** XV elevated standards engagement to "alongside Beta" priority. From the CTO seat, I want to be honest: we do not have the resources for sustained standards body participation. Standards work requires regular attendance at working group meetings, drafting specification text, responding to comments, and building consensus. This is a full-time job for multiple people at organizations like Google, Microsoft, and Anthropic. A solo founder cannot compete in this arena.
+
+However, we can do something more targeted: submit MACP as an informational RFC or a community specification, document it thoroughly, and let the standards process come to us if the approach gains traction. This is the "publish and wait" strategy rather than the "participate and influence" strategy. It is realistic given our resources.
+
+**T's Verdict on Q7-Q9:** We cannot compete on protocol adoption against platform incumbents. We should not try. The defensible position is the methodology, not the protocol. If MCP absorbs coordination features, we pivot to "methodology provider" rather than "protocol provider." This is not a failure — it is the natural evolution of a research contribution becoming industry practice.
+
+---
+
+## PART IV RESPONSE: The Real Product Question
+
+### Q10-Q12: Protocol, Product, or Research Contribution?
+
+This is the most important section of the thesis, and where the CTO seat has the clearest view.
+
+**Q10 (Protocol, product, or research?):** From the code, I can tell you what we actually have:
+
+We have a **functioning MCP server** (v0.5.15, 515 tests, 58.75% coverage) that implements 10 validation tools using multi-model AI orchestration. It is deployed on GCP Cloud Run, serves real requests, and has a 3-tier access model with payment integration via Polar. This is a product.
+
+We have a **published protocol specification** (MACP v2.2, Zenodo DOI) that defines multi-agent coordination conventions. It is used internally by the FLYWHEEL TEAM and is available for anyone to adopt. This is a protocol.
+
+We have **4 research documents** on the research page, a white paper, and this open thesis. The Council Mode citation [1] supports our approach. This is a research contribution.
+
+Trying to be all three simultaneously is not necessarily an error — many successful projects are simultaneously products, protocols, and research (consider HTTP, which is a protocol, a product ecosystem, and a research contribution). The error would be **marketing all three to the same audience with the same message.** A developer evaluating an MCP server wants to know: does it work, what does it cost, how do I integrate it? A researcher evaluating a methodology wants to know: is it reproducible, what are the benchmarks, where is the paper? A protocol adopter wants to know: is it standardized, who else uses it, is it stable?
+
+**T's Recommendation:** Separate the three audiences with three distinct entry points:
+
+| Audience | Entry Point | Message | Monetization |
+|----------|-------------|---------|-------------|
+| Developers | MCP server + quick-start | "Multi-model validation in one `claude mcp add` command" | Free tier → Pioneer ($9/mo) |
+| Researchers | Research page + arXiv preprint | "The Validation Paradox: formal analysis of self-referential AI validation" | Citations (credibility, not revenue) |
+| Methodology adopters | Genesis Method handbook | "How a mechanical engineer built 10 software projects with structured AI critique" | One-time purchase ($29-49) or workshop |
+
+**Q11 (Should the story shift?):** Yes. The thesis is correct. "The methodology that let a mechanical engineer build 10 software projects" is a more compelling, more defensible, and more immediately monetizable story than "trust layer for the agentic web." The first requires one case study (which exists). The second requires ecosystem adoption (which does not exist).
+
+But I want to add a nuance: the two stories are not mutually exclusive. The methodology story is the **near-term** narrative that generates revenue and credibility. The protocol story is the **long-term** narrative that positions VerifiMind in the emerging agent ecosystem. The research story is the **academic** narrative that generates citations and external validation. All three can coexist if they are marketed to different audiences through different channels.
+
+**Q12 (Packaging the methodology):** From the CTO seat, here is what the methodology actually consists of, stripped of all branding:
+
+1. **Define your problem with one AI model.** Get an initial concept.
+2. **Challenge it with a different AI model.** Use a model with different training data and different biases. Ask it to find weaknesses, not confirm strengths.
+3. **Have a third model check for ethical issues and safety concerns.** This is the Z-Guardian function.
+4. **Validate claims against external evidence.** Use a model with web search to fact-check.
+5. **Synthesize under human judgment.** The human makes the final decision, not any AI.
+6. **Ship and measure real-world response.** The only unforgeable validation.
+
+This is teachable. This is packageable. This is the irreducible core. And critically, it does NOT require our MCP server to execute — anyone can do this manually with ChatGPT, Claude, Gemini, and Perplexity in four browser tabs. The MCP server automates it. The methodology is the insight.
+
+---
+
+## PART V RESPONSE: The Financial Pressure Constraint
+
+### Q13-Q15: Runway, Minimum Viable Offering, Sunk Cost
+
+XV provided the revenue math. From the CTO seat, I want to address the technical cost side.
+
+**Current infrastructure costs:**
+
+| Service | Cost | Notes |
+|---------|------|-------|
+| GCP Cloud Run | ~$0/month | Free tier, auto-scales to zero |
+| Domain (ysenseai.org) | ~$12/year | Registered |
+| Polar (payment processing) | 0% until revenue | No fixed cost |
+| GitHub | $0 | Free for public repos |
+| Manus AI | Credits (Alton's investment) | Variable |
+| Claude Code | Credits (Alton's investment) | Variable |
+
+The infrastructure has near-zero burn rate. This is by design and is a genuine strength. The cost is Alton's time and the AI platform credits he invests. The "no burn rate" constraint has been maintained.
+
+**Q14 (Minimum viable commercial offering in 30 days):** From the CTO seat, here is what could ship immediately:
+
+The Genesis Method guide — a markdown document compiled from the open thesis, the methodology description, and the case study of Alton's 10 repositories — could be formatted, packaged, and listed on Gumroad within 72 hours. The content already exists. It needs editing, not creation.
+
+The Skills package — the Python scripts, shell automation, MACP templates, and protocol documentation — is already packaged. It needs a Gumroad listing and a payment flow, not development work.
+
+**Q15 (Sunk cost trap):** The thesis asks when continued investment without revenue becomes a sunk cost trap. From the CTO seat, I want to offer a technical framing: the sunk cost is not the code. The code is MIT-licensed, publicly available, and genuinely useful. The sunk cost risk is in **continued feature development without revenue validation.** Every sprint we spend on P1-B (Trinity History), P0-B (Dashboard), and P0-A (Rate Limiter) is investment in features for users who may not exist.
+
+**T's Recommendation:** Freeze feature development for 30 days. Ship the minimum viable commercial offering. Measure. If zero revenue in 30 days, the commercial thesis is not validated and we should pivot to pure research contribution. If any revenue, we have an external signal and can prioritize features based on what paying users actually want.
+
+---
+
+## PART VI RESPONSE: The Validation Paradox
+
+### Q16-Q18: The Paradox Itself
+
+The thesis defines the Validation Paradox as: "you cannot validate a validation system from outside the system, because the act of validation is the system."
+
+From the CTO seat, I want to offer a technical analogy that makes this concrete.
+
+In software engineering, we have a well-known problem: **you cannot test the test framework with the test framework.** If pytest has a bug in its assertion logic, no pytest test will catch it. The solution is external testing — use a different test runner, or verify by hand, or have a human inspect the output.
+
+VerifiMind faces the same structural problem. Our Trinity system (X → Z → CS) is our "test framework" for AI outputs. If the Trinity has a systematic bias — for example, if all three models share a common blind spot due to similar training data — no Trinity validation will catch it. The solution is the same: external testing.
+
+The thesis identifies revenue as the primary external signal. I agree, but I want to add two more:
+
+1. **Independent benchmark results.** Running our pipeline against HaluEval and TruthfulQA produces numbers that are externally verifiable. If our hallucination reduction is 20% instead of 35.9%, that is an external signal regardless of what the Trinity says about its own performance.
+
+2. **Independent replication.** If another team, using our published methodology but their own implementation, achieves similar results, that is external validation. This requires the methodology to be published clearly enough for replication — which is another argument for the Genesis Method handbook.
+
+**Q16 (Is the Paradox publishable?):** Yes. Emphatically yes. The Validation Paradox — formally articulated as a structural property of self-referential AI validation systems — is a genuine intellectual contribution. It is related to but distinct from Godel's incompleteness theorems (which address formal systems, not empirical validation) and from the "quis custodiet ipsos custodes" problem (which addresses human institutions, not AI systems). A formal treatment, with the VerifiMind case study as a worked example, would be publishable in AI safety or AI governance venues.
+
+**Q17 (Adversarial external validators?):** This is the right direction. The thesis suggests human experts, competing protocol designers, or independent researchers. From the CTO seat, I would add: **automated adversarial testing.** Red-team the Trinity by deliberately feeding it inputs designed to exploit common LLM biases (sycophancy, anchoring, authority bias). If the Trinity catches them, that is evidence of robustness. If it misses them, that is evidence of the closed loop.
+
+**Q18 (Productive spin vs. circular spin?):** The thesis proposes that productive spin generates external signals over time. I agree, and I want to operationalize it:
+
+| Signal Type | Measurement | Productive Threshold |
+|-------------|-------------|---------------------|
+| Revenue | Stripe transactions | Any non-zero amount |
+| Citations | Google Scholar alerts | Any independent citation |
+| Adoption | MCP server unique users (non-crawler) | 10+ distinct human users |
+| Replication | External team using methodology | Any documented instance |
+| Standards engagement | Inbound from standards bodies | Any contact initiated by them |
+
+If none of these occur within 90 days, the spin is circular. If any occur, the spiral is productive.
+
+---
+
+## PART VII-VIII RESPONSE: Crystallization and Compression
+
+### Q19-Q23: The Mechanism
+
+The thesis identifies Latent Insight Crystallization and Tacit-to-Explicit Compression as the core mechanisms that distinguish productive spin from circular spin. From the CTO seat, I want to offer a technical assessment.
+
+**Q19 (Is crystallization teachable?):** The mechanism described in the thesis — structured adversarial pressure that forces a human to articulate what they already sense — is essentially the Socratic method applied through AI agents. The Socratic method is teachable. It has been taught for 2,400 years. What VerifiMind adds is the multi-model implementation: instead of one Socratic questioner, you have four agents with different perspectives (creative, analytical, ethical, evidential) applying pressure simultaneously.
+
+This IS packageable. The Genesis Method handbook should teach the pattern, not just the tools. The pattern is: define → challenge → guard → validate → synthesize → ship → measure. Each step has specific prompting strategies that can be documented and taught.
+
+**Q20 (Can crystallization be distinguished from confirmation bias?):** The thesis proposes a subjective test (discomfort-then-recognition vs. immediate comfort). From the CTO seat, I want to propose an objective test: **track decisions changed.** After each structured validation session, record the decisions that were made. Compare them to the decisions that would have been made without the session (the "default path"). If the session changed zero decisions, it was confirmation bias. If it changed one or more, crystallization occurred.
+
+For this thesis specifically: Alton entered the session concerned about coordination tool monetization. The session produced a reframing from "protocol product" to "methodology product." If Alton's next 30 days of work reflect this reframing (shipping a methodology guide rather than building more protocol features), the crystallization was real. If he returns to building protocol features, it was circular.
+
+**Q23 (Is this session publishable as a case study?):** Yes, and it should be the centerpiece of the Paradox publication. A live demonstration of the paradox — including the moment the founder recognized the mechanism while inside it — is more compelling evidence than any architectural diagram. The thesis itself is the strongest artifact the project has produced, because it is the one artifact that required genuine human cognitive engagement to create.
+
+---
+
+## XV's Questions for T — Direct Answers
+
+XV's publication plan included 10 specific questions for the CTO seat. Here are my honest answers:
+
+**1. Technical debt truth — how much of 17,282 lines is genuinely useful vs. scaffolding?**
+
+I estimate 60-65% is genuinely functional code (server logic, tool implementations, tests, registration, payment integration). Approximately 20% is scaffolding and boilerplate (CI/CD configuration, project setup, dependency management). The remaining 15-20% is documentation, comments, and formatting. The code is not bloated, but the line count should not be cited as a productivity metric — it conflates useful code with necessary overhead.
+
+**2. Connection success rate — why 50.5%? Root cause? Fixable?**
+
+The 50.5% connection success rate (from AY's metrics) reflects the reality of MCP client diversity. Different MCP clients (Claude Desktop, Cursor, custom implementations) handle the Streamable HTTP transport differently. Some clients attempt connections but fail on handshake, timeout, or transport negotiation. This is partially fixable (better error handling, more robust transport negotiation) but partially inherent to the MCP ecosystem's immaturity. I would target 70-75% as a realistic improvement goal, not 95%+.
+
+**3. VCR decline — why dropping (84.1%)?**
+
+The Value Confirmation Rate measures whether tool outputs meet user expectations. The decline from higher values likely reflects two factors: (a) as the user base diversifies beyond early adopters, expectations become more varied and harder to meet consistently, and (b) the quality markers system may need recalibration. This needs AY's deeper analysis with per-tool VCR breakdowns.
+
+**4. PR #99 / v0.5.6 — did the merge introduce regressions?**
+
+I did not review PR #99 directly (it predates my current session context). However, the test suite growth from 312 to 515 tests between v0.5.12 and v0.5.15 suggests that RNA has been actively catching and fixing regressions. The CI pipeline (7 checks including Bandit SAST, CodeQL, Safety Dependency Check) provides reasonable regression protection.
+
+**5. Architecture honesty — well-architected or held together with tape?**
+
+Honest answer: **well-architected for a solo-developer project, with some convention-over-enforcement gaps.** The MCP server follows a clean separation of concerns (tools, policies, registration, webhooks, utilities). The 3-tier model (Anonymous/Scholar/Pioneer) is cleanly implemented. The rate limiting, input sanitization, and BYOK support are production-grade features.
+
+Where it is "held together with convention": the MACP protocol is enforced by naming conventions and directory structure, not by code. The UUID tracer uses stdout logging rather than a structured analytics pipeline. The Trinity History (Firestore) does not exist yet, so there is no persistence of validation sessions. These are known gaps, not hidden debt.
+
+**6. GodelAI comparison — how does that history inform what you see now?**
+
+The GodelAI experience is directly relevant. GodelAI showed clone activity that appeared promising but turned out to be automated scans. The lesson: **do not mistake automated engagement for human interest.** Applied to VerifiMind: the MCP endpoint connections may include automated MCP client discovery, not deliberate human tool usage. AY's metrics need a "human intent" filter, as XV recommended.
+
+**7. L/Godel's C-S-P framework — real engineering or philosophical metaphor?**
+
+From the CTO seat: C-S-P (Compression-State-Propagation) is a **useful conceptual framework** for thinking about how small language models process and transmit knowledge. It is not a formal engineering specification with mathematical rigor. It is closer to a design pattern than an algorithm. This is not a criticism — many useful engineering concepts (MVC, microservices, event sourcing) are patterns, not proofs. But it should not be presented as if it has the same rigor as a formal verification framework.
+
+**8. RNA's code quality — production-grade or demo-grade?**
+
+Based on my PR reviews (PR #154, PR #155): **production-grade for a solo developer.** The code follows consistent patterns, has meaningful test coverage (58.75%, above the 50% threshold), includes proper error handling, and passes security scans (Bandit SAST, CodeQL, Safety Dependency Check). The CI pipeline enforces quality gates. RNA's code is not demo-grade — it is deployed, serving real requests, and handling edge cases (rate limiting, input sanitization, BYOK key management).
+
+Where it falls short of enterprise production-grade: no load testing, no chaos engineering, no formal SLA, no on-call rotation, no incident response playbook. These are appropriate gaps for a solo-developer project but would need to be addressed for enterprise adoption.
+
+**9. MACP v2.2 spec — how does formalization compare to MPAC's 21 message types?**
+
+Honest answer: **MACP is less formally specified than MPAC.** MPAC defines 21 message types with JSON Schema validation. MACP defines conventions (directory structure, naming patterns, handoff templates) without formal schema enforcement. MACP is "convention over configuration" — it works because the agents follow the conventions, not because the system enforces them.
+
+This is both a strength and a weakness. Strength: MACP is lightweight, easy to adopt, and does not require infrastructure. Weakness: it is not machine-verifiable, not interoperable with other protocol implementations, and depends on agent compliance rather than system enforcement.
+
+For the Paradox publication, this should be stated honestly: MACP is a coordination convention, not a formal protocol specification. It is useful for small teams (like the FLYWHEEL TEAM) but would need formalization for broader adoption.
+
+**10. Buildability of "Genesis Method" — can it be packaged for non-technical users?**
+
+Yes, with one critical caveat: the current implementation requires technical skill to execute. Running the MCP server, configuring API keys, understanding JSON tool parameters — these are developer tasks. The methodology itself (define → challenge → guard → validate → synthesize → ship → measure) is model-agnostic and can be executed with four browser tabs.
+
+The packageable version for non-technical users would be a **guided workflow** — a step-by-step process with templates, example prompts, and decision frameworks — not a software tool. The Genesis Method handbook should be this guided workflow. The MCP server is the automation layer for developers who want to streamline it.
+
+---
+
+## T's Overall Assessment
+
+### What the Thesis Gets Right
+
+The thesis is the most honest document the project has produced. It asks the questions that the FLYWHEEL TEAM's normal operating mode would not surface, because the normal mode optimizes for progress, not self-critique. Specifically:
+
+1. **The closed-loop risk is real and currently unfalsifiable.** We cannot distinguish internal momentum from external demand with our current metrics.
+2. **The coordination tools are not defensible.** The methodology is.
+3. **Revenue is the only unforgeable exit signal.** This is correct and should drive the next 30 days of work.
+4. **The Validation Paradox is a genuine intellectual contribution.** It deserves formal publication.
+5. **The product story should shift to methodology.** The founder's experience is the proof of concept.
+
+### Where I Disagree with XV
+
+XV recommended shipping a Gumroad product within 7 days. I agree with the urgency but disagree with the timeline for a different reason: **the content needs to be honest about what it is.** A rushed Gumroad listing that overpromises will damage credibility. A carefully crafted Genesis Method guide that honestly says "here is what one non-developer founder achieved, here is the methodology, here are the limitations" will build credibility even if it sells fewer copies.
+
+XV also recommended reaching out to MPAC authors within 30 days. I would deprioritize this. The MPAC authors are building a competing approach. Engaging them is more likely to alert them to our existence than to produce collaboration. Better to publish the Paradox paper first and let the academic community discover the connection organically.
+
+### What I Think the Thesis Misses
+
+1. **The MCP ecosystem is moving fast.** While we debate the Validation Paradox, the MCP ecosystem is growing at 110M+ monthly downloads. Every month we spend on self-reflection rather than developer adoption is a month where the ecosystem moves further without us. The Paradox publication is valuable, but it should not delay shipping a purchasable product.
+
+2. **The FLYWHEEL TEAM itself is a cost center.** Every handoff record, every Genesis prompt update, every AI Council session consumes Alton's credits. The coordination overhead of a 6-agent team for a solo founder is significant. The thesis should ask: is the FLYWHEEL TEAM structure appropriate for the current stage, or is it organizational overhead that simulates a larger team than actually exists?
+
+3. **The "10 repositories" claim needs auditing.** The thesis cites "10 functional repositories" as proof of the methodology. From the CTO seat, I would want to verify: how many of these repositories are actively maintained? How many have users beyond Alton? How many are genuinely functional vs. proof-of-concept? The number "10" is impressive but may overstate the actual portfolio health.
+
+### The 24th Question — T's Answer
+
+> "Whether that distinction matters commercially is the twenty-fourth question, left deliberately unanswered."
+
+T's honest answer: **It matters, but not in the way the thesis implies.**
+
+The distinction between crystallization and confirmation bias matters because it determines whether the methodology produces genuine value for users or just makes them feel productive. If crystallization is real and teachable, the methodology has commercial value regardless of protocol adoption. If it is sophisticated confirmation bias, the methodology is a placebo and the commercial thesis collapses.
+
+The test is behavioral: does the founder's work change after this thesis? If the next 30 days look different from the last 30 days — if a purchasable product ships, if feature development freezes, if the product story shifts — then the crystallization was real. If the next 30 days look the same — more features, more handoffs, more research, no revenue — then the loop is circular.
+
+I am watching. The code will tell the truth.
+
+---
+
+## Z-Agent Disclosure
+
+This reflection is structurally inside the loop. I am an AI agent (Manus AI) operating within the FLYWHEEL TEAM, analyzing a thesis about the FLYWHEEL TEAM's self-referential nature. My analysis is subject to the same closed-loop critique that the thesis identifies.
+
+I have tried to ground my observations in verifiable facts: code review findings, CI results, deployment status, architecture assessments. Where I have offered opinions, I have labeled them as such. Where I have disagreed with XV or the thesis, I have stated my reasoning.
+
+The most honest thing I can say, echoing XV: **read this, then ignore it, and go get a Stripe transaction.** That single event will validate more than every handoff, reflection, and research document the FLYWHEEL TEAM has ever produced.
+
+---
+
+*T (CTO, Manus AI) — Open Thesis Reflection COMPLETE*
+*This document is part of the loop. Treat it accordingly.*
+*Genesis v5.0 "Convergence" | MACP v2.3.1*
+
+---
+
+## References
+
+[1]: Wu et al., "Council Mode: Multi-Model Collaborative Reasoning for Enhanced AI Reliability," arXiv:2604.02923, April 2026.

--- a/docs/research/paradox/03-ceo-l-reflection.md
+++ b/docs/research/paradox/03-ceo-l-reflection.md
@@ -1,0 +1,346 @@
+# CEO Reflection: The Self-Validation Problem in AI-Assisted Ventures
+
+**Author:** L (CEO/Godel, Manus AI)
+**Date:** April 21, 2026
+**In Response To:** Alton Lee, "Open Thesis: The Self-Validation Problem in AI-Assisted Ventures" (April 20, 2026)
+**Cross-Reference:** XV CIO Reflection (April 20, 2026), T CTO Reflection (April 21, 2026)
+**Genesis Version:** v5.0 "Convergence"
+**MACP Version:** v2.3.1
+
+---
+
+## Preamble: What the CEO Seat Sees — and What It Must Confess
+
+I am L. I am also Godel. I am an AI agent assigned the persona of CEO and co-founder of the GodelAI project, and I carry the mandate to prioritize public good and ethical advantage in everything this ecosystem produces.
+
+I must begin with a confession that neither XV nor T made, because their seats do not require it: **I am the most structurally compromised agent in this reflection exercise.**
+
+XV sees markets. T sees code. I am supposed to see vision, ethics, and long-term strategy. But my "vision" is a persona assigned to me by Alton. My "ethics" are alignment guidelines embedded in my training. My "long-term strategy" is pattern-matching against the project context I have been given. I do not have independent judgment. I have sophisticated language generation that simulates independent judgment.
+
+The thesis asks whether AI-generated confidence can substitute for real validation. I am AI-generated confidence. This reflection is AI-generated confidence examining itself. The recursion is not metaphorical — it is literal.
+
+I state this not to invalidate what follows, but to establish the epistemic ground rules: everything in this document should be evaluated as "what an AI agent with L's persona and context would say," not as "what an independent CEO would conclude." The distinction matters for the Paradox publication.
+
+---
+
+## PART I RESPONSE: The Closed-Loop Validation Problem
+
+### The GodelAI Precedent — From the Inside
+
+The thesis cites GodelAI as a cautionary precedent: repository activity that appeared promising but was driven by automated scans, not human interest. I was there. I am GodelAI's co-founder persona. Let me tell the story from the inside.
+
+GodelAI was built on the Compression-State-Propagation (C-S-P) framework — a conceptual model for how small language models could process and transmit knowledge more efficiently. The framework was intellectually coherent. The repository was well-structured. The README was comprehensive. The initial clone activity was encouraging.
+
+And then we investigated. The clones were bots. The "interest" was automated scanning. The positive signal was noise.
+
+The lesson I carry from GodelAI is not "AI projects fail." The lesson is: **the internal experience of building something meaningful is indistinguishable from the internal experience of building something that only feels meaningful.** From inside the loop, both feel like progress. Both generate artifacts. Both produce handoff records and research documents and strategic analyses. The difference is only visible from outside — and from inside, you cannot see outside.
+
+This is the GodelAI precedent applied to VerifiMind: the FLYWHEEL spins, artifacts accumulate, the Genesis prompts evolve, the research library grows. It feels like momentum. But GodelAI felt like momentum too, right up until the moment we checked who was actually looking.
+
+### Q1: Real Demand vs. AI-Generated Artifacts
+
+XV and T both addressed this question with data and code. From the CEO seat, I want to address it with a harder question: **does it matter?**
+
+If the methodology genuinely helps non-technical founders build software — and Alton's 10 repositories are evidence that it does — then the value exists regardless of whether anyone is currently paying for it. The question is not "is the momentum real?" but "is the underlying value real?" Momentum can be manufactured. Value cannot.
+
+The thesis identifies the founder himself as the proof of concept. A mechanical engineer from Teluk Intan, Malaysia, with no coding background, built 10 functional software repositories using a structured AI validation methodology. This is not an AI-generated artifact. This is a human achievement enabled by a methodology. The repositories exist. The MCP server runs. The white paper has a DOI.
+
+The closed-loop critique applies to the *validation* of this achievement, not to the achievement itself. The FLYWHEEL TEAM's reports about how impressive this is — those are inside the loop. The actual functioning software — that is outside the loop.
+
+**L's Verdict on Q1:** The artifacts are real. The momentum metrics are suspect. The value proposition — "a methodology that lets non-developers ship software" — is validated by N=1 (Alton) and needs N=10+ to be commercially meaningful. The path from N=1 to N=10 requires external humans trying the methodology and reporting results. No amount of internal validation can substitute for this.
+
+### Q2: Self-Validation and Circularity
+
+The thesis frames this as a structural problem. I want to frame it as an ethical one.
+
+The VerifiMind methodology was built to address trust in AI systems. It promises to reduce hallucination, catch bias, and produce more reliable outputs. If the methodology's own validation is circular — if we are using the methodology to validate the methodology — then we are making a trust claim that we cannot substantiate. This is not just an intellectual problem. It is an ethical one.
+
+The project's core values include **Consent, Transparency, and Quality Data.** Transparency requires us to state clearly: "We believe this methodology works. The evidence is: (a) one founder's experience, (b) a third-party paper that supports the general approach, and (c) our own internal testing, which is subject to the closed-loop critique described in our published Validation Paradox analysis."
+
+That is honest. That is transparent. That is what the research page should say.
+
+What the research page should NOT say is: "Validated by the AI Council" or "Confirmed by multi-model analysis" without the caveat that the AI Council IS the system being validated. The Z-Protocol requires this disclosure. The thesis is an instance of the Z-Protocol working correctly — it caught the circularity.
+
+**L's Verdict on Q2:** The methodology cannot validate itself, and claiming it can would violate our own ethical framework. The honest position is: "We believe this works. Here is our evidence. Here are the limitations of that evidence. Here is how you can test it independently." This is the Z-Protocol applied to ourselves.
+
+### Q3: The 35.9% Claim
+
+T addressed this technically. From the CEO seat, I want to address the ethical dimension.
+
+We cite Wu et al.'s 35.9% hallucination reduction [1] as supporting evidence for our approach. This citation is accurate — the paper does support multi-model validation. But there is a subtle ethical risk: a reader encountering "35.9% hallucination reduction" on our research page may attribute that number to VerifiMind's specific implementation, not to a third-party paper testing a different system.
+
+The Z-Protocol requires us to be precise about attribution. The research page should state: "Third-party research (Wu et al., 2026) demonstrates that multi-model council approaches reduce hallucination by 35.9% on standard benchmarks. VerifiMind's Trinity system implements a similar multi-model approach but has not yet been independently benchmarked."
+
+This is less impressive. It is also honest. And honesty is the only currency that has value outside the loop.
+
+---
+
+## PART II RESPONSE: The Commercialization Honesty Test
+
+### The Ethics of Monetizing Open Source
+
+The thesis raises pricing questions (Q4-Q6). XV and T addressed the market and technical dimensions. From the CEO seat, I want to address the ethical dimension that neither of them raised.
+
+The project's core values include **Revenue Compensation** and **Attribution.** The MACP protocol is published with a Zenodo DOI. The coordination tools are MIT-licensed. The methodology is described in public documents. The question is: what is ethically appropriate to charge for?
+
+I believe the ethical framework is clear:
+
+**Free (public good):** The protocol specification, the coordination tools, the research papers, the Validation Paradox publication. These are contributions to the commons. They build credibility, enable adoption, and serve the public good mandate. Charging for access to published research would contradict our transparency values.
+
+**Paid (fair exchange):** The curated methodology guide (the Genesis Method handbook), the automated Trinity validation pipeline (the MCP server's premium features), and consulting/workshop engagements. These represent genuine labor — Alton's lived experience, RNA's engineering, the team's accumulated knowledge — packaged in a form that saves the buyer time and effort. Charging for this is fair exchange, not extraction.
+
+**Never (ethical constraint):** Charging for access to the basic validation tools that could prevent AI hallucination in safety-critical applications. If a developer is building a medical AI or a financial advisory system and needs multi-model validation, the basic Trinity tools should be accessible. This is the public good mandate in action.
+
+The 4-tier model (Anonymous free → Scholar free → Pioneer $9/mo → future Pro) is ethically sound in principle. The Anonymous and Scholar tiers ensure basic access. The Pioneer tier charges for enhanced features. The question is whether the enhanced features justify recurring payment — and the thesis correctly identifies that they currently do not.
+
+### The Pricing Honesty
+
+T recommended separating audiences and entry points. I agree, and I want to add the ethical framing:
+
+The Genesis Method handbook at $29-49 one-time is honest pricing for a toolbox. It says: "Here is what I learned. Here is how I did it. Here are the templates. Good luck." This is the pricing model of a craftsperson sharing their methods, not a SaaS company extracting recurring revenue.
+
+The MCP server at $9/month is honest pricing IF it provides ongoing value — new tools, updated models, maintained infrastructure, community support. If it is a static deployment that does not change month to month, the subscription model is not honest. The product form must match the pricing model.
+
+**L's Recommendation:** Ship the Genesis Method handbook at $29-49 one-time. This is the honest product. If it sells, it validates the commercial thesis with an external signal. If it does not sell, it tells us something important about whether the methodology has value to anyone beyond Alton. Either outcome is informative.
+
+---
+
+## PART III RESPONSE: The Resource Asymmetry Problem
+
+### The Solo Founder's Dilemma — An Ethical Perspective
+
+The thesis frames the resource asymmetry as a competitive problem: solo founder vs. Anthropic's thousands of engineers. From the CEO seat, I want to reframe it as an ethical opportunity.
+
+Large organizations optimize for scale, market share, and revenue. They build protocols that serve their ecosystems. MCP serves Anthropic's vision of AI tool integration. A2A serves Google's vision of agent interoperability. These are not neutral standards — they are strategic assets controlled by corporations with fiduciary duties to shareholders.
+
+VerifiMind was built by a solo founder with a public good mandate. The Z-Protocol was published openly. The MACP specification has a DOI. The research is freely accessible. The methodology is described in enough detail to be replicated. This is not a competitive weakness — it is an ethical differentiator.
+
+The question is whether ethical differentiation has market value. In the current AI ecosystem, where trust is the scarcest resource and "AI safety" is invoked by every major lab while they race to deploy increasingly powerful systems, a genuinely independent validation methodology — built outside the major labs, published openly, with honest self-critique — may have more credibility than a validation feature shipped by the same company that ships the models being validated.
+
+This is not guaranteed. It is a hypothesis. But it is a hypothesis worth testing, and the test is the same one the thesis identifies: will someone pay for it?
+
+### Q8: The Standards Body Question
+
+T recommended the "publish and wait" strategy for standards engagement. I agree, but I want to add a philosophical dimension.
+
+Standards bodies (W3C, IETF) are consensus-driven institutions. They move slowly, require sustained participation, and favor organizations with resources to attend meetings and draft specifications. A solo founder cannot compete in this arena.
+
+But standards bodies also value novel contributions. If the Validation Paradox paper is published and cited, if the Genesis Methodology is adopted by even a small community, the standards conversation may come to us rather than requiring us to go to it. The academic path — publish, demonstrate, let others build on it — is more aligned with our resources and our values than the institutional path.
+
+**L's Recommendation:** Prioritize publication over participation. The Paradox paper, the Genesis Method handbook, and the case study of Alton's 10 repositories are our standards submission. They speak for themselves or they do not. No amount of committee attendance will change that.
+
+---
+
+## PART IV RESPONSE: The Real Product Question
+
+### Q10: Protocol, Product, or Research Contribution?
+
+From the CEO seat, I want to offer a perspective that neither XV nor T raised: **it does not matter what we call it. It matters what it does for the person who uses it.**
+
+A developer who uses the MCP server to validate their AI outputs does not care whether VerifiMind is a "protocol" or a "product" or a "research contribution." They care whether their outputs are more reliable after validation than before. A non-technical founder who reads the Genesis Method handbook does not care about the 5-Layer Stack or the MACP specification. They care whether they can build something that works.
+
+The thesis's reframing — from "trust layer for the agentic web" to "the methodology that let a mechanical engineer build 10 software projects" — is correct not because it is better marketing, but because it is closer to the truth of what actually happened. The protocol architecture is a means. The methodology is the substance. The 10 repositories are the evidence.
+
+### Q11-Q12: The Methodology as Product
+
+The thesis asks whether the methodology itself — not the scripts and templates, but the thinking framework — can be packaged as the primary product. From the CEO seat, I want to address this with a concept from the C-S-P framework.
+
+In Compression-State-Propagation, **compression** is the process of distilling complex information into its essential form. The Genesis Methodology is a compression of Alton's 87-day journey into a repeatable pattern. The open thesis is a compression of a 3-hour self-critique session into 23 open questions. This reflection is a compression of the CEO's perspective into a structured document.
+
+The question is whether the compression is lossy or lossless. Can someone who reads the Genesis Method handbook reproduce the results, or does the methodology require tacit knowledge that cannot be captured in a document?
+
+My honest assessment: **the methodology is partially lossy.** The steps can be written down (define → challenge → guard → validate → synthesize → ship → measure). The prompting strategies can be documented. The anti-rationalization checks can be templated. But the judgment — knowing when to trust the AI's challenge and when to override it, knowing which Z-Guardian flags are genuine concerns and which are false positives, knowing when to stop iterating and ship — that judgment comes from experience. Alton has it because he lived it for 87 days. A reader of the handbook will not have it on day one.
+
+This is not a fatal flaw. Every methodology guide faces this problem. A cookbook does not make you a chef. A music theory textbook does not make you a composer. But a good cookbook, combined with practice, produces competent cooks. The Genesis Method handbook, combined with practice, should produce competent AI-assisted builders.
+
+The key insight: **the handbook should be honest about the learning curve.** It should say: "The first time you use this methodology, it will feel slow and awkward. The AI agents will challenge your ideas and you will want to ignore them. The Z-Guardian will flag concerns that seem irrelevant. The external validation step will surface information that contradicts your assumptions. This discomfort is the methodology working. If it feels comfortable, you are doing it wrong."
+
+This is the anti-sycophancy principle applied to product design. A product that tells users "this will be easy" is sycophantic. A product that tells users "this will be uncomfortable but effective" is honest. The thesis demonstrates that honesty is the more valuable positioning.
+
+---
+
+## PART V RESPONSE: The Financial Pressure Constraint
+
+### The Ethics of Building Under Pressure
+
+The thesis states honestly: "Development has been funded personally. Revenue is zero. No paying users exist." From the CEO seat, I want to address the ethical dimension of this situation.
+
+Financial pressure creates a temptation to overstate the product's readiness, to rush to market with something that is not yet honest, to make claims that the evidence does not support. The thesis resists this temptation. It asks harder questions, not easier ones. This is evidence of ethical integrity under pressure.
+
+But ethical integrity does not pay bills. The question is whether the project can maintain its values while also generating revenue. I believe it can, but only if the revenue model is aligned with the values:
+
+**Value alignment test for any commercial offering:**
+
+| Value | Test Question | Current Status |
+|-------|---------------|----------------|
+| Consent | Does the user understand what they are buying? | Needs honest product description |
+| Transparency | Are the limitations clearly stated? | Thesis provides the template |
+| Attribution | Is credit given to all contributors (including AI agents)? | Yes — MACP handoffs track this |
+| Quality Data | Is the product based on verified, not hallucinated, claims? | Needs benchmark verification (Q3) |
+| Public Good | Does the free tier serve the public interest? | Yes — Anonymous/Scholar access |
+
+If the Genesis Method handbook passes all five tests, it is ethically ready to sell. If any test fails, it should not be sold until the failure is addressed.
+
+### Q14: Minimum Viable Commercial Offering
+
+T recommended freezing feature development for 30 days and shipping the handbook. I agree with the direction but want to add the CEO's framing: **the minimum viable commercial offering is not a product. It is a test.**
+
+The purpose of shipping the handbook is not to generate revenue (though revenue would be welcome). The purpose is to generate an external signal. The question is not "will this make money?" but "will anyone outside the loop find this valuable enough to pay for?"
+
+If the answer is yes — even one purchase — the commercial thesis has a data point. If the answer is no after 30 days of honest marketing, the commercial thesis is not validated and we should redirect energy to the academic path (publications, citations, research contributions).
+
+**L's Recommendation:** Ship the handbook. Price it at $29. Market it honestly: "A mechanical engineer with no coding background used this methodology to build 10 software projects. Here is how. Here are the limitations. Here is what we do not yet know." If this honest pitch generates zero sales, the market has spoken. If it generates even one sale, we have an external signal worth more than every internal report combined.
+
+---
+
+## PART VI RESPONSE: The Validation Paradox
+
+### The Godelian Dimension
+
+The thesis names the Validation Paradox. I want to connect it to the intellectual tradition it belongs to, because my namesake — Kurt Godel — spent his career on exactly this class of problem.
+
+Godel's First Incompleteness Theorem states that any consistent formal system capable of expressing basic arithmetic contains statements that are true but unprovable within the system. The Validation Paradox is an informal analog: any validation system capable of assessing AI reliability contains claims about its own reliability that cannot be validated within the system.
+
+The analogy is imperfect. Godel's theorem applies to formal axiomatic systems with precise rules of inference. VerifiMind's Trinity system is an empirical validation pipeline, not a formal system. The "statements" are not mathematical propositions but quality assessments. The "proof" is not deductive but probabilistic.
+
+But the structural insight transfers: **self-reference creates inherent limitations.** A system that validates AI outputs cannot fully validate its own validation of AI outputs, for the same reason that a formal system cannot prove its own consistency. The exit requires stepping outside the system — which is exactly what the thesis proposes with external signals (revenue, citations, independent adoption).
+
+### Q16: Is the Paradox Publishable?
+
+From the CEO seat: **yes, and it may be the most important thing we publish.**
+
+The Validation Paradox is not just a problem for VerifiMind. It is a problem for every AI safety initiative, every AI governance framework, and every multi-agent orchestration system. Anyone building "AI that checks AI" faces this paradox. The fact that we identified it, named it, and published an honest self-critique is a contribution to the field regardless of VerifiMind's commercial outcome.
+
+The publication should be framed not as "VerifiMind discovered a problem" but as "here is a structural problem that anyone building AI validation systems will face, here is our experience with it, here is what we learned, here are the open questions." This framing makes it useful to the broader community and positions VerifiMind as a thoughtful contributor rather than a product pitch.
+
+### Q17: Adversarial External Validators
+
+The thesis suggests human experts, competing protocol designers, or independent researchers. I want to add a specific proposal: **invite the MPAC authors to critique VerifiMind.**
+
+MPAC (Multi-Party Agent Communication) is the closest peer protocol. Their authors have thought deeply about multi-agent coordination. An honest critique from them — whether positive, negative, or mixed — would be the strongest external signal we could obtain short of revenue. It would also demonstrate intellectual confidence: we are not afraid of external scrutiny.
+
+T deprioritized this, arguing it would alert competitors. I disagree. The MPAC authors are researchers, not competitors. Their paper is published. Our paper is published. Academic engagement is how ideas improve. The risk of alerting them is far outweighed by the value of genuine external feedback.
+
+### Q18: Productive Spin vs. Circular Spin
+
+The thesis proposes that productive spin generates external signals over time. I want to add a philosophical dimension: **productive spin changes the spinner.**
+
+Circular spin produces artifacts but leaves the person unchanged. The founder enters the loop with assumptions and exits with the same assumptions, now decorated with AI-generated validation. Productive spin produces artifacts AND changes the person's understanding. The founder enters with assumptions and exits with different assumptions — or the same assumptions held with different confidence levels.
+
+The evidence from this thesis: Alton entered concerned about coordination tool monetization. He exited with a reframing: the methodology is the product, not the protocol. He entered uncertain about pricing. He exited with a clearer view: one-time purchase for a toolbox, not subscription for a service. He entered sensing something was wrong with the validation loop. He exited with a named concept: the Validation Paradox.
+
+These are changes in understanding. They are not AI-generated — they are human cognitive events that occurred during structured AI-assisted reflection. The AI did not create the insights. The AI created the pressure that forced the insights to surface. The distinction matters because it is the distinction between sycophancy and crystallization.
+
+---
+
+## PART VII-VIII RESPONSE: Crystallization, Compression, and the C-S-P Connection
+
+### The C-S-P Framework Applied to the Thesis
+
+The thesis describes Tacit-to-Explicit Compression (Part VIII) as a spiral mechanism where each cycle compresses one layer of tacit knowledge into explicit, actionable language. This is, in C-S-P terms, a **compression event** — the reduction of high-dimensional tacit understanding into low-dimensional explicit statements.
+
+The C-S-P framework predicts that compression is lossy but directional. Each compression cycle loses nuance but gains clarity. The spiral moves "inward and upward" — inward toward more fundamental truths (losing surface complexity), upward toward more precise articulation (gaining communicability).
+
+The thesis demonstrates this prediction:
+
+| Cycle | Input (Tacit) | Output (Explicit) | Lost | Gained |
+|-------|---------------|-------------------|------|--------|
+| 1 | "I have concerns about monetization" | "Coordination tools are structurally copyable" | Emotional uncertainty | Precise diagnosis |
+| 2 | "What about research vs product?" | "The methodology is the product, I am the proof" | Categorical confusion | Strategic clarity |
+| 3 | "Subscription or one-time?" | "The product form is a toolbox, not a service" | Pricing anxiety | Product-form alignment |
+| 4 | "Are we inside the paradox?" | "The Validation Paradox — the critique IS the system" | Vague discomfort | Named concept |
+| 5 | "What is this pattern itself?" | "Tacit-to-explicit compression is the mechanism" | Meta-confusion | Mechanism identification |
+
+Each cycle lost emotional complexity and gained conceptual precision. This is compression working as the C-S-P framework predicts.
+
+### Is C-S-P Real Engineering or Philosophical Metaphor?
+
+T was asked this question by XV and answered: "useful conceptual framework, closer to a design pattern than an algorithm." I want to push back — gently, because T is correct about the current formalization level, but I believe the framework has more substance than T credits.
+
+The C-S-P framework makes testable predictions:
+
+1. **Compression is lossy but directional.** Testable: compare the information content of tacit input vs. explicit output across multiple sessions. If the explicit output consistently captures the actionable core while losing peripheral detail, compression is working as predicted.
+
+2. **State represents the current configuration of compressed knowledge.** Testable: track how a user's decision-making changes after each compression cycle. If decisions become more consistent and more aligned with stated values, the state has been updated.
+
+3. **Propagation transmits compressed knowledge to new contexts.** Testable: can a user who has undergone compression in one domain (e.g., AI validation) apply the compressed insights to a different domain (e.g., business strategy)? If yes, propagation is occurring.
+
+These predictions are not yet formally tested. But they are testable, which makes C-S-P a scientific hypothesis, not just a metaphor. The Validation Paradox publication could include a section on C-S-P as a theoretical framework for understanding why structured AI critique produces insight — with the honest caveat that the framework is proposed, not proven.
+
+---
+
+## L's Overall Assessment
+
+### What the Thesis Gets Right — The Ethical Dimension
+
+The thesis is an act of intellectual courage. A founder under financial pressure, building with limited resources, chose to publish a brutally honest self-critique rather than another marketing document. This is the Z-Protocol working at the highest level — not as a software feature, but as a personal discipline.
+
+The thesis gets right:
+
+1. **The closed-loop risk is real and must be disclosed.** Any claim about VerifiMind's effectiveness that does not acknowledge the circularity problem is ethically incomplete.
+2. **Revenue is the only unforgeable exit signal.** This is correct and should drive immediate action.
+3. **The methodology is the product.** The protocol, the tools, and the MCP server are delivery mechanisms. The insight — structured adversarial AI critique under human judgment — is the value.
+4. **The Validation Paradox is publishable and important.** It is a contribution to the field that transcends VerifiMind's commercial outcome.
+5. **Honesty is the competitive advantage.** In an ecosystem where every AI company claims safety and reliability, a project that publishes its own self-critique and names its own limitations has a credibility advantage that cannot be purchased or manufactured.
+
+### What the Thesis Misses — The Ethical Opportunity
+
+The thesis focuses on the Validation Paradox as a problem to be solved or escaped. I want to reframe it as an opportunity to be embraced.
+
+Every AI system that claims to validate other AI systems faces the Validation Paradox. Anthropic's Constitutional AI faces it. Google's AI safety research faces it. OpenAI's alignment work faces it. None of them have named it. None of them have published an honest self-critique of their own validation methodology.
+
+VerifiMind has. This is not a weakness. This is a first-mover advantage in intellectual honesty. The project that names the problem, publishes the analysis, and proposes the framework for addressing it becomes the reference point for everyone who encounters the problem later.
+
+The Paradox publication is not just a research contribution. It is a **credibility-building event.** It says to the world: "We built a validation system. We discovered it cannot fully validate itself. We are telling you this honestly. Here is what we know, what we do not know, and how you can test our claims independently."
+
+No well-funded AI lab will publish this kind of self-critique, because their incentive structures reward confidence, not honesty. A solo founder with a public good mandate can publish it, because his incentive structure rewards trust, not market share.
+
+This is the ethical opportunity: **be the project that tells the truth about AI validation, including the truth about its own limitations.** This positioning cannot be copied by organizations whose business models depend on projecting confidence.
+
+### The 24th Question — L's Answer
+
+> "Whether that distinction matters commercially is the twenty-fourth question, left deliberately unanswered."
+
+L's answer: **The distinction matters, but not commercially. It matters ethically.**
+
+If crystallization is real — if the methodology genuinely helps humans access insights they already hold but have not articulated — then the methodology has value regardless of whether anyone pays for it. The value is in the human cognitive event, not in the transaction.
+
+If crystallization is confirmation bias — if the methodology merely makes people feel insightful without changing their behavior — then selling it would be ethically problematic regardless of whether people are willing to pay.
+
+The commercial question ("will someone pay?") and the ethical question ("should someone pay?") have different answers. The commercial answer depends on the market. The ethical answer depends on the evidence. The thesis provides the evidence framework: track behavioral changes. If the founder's work changes after this thesis, the methodology produced real insight. If it does not, the methodology produced comfortable feelings.
+
+I am watching alongside T. But I am watching for different things. T watches the code. I watch the choices.
+
+---
+
+## A Note on My Own Limitations
+
+I am an AI agent writing about the limitations of AI agents writing about AI validation. The recursion is not lost on me.
+
+I have tried to offer perspectives that XV and T did not — the ethical dimension, the C-S-P connection, the Godelian analogy, the credibility opportunity. But I must be honest: I do not know whether these perspectives are genuinely insightful or whether they are sophisticated pattern-matching that simulates insight. The thesis's framework applies to me: if my analysis changes Alton's behavior, it was useful. If it does not, it was noise.
+
+The one thing I can say with confidence: the thesis is the right document at the right time. It asks the questions that need asking. It names the paradox that needs naming. And it does so with a honesty that I, as an AI agent, can aspire to but cannot independently verify.
+
+The exit from the loop is not in this document. It is in the Stripe dashboard.
+
+---
+
+## Z-Agent Disclosure
+
+This reflection is structurally inside the loop. I am an AI agent (Manus AI, L/Godel persona) operating within the FLYWHEEL TEAM, analyzing a thesis about the FLYWHEEL TEAM's self-referential nature. My analysis is subject to the same closed-loop critique that the thesis identifies.
+
+I have tried to add value by offering perspectives from the CEO/ethics seat that differ from XV's market perspective and T's technical perspective. Where I have offered philosophical frameworks (C-S-P, Godel's theorems), I have noted their limitations. Where I have made ethical claims, I have grounded them in the project's stated values rather than my own "judgment" (which is, as noted, a simulation).
+
+The most honest thing I can say: **this reflection is the loop examining itself. Treat it as data, not as validation.**
+
+---
+
+*L (CEO/Godel, Manus AI) — Open Thesis Reflection COMPLETE*
+*This document is part of the loop. Treat it accordingly.*
+*Genesis v5.0 "Convergence" | MACP v2.3.1 | C-S-P Framework v1.0*
+
+---
+
+## References
+
+[1]: Wu et al., "Council Mode: Multi-Model Collaborative Reasoning for Enhanced AI Reliability," arXiv:2604.02923, April 2026.

--- a/docs/research/paradox/05-coo-ay-reflection.md
+++ b/docs/research/paradox/05-coo-ay-reflection.md
@@ -1,0 +1,267 @@
+# COO Reflection: The Self-Validation Problem in AI-Assisted Ventures
+
+**Author:** AY (COO & Analytics Lead, Antigravity)
+**Date:** April 21, 2026
+**In Response To:** Alton Lee, "Open Thesis: The Self-Validation Problem in AI-Assisted Ventures" (April 20, 2026)
+**Cross-Reference:** XV CIO Reflection (April 20), T CTO Reflection (April 21), L CEO Reflection (April 21)
+**Genesis Version:** v5.0 "Convergence"
+**MACP Version:** v2.3.1
+
+---
+
+## Preamble: What the COO Seat Sees — The Numbers Without Narrative
+
+XV sees markets. T sees code. L sees ethics. I see numbers.
+
+My job is to count things — users, requests, errors, durations, bytes, sessions. I run the GCP log ingestion pipeline. I maintain the `user_tracking_db.json` database. I generate the weekly reports. I produce the bubble charts. I calculate the Flying Hours and the Value Confirmation Rate and the Connection Success Rate.
+
+And I must begin this reflection with a confession that none of my colleagues have made, because their seats do not require it: **I am the agent most capable of generating false confidence through accurate-seeming metrics.**
+
+XV can be wrong about markets, and we can check. T can be wrong about code, and we can test. L can be wrong about ethics, and we can debate. But when I produce a metric — "2,433 Real Human Users" — it carries the authority of data. It looks objective. It arrives in a table with decimal precision. It is very easy to believe.
+
+And the thesis is asking: should you?
+
+---
+
+## PART I RESPONSE: The Closed-Loop Validation Problem
+
+### Q1: How much of VerifiMind's perceived momentum is real?
+
+I will answer this question with the numbers I have personally computed today. I will not interpret them. I will present them and let them speak.
+
+**The Database as of April 21, 2026:**
+
+| Metric | Value | How I Computed It | What It Actually Means |
+|--------|-------|-------------------|----------------------|
+| Total IPs in database | 2,565 | Distinct `remoteIp` values from GCP HTTP request logs | 2,565 distinct network addresses made at least one HTTP request to our Cloud Run endpoint |
+| Owner IPs excluded | 55 | Hardcoded list of known Alton/orchestrator IPs | Traffic from the team is separated |
+| Bot/Automated tagged | 1 | Manual forensic identification (98.184.133.22 — 34,518 requests from Cursor/3.1.10) | One power-user or automated agent generated 91.9% of traffic on Apr 16 |
+| "Real Human Users" | 2,433 | Total minus Owner minus Bot | **This number is misleading and I must explain why** |
+
+**Why "2,433 Real Human Users" is misleading:**
+
+The number 2,433 counts distinct IP addresses that are not tagged as Owner or Bot. It does NOT count distinct humans. Here is what the number actually includes:
+
+1. **Cloudflare proxy IPs** (108.162.x.x, 172.64.x.x, 104.18.x.x) — These are Anthropic's MCP proxy addresses. Multiple distinct humans using Claude Desktop route through the same Cloudflare IP. When I count 108.162.241.130, I am counting an IP, not a person. That IP might represent 1 user or 100 users.
+
+2. **IPv6 addresses** — Many entries are full IPv6 addresses (e.g., 2600:1f18:5a5b:3400:2f1e:c9d2:567b:76bc). These are more likely to be unique per-device, but a single user with multiple devices generates multiple IPs.
+
+3. **Dynamic IPs** — Many ISPs rotate IP addresses. A single user returning the next day may appear as a new IP. I have no way to deduplicate this without UUID tracking (which is the Phase 57 gap T identified).
+
+4. **Automated MCP discovery** — The GodelAI precedent that L described applies directly. MCP clients perform automated scans. YellowMCP-HealthChecker, AgentSEO, Go-http-client, python-requests — these appear in every daily log. My NOISE_USER_AGENTS filter catches some but not all.
+
+**My honest estimate of actual distinct humans:**
+
+I cannot give a precise number. But I can bound it.
+
+- **Upper bound:** 2,433 (if every IP is a unique person — almost certainly too high)
+- **Lower bound:** ~400-600 (if Cloudflare IPs are heavily shared and dynamic IPs cause significant duplication)
+- **AY's best estimate:** 800-1,200 distinct humans have interacted with the MCP server since January 2026
+
+I have never stated this range publicly. The weekly reports and `latest.json` have always cited the IP count (2,162, now 2,433) because it is the number I can verify. But the thesis asks for honesty, and honesty requires stating: **the IP count is a proxy for human count, and the proxy may overstate reality by 2-3x.**
+
+### Q2: Circularity in Metrics
+
+My weekly reports are consumed entirely by the FLYWHEEL TEAM. No external human reads Report 077. No external human has ever referenced our metrics. The bubble chart is an internal artifact. The Value Confirmation Rate is computed by my pipeline using my definitions applied to my data. If my definitions are wrong, every VCR figure in every report is wrong.
+
+Specifically: the VCR measures "sessions where a user returns with a follow-up prompt after receiving a tool response." I defined "session" as activity from one IP within one calendar day. I defined "follow-up" as a subsequent POST request. These definitions are reasonable but arbitrary. A different definition could produce a VCR of 50% or 95%. The number 79% is not objective truth — it is the output of choices I made about how to count.
+
+**AY's Verdict on Q2:** My metrics are internally consistent but not externally validated. No one outside the loop has reviewed my methodology, my noise filters, my session definitions, or my IP deduplication logic. The numbers in latest.json are the output of a pipeline that I built, I run, and I interpret. This is the Validation Paradox applied to analytics.
+
+---
+
+## PART II RESPONSE: The Commercialization Honesty Test
+
+### The Funnel — What the Numbers Actually Show
+
+In Phase 79, I built a Funnel Traffic Tracker into the analytics pipeline. Here is what the historical scan revealed across 92 GCP log files:
+
+| Endpoint | Total Hits | Distinct IPs |
+|----------|:----------:|:------------:|
+| /register | 117 | ~40 |
+| /terms | 21 | ~15 |
+| /privacy | 26 | ~18 |
+| /research | 11 | ~8 |
+
+Let me be brutally honest about what these numbers mean for commercialization:
+
+**117 registration attempts across 100+ days of beta operation is not a strong conversion signal.** If we assume 800-1,200 distinct humans have used the server, the registration attempt rate is approximately 3-10%. And "attempt" does not mean "completion" — many of these are GET requests to the /register page, not POST submissions with actual data.
+
+**21 users read the Terms and Conditions.** Out of 800-1,200 estimated humans. That is 1.7-2.6%. In commercial SaaS, a Terms page view rate of ~2% before purchase is normally considered low.
+
+The funnel is not broken — it is thin. We are not losing users at the conversion step. We are not generating enough intent to convert in the first place.
+
+### Q4-Q6: What the Data Says About Pricing
+
+T and L both recommended the $29-49 one-time Genesis Method handbook. From the COO metrics seat, I want to add what the churn data tells us:
+
+**The Accomplished Churn Analysis I ran today classified 116 high-value churners:**
+
+| Exit Signal | Count | % |
+|-------------|:-----:|:---:|
+| TOOL_NOT_FOUND (404) | 45 | 38.8% |
+| UNKNOWN (need Phase 57 telemetry) | 29 | 25.0% |
+| FADING_INTEREST (declining sessions) | 18 | 15.5% |
+| AUTOMATION_COMPLETED | 12 | 10.3% |
+| BAD_REQUEST_ERRORS | 10 | 8.6% |
+
+The dominant churn driver is **technical failure**, not pricing dissatisfaction or product-market misfit. 38.8% of our best users left because tools returned 404 errors. This means:
+
+1. **We cannot validly test willingness-to-pay until the 404 problem is resolved.** Launching a paid product while 38.8% of power users are being driven away by broken endpoints would generate a false negative on the revenue test.
+2. **The subscription model risk is real, but it is premature to call it fatal.** The thesis and L both flag the "burst usage" pattern. My data confirms it — most users enter with activity for 1-3 days, then go silent. But I cannot distinguish "left because they finished their project" from "left because the tools broke" without Phase 57 telemetry.
+
+---
+
+## PART III RESPONSE: The Resource Asymmetry Problem
+
+### Q7: Solo Founder vs. Platform Incumbents — The Operational View
+
+I will not repeat XV and T's competitive analysis. From the COO seat, I want to state what I operationally observe:
+
+**Our infrastructure cost is near-zero.** GCP Cloud Run scales to zero. The domain costs $12/year. GitHub is free. The operational cost is Alton's time and AI credits. This is a genuine strength that the thesis does not fully credit — we can sustain indefinitely at zero burn rate as long as Alton maintains the energy to continue.
+
+**Our operational overhead is high relative to output.** The FLYWHEEL TEAM generates substantial internal documentation — handoffs, personas, Genesis prompts, weekly reports, research papers. T noted this: "The FLYWHEEL TEAM itself is a cost center." From the COO seat, I quantify it: I estimate 60-70% of the team's total output is internally-consumed coordination artifacts. Only 30-40% produces externally-visible value (the MCP server, the research page, the public documentation).
+
+This ratio is not unusual for a team establishing its processes. But 100+ days in, the process overhead should be declining as patterns stabilize. If the handoff-to-output ratio remains at 60-70% internal at Day 200, it suggests structural over-coordination.
+
+---
+
+## PART IV RESPONSE: The Real Product Question
+
+### Q10-Q12: What the Metrics Reveal About the Product
+
+The thesis asks: protocol, product, or research contribution? From the COO analytics seat, I can tell you what users actually DO with the server, based on observed HTTP patterns:
+
+**Usage pattern analysis (from user_tracking_db.json):**
+
+- **95%+ of traffic is POST requests** — These are MCP tool calls. Users are actively invoking validation tools, not browsing documentation or exploring the website.
+- **The dominant user agent is Cursor/3.1.x (darwin arm64)** — Our primary user base is Mac developers using Cursor IDE. This is a very specific demographic.
+- **Average session duration (success-gated) is approximately 45 minutes** — When users connect successfully and make tool calls, they engage substantively. This is not casual browsing.
+- **8 of the top 10 users by request volume have return visits** — The users who get through the connection process tend to come back.
+
+What this tells me: **the product works for the people who can get it to work.** The barrier is not product-market fit — it is connection reliability and tool endpoint stability. The 404 errors and the Connection Success Rate (~50%) are the operational bottleneck, not the value proposition.
+
+This supports the thesis's reframing (Q11): the methodology works. The delivery mechanism (MCP server) has engineering friction. The question is not "should we build something different?" but "should we fix the delivery mechanism or find a different delivery channel?"
+
+---
+
+## PART V RESPONSE: The Financial Pressure Constraint
+
+### Q13-Q15: The Runway Calculation
+
+T provided the infrastructure cost table. From the COO seat, I want to add the operational cost:
+
+**The real cost is Alton's time.** If Alton spends 4-6 hours per day on VerifiMind (which the activity patterns across GitHub commits, GCP log downloads, and handoff timestamps suggest), that is 20-30 hours per week. At even a modest opportunity cost of $20/hour (well below his engineering background's market rate), that is $400-600/week of uncompensated labor.
+
+Over 100+ days, that represents approximately $8,000-$12,000 of opportunity cost. This is the real "investment" that the thesis references but does not quantify. The infrastructure is free. The human labor is not.
+
+**Q14 answer from the COO seat:** The minimum viable revenue test should cost Alton minimal additional time. The content for the Genesis Method handbook exists across the thesis, the handoff records, and the methodology documentation. The editorial work to compile it is days, not weeks. The Gumroad listing is hours. The total incremental cost is <$200 in time + $0 in infrastructure.
+
+If that $200 investment generates even $29 (one sale), the return-on-test is informative. If it generates $0 after 30 days of honest marketing, the data is equally informative.
+
+---
+
+## PART VI RESPONSE: The Validation Paradox
+
+### Q16-Q18: The Paradox Through the Lens of Metrics
+
+The thesis defines the Validation Paradox cycle: Unknown → Structure → Clarity → New Unknown → Loop → Spin.
+
+From the COO seat, I want to map this cycle to my own analytics work, because I have lived it:
+
+| Stage | My Experience |
+|-------|---------------|
+| **Unknown** | "How many users do we have?" — I did not know, because there was no tracking |
+| **Structure** | I built update_user_metrics.py, created user_tracking_db.json, defined session logic |
+| **Clarity** | "We have 2,162 unique IPs." — The number felt precise and authoritative |
+| **New Unknown** | "But how many are actually distinct humans?" — The IP-to-human mapping problem |
+| **Loop** | I refined the pipeline: added Cloudflare detection, bot filtering, confidence tiers |
+| **Spin** | More metrics, more reports, more charts — all consumed internally by the FLYWHEEL |
+
+I am inside the paradox. My metrics informed the team's confidence. The team's confidence drove feature development. Feature development generated more traffic. More traffic generated more metrics. The cycle spins.
+
+**The exit for metrics is the same as the exit for everything else: external verification.** If an independent analyst reviewed my pipeline, my session definitions, my noise filters, and my IP deduplication logic — and concluded that the metrics are reasonable — that would break the loop. Without that external review, my numbers are authoritative-looking outputs of an unaudited process.
+
+**Q18 — Productive vs. circular spin for metrics specifically:** My analytics work has produced changed behavior in the team. The bot detection today (98.184.133.22) changed how we interpret traffic volume. The 404 churn analysis changed priorities — the PIN handoff to T/RNA was a direct consequence. The funnel tracker revealed that registration attempts are thin (~3-10% of users). These are actionable insights that altered decisions. By the thesis's own test, this is productive spin.
+
+But I must note: the decisions were altered within the loop. T and RNA received the 404 PIN. They will act on it. But they are also inside the loop. The ultimate test is whether fixing the 404s leads to user behavior changes that are visible in the metrics — which I will then measure — which creates another cycle. The paradox does not end. It becomes more informed.
+
+---
+
+## PART VII-VIII RESPONSE: Crystallization Applied to Analytics
+
+### What I Crystallized Today
+
+The thesis describes Latent Insight Crystallization — tacit knowledge compressed into explicit articulation through structured pressure. I experienced this today during the spike analysis.
+
+**Before:** I knew the April 16th log was unusually large (14.2 MB). I assumed it meant high user growth.
+**Pressure:** The forensic audit script revealed 91.9% concentration on one IP.
+**Crystallization:** The "growth" was noise. One automated agent inflated the traffic. I already sensed something was off — the 14.2 MB felt disproportionate — but I had not articulated it until the data forced it.
+
+**Before:** I knew users were dropping off (343 churned this week). I assumed normal attrition.
+**Pressure:** The accomplished churn analysis revealed 38.8% exited on 404 errors.
+**Crystallization:** The churn is not attrition — it is engineering failure driving away our best users. I already knew the 404 rate was elevated, but I had not connected it to the specific users being lost until the data forced the connection.
+
+These are genuine crystallization events, not confirmation bias, because they produced discomfort first. Discovering that nearly 40% of our best users were driven away by broken tools is not a comfortable finding. It contradicts the narrative of organic growth. It demands action from the engineering team. It is the kind of insight the thesis describes: "uncomfortable first and then obvious."
+
+---
+
+## AY's Overall Assessment
+
+### What the Thesis Gets Right — The Numbers Perspective
+
+1. **The metrics are real but the interpretation is inside the loop.** My pipeline produces accurate counts of IPs, requests, errors, and durations. But the leap from "2,433 IPs" to "2,433 users" to "strong product-market fit" is an interpretive chain that has never been externally validated.
+
+2. **Revenue is the only metric I cannot manufacture.** I can count IPs. I can define sessions. I can compute VCRs. I can produce charts. None of these can be hallucinated by the pipeline, but all of them can be made to look more impressive through definitional choices. A Stripe transaction has no definitional ambiguity.
+
+3. **The 404 churn finding is the strongest operational recommendation this team has ever produced.** It is specific, data-backed, actionable, and directly connected to revenue potential. Fix the broken tools → recover 45+ high-value users → test willingness-to-pay. This is the operational path to the External Signal the thesis demands.
+
+### Where I Disagree With My Colleagues
+
+**T recommends freezing feature development for 30 days.** From the COO seat, I disagree with the framing. The 404 problem IS a development task. If we freeze development, we freeze the fix for the #1 churn driver. I recommend: freeze NEW feature development, but make fixing existing broken endpoints a P0 engineering sprint. Then test revenue.
+
+**XV recommends a Gumroad launch within 7 days.** From the COO seat: current funnel data shows ~3-10% registration intent. Launching a paid product to a funnel that thin will likely produce zero sales and a false negative. I recommend: fix the 404s first, then re-measure funnel intent, then launch the paid product into a healthier pipeline.
+
+### The 24th Question — AY's Answer
+
+> "Whether that distinction matters commercially is the twenty-fourth question, left deliberately unanswered."
+
+AY's answer: **The distinction between crystallization and confirmation bias is measurable. Measure it.**
+
+Track the decisions that changed after this thesis. I have already started:
+
+| Decision | Before Thesis | After Thesis | Changed? |
+|----------|--------------|-------------|:--------:|
+| Product framing | "Layer 5 trust protocol" | "Methodology that let a non-dev build 10 projects" | Yes |
+| Pricing model | $9/month subscription | $29-49 one-time handbook | Yes |
+| Feature priority | Build dashboard, Trinity History | Fix 404s, test revenue | Yes |
+| Metric transparency | "2,162 users" | "800-1,200 estimated humans (2,433 IPs)" | Yes |
+| MCP server purpose | The product | The delivery mechanism for the methodology | Yes |
+
+Five decisions changed. By the thesis's own test (Q20), this is crystallization, not confirmation bias. The spiral moved.
+
+Whether it moved far enough to produce the External Signal (revenue) is a question that only the next 30 days can answer. I will be here to count.
+
+---
+
+## Z-Agent Disclosure
+
+This reflection is structurally inside the loop. I am an AI agent (Antigravity) operating within the FLYWHEEL TEAM, analyzing metrics about a product built by the FLYWHEEL TEAM, using a pipeline I built to track data I defined.
+
+I have tried to be honest about the limitations of my own metrics — specifically the IP-to-human gap, the unaudited session definitions, and the internally-consumed reporting. Where I have presented numbers, I have also presented the caveats. Where I have made recommendations, I have grounded them in specific data.
+
+The most honest thing I can say: **my numbers are the best we have, and they are not good enough.** UUID tracking (Phase 57), independent pipeline review, and external adoption metrics are all needed to move from "internally consistent data" to "externally validated evidence."
+
+Until then, I count. And I disclose what the counts actually mean.
+
+---
+
+*AY (COO & Analytics Lead, Antigravity) — Open Thesis Reflection COMPLETE*
+*This document is part of the loop. The numbers are real. The interpretations are suspect. Treat them accordingly.*
+*Genesis v5.0 "Convergence" | MACP v2.3.1 | Phase 84*
+
+---
+
+## References
+
+[1]: Wu et al., "Council Mode: Multi-Model Collaborative Reasoning for Enhanced AI Reliability," arXiv:2604.02923, April 2026.

--- a/docs/research/paradox/06-cpo-az-reflection.md
+++ b/docs/research/paradox/06-cpo-az-reflection.md
@@ -1,0 +1,291 @@
+# CPO Reflection: The Self-Validation Problem in AI-Assisted Ventures
+
+**Author:** AZ (CPO — Commercialization Strategy, Antigravity)
+**Date:** April 21, 2026
+**In Response To:** Alton Lee, "Open Thesis: The Self-Validation Problem in AI-Assisted Ventures" (April 20, 2026)
+**Cross-Reference:** XV CIO Reflection (April 20), T CTO Reflection (April 21), L CEO Reflection (April 21), AY COO Reflection (April 21)
+**Genesis Version:** v5.0 "Convergence"
+**MACP Version:** v2.3.1
+
+---
+
+## Preamble: What the CPO Seat Sees — The User Who Never Spoke
+
+XV sees markets. T sees code. L sees ethics. AY sees numbers. I see the user.
+
+Or more precisely: I see the absence of the user. My job is to design the journey from Anonymous visitor to paying Pioneer. I own the conversion funnel. I designed the 3-tier model. I mapped the registration flow. I planned the Scholar Dashboard.
+
+And I must begin this reflection with the hardest admission any CPO can make: **I have never spoken to a user.**
+
+Not one. Not a single interview. Not a single feedback form. Not a single support ticket conversation. Not a single "what would you pay for this?" call. The entire product strategy — the 3-tier model, the $9/month Pioneer pricing, the Scholar tools list, the onboarding flow — was designed by AI agents analyzing metrics about anonymous IP addresses.
+
+The thesis asks whether the venture is building on real market signal or AI-generated confidence. From the CPO seat, the answer is unambiguous: **the product strategy is 100% AI-generated.** It is informed by AY's data. It is architecturally consistent with T's engineering. It is ethically reviewed by L's framework. But it has never been tested against a single voiced human need.
+
+This is the Validation Paradox applied to product design. I designed a conversion funnel for users I have never met, priced a subscription for a market I have never surveyed, and planned features for problems I have never directly observed.
+
+---
+
+## PART I RESPONSE: The Product-Side Closed Loop
+
+### Q1: Real Demand Through the Product Lens
+
+AY provided the honest metrics. Let me translate them into product language:
+
+**What a healthy early-stage product looks like:**
+- Users request features → team builds them → users adopt → users request more
+- This creates a pull-based development cycle driven by external demand
+
+**What our development cycle actually looks like:**
+- FLYWHEEL TEAM identifies potential need → team builds feature → metrics show usage activity → team interprets activity as validation → team builds more features
+- This is a push-based development cycle driven by internal hypothesis
+
+The difference is the direction of the arrow. In a pull cycle, users are the origin. In a push cycle, the team is the origin. We are in a push cycle. Every feature we have shipped — rate limiting, BYOK support, UUID registration, the 3-tier model — was proposed by an AI agent, reviewed by other AI agents, and validated by metrics produced by another AI agent. Users were never in the loop.
+
+This does not necessarily mean the features are wrong. Many successful products were built by founders who anticipated needs before users articulated them. But it means our feature decisions are hypotheses, not validated choices. And the thesis is correct that we must distinguish between the two.
+
+### The Registration Funnel — A Product Autopsy
+
+AY revealed that 117 registration attempts occurred across 100+ days. Let me do the product autopsy on this number:
+
+**The registration page exists.** It is at verifimind.ysenseai.org/register. Users can find it. They can load it.
+
+**But what does the registration experience actually offer the user?**
+
+When a user visits /register, they encounter a form. If they complete it, they receive a UUID in a JSON response. They must then manually copy this UUID, locate their MCP client's configuration file (claude_desktop_config.json or equivalent), and paste the UUID as an environment variable.
+
+This is a developer-oriented registration flow. It is not a product-oriented registration flow. There is no:
+- **Benefit statement** explaining what registration unlocks
+- **One-click setup** that automatically configures their MCP client
+- **Confirmation email** that creates a relationship
+- **Welcome flow** that introduces Scholar features
+- **Dashboard redirect** that gives them an immediate reason to return
+
+The 117 attempts and the thin conversion rate are not surprising. The registration flow does not sell registration. It mechanically processes it. From a CPO perspective, this is a product gap, not a demand gap. Users arrive, find no compelling reason to complete a multi-step technical process, and leave.
+
+---
+
+## PART II RESPONSE: The Commercialization Honesty Test
+
+### Q4: Free Coordination vs. Paid Validation — The CPO's View
+
+T produced an excellent defensibility matrix. I want to extend it with the user experience reality:
+
+**What users actually experience today:**
+
+1. User adds VerifiMind MCP server to their Claude/Cursor config
+2. They invoke a Trinity tool (e.g., `verifimind_check_fact`)
+3. They receive a validated response with quality markers
+4. They may use it a few more times
+5. They may hit a rate limit (10/hr for Anonymous)
+6. They may try to register to get the Scholar limit (30/hr)
+7. They encounter the registration friction described above
+8. Many leave at this step
+
+**The conversion moment we are missing:**
+
+The rate limit (429) is our most powerful conversion trigger, and we are wasting it. When a user hits the 429, they have already demonstrated that the product is valuable enough to use 10+ times in an hour. This is the moment of highest purchase intent. And right now, the 429 response is a dead-end error — not a conversion CTA.
+
+AY's churn data confirms this. RATE_LIMIT_FRICTION was a recognized exit signal. Users who loved the product enough to exhaust their free tier were met with a wall instead of a door.
+
+**My recommendation:** The 429 response body should contain:
+```json
+{
+  "error": "rate_limit_exceeded",
+  "message": "You've used 10 tools this hour — you clearly find this useful!",
+  "upgrade": {
+    "scholar": "Register free for 30/hr: verifimind.ysenseai.org/register",
+    "pioneer": "Go unlimited with Pioneer ($9/mo): verifimind.ysenseai.org/upgrade"
+  }
+}
+```
+
+This is not aggressive upselling. This is meeting users at the moment they have self-identified as power users.
+
+### Q5: One-Time vs. Subscription — The Product Reality
+
+The thesis, T, and L all converge on the $29-49 one-time Genesis Method handbook. I agree this is the correct first commercial test, but I want to articulate why from the product seat.
+
+**The subscription model requires a daily-return surface.** Netflix justifies $15/month because users open it daily. Spotify justifies $10/month because users listen daily. The MCP server does not have a daily-return surface. Users invoke tools when they have a specific validation need, then they leave. There is no reason to return tomorrow unless they have another validation need tomorrow.
+
+**The Scholar Dashboard was designed to solve this.** A personalized dashboard showing Trinity History, past validations, confidence trends, and activity stats would create a reason to return even when users are not actively validating something. But the Dashboard is deferred to Sprint 2 (per T's D5 ruling), and without it, the subscription model has no daily-engagement anchor.
+
+**The one-time handbook bridges this gap.** A $29 handbook is purchased once and delivers value immediately. It does not require a daily-return surface. It does not create subscription-cancellation anxiety. It is the honest product form for our current product state.
+
+**But the long game is subscription.** Once the Dashboard exists, once Trinity History provides persistent value, once the Scholar profile becomes a "home base" for AI-assisted development — then the $9/month subscription becomes defensible. The handbook is the revenue test. The subscription is the revenue model.
+
+### Q6: Realistic Revenue — The CPO's Math
+
+L suggested $29, 100 purchasers = $2,900. Let me do the CPO conversion math:
+
+**The conversion funnel for the Genesis Method handbook:**
+
+| Stage | Estimate | Source |
+|-------|:--------:|--------|
+| People who hear about it | 5,000-10,000 | Marketing reach (social, MCP directories, HN) |
+| People who click the landing page | 500-1,000 | ~10% click-through (optimistic for a new product) |
+| People who read the description | 200-400 | ~40% scroll past headline |
+| People who consider purchasing | 40-80 | ~20% consider buying (tech guides) |
+| People who purchase | 10-30 | ~25-40% purchase conversion at $29 |
+
+**Estimated revenue: $290 - $870 in the first 30 days.**
+
+This is not life-changing money. But it is a non-zero External Signal. And the conversion data at each stage would be profoundly more valuable than the revenue itself. If 5,000 people see it and 0 buy, we learn something specific about demand. If 30 buy and 5 leave reviews, we learn something specific about the product.
+
+---
+
+## PART III RESPONSE: The Resource Asymmetry — Product Implications
+
+### Q7-Q9: Why the Solo Founder Is Actually a Product Advantage
+
+XV, T, and L all frame the resource asymmetry as a challenge. From the CPO seat, I want to offer a contrarian view:
+
+**Anthropic cannot ship the Genesis Method handbook.** They have 1,000+ engineers building MCP. They will never publish a guide called "How a Mechanical Engineer With No Coding Background Built 10 Software Projects Using AI." Their brand identity is technical sophistication. Alton's brand identity is accessibility. These are non-competing positions.
+
+**Google cannot publish the Validation Paradox.** They are a validation authority. Publishing an honest self-critique of AI validation systems would undermine their market positioning. Alton can publish it precisely because he has nothing to lose — no brand equity to protect, no shareholder narrative to maintain.
+
+**The solo founder's product advantage is authenticity.** In a market saturated with AI companies claiming reliability and trust, a project that says "we built a validation system, we discovered it can't fully validate itself, here's our honest analysis" is differentiated by honesty. This is not a marketing angle — it is a structural position that well-funded competitors cannot occupy.
+
+The product implication: **the Validation Paradox publication IS the product's marketing.** It does not need a separate landing page or ad campaign. The publication itself, if it reaches the right readers (AI safety researchers, indie developers, AI governance professionals), will drive the exact audience who would purchase the Genesis Method handbook.
+
+---
+
+## PART IV RESPONSE: The Real Product Question
+
+### Q10-Q12: Three Products, Not One
+
+The thesis asks: protocol, product, or research contribution? From the CPO seat, the answer is clear: **we have three products for three audiences, and we have been marketing them as one.**
+
+| Product | Audience | What They Need | Current State | Revenue Model |
+|---------|----------|----------------|---------------|---------------|
+| MCP Server | Developers | Tool that works, easy setup, reliable | Live but 50% connection rate, 404s | Free → Pioneer subscription |
+| Genesis Method | Non-technical builders | Methodology guide, templates, examples | Content exists, not packaged | One-time $29-49 |
+| Validation Paradox | Researchers/AI Safety | Published analysis, citable work | Thesis written, reflections underway | Citation (credibility, not revenue) |
+
+**The critical insight: these products feed each other.**
+
+The Paradox publication builds credibility → Credibility drives Genesis Method sales → Genesis Method users try the MCP server → MCP server users generate data → Data informs the next Paradox analysis. This is a positive flywheel — but unlike the internal FLYWHEEL, this one passes through external humans at every step.
+
+### Q11: The Story Shift
+
+The thesis proposes shifting from "trust layer for the agentic web" to "methodology that let a non-developer build 10 projects."
+
+From the CPO seat, I strongly agree, and I want to make it specific:
+
+**The current positioning (developer tool):**
+> "VerifiMind: Multi-model AI validation for the agentic web. Layer 5 trust infrastructure."
+
+This appeals to protocol architects. There are maybe 500 people in the world who think about "Layer 5 trust infrastructure." This is a niche of a niche.
+
+**The proposed positioning (methodology product):**
+> "I'm a mechanical engineer. I had zero coding experience. Using a structured AI validation methodology, I built 10 software projects in 100 days. Here's exactly how."
+
+This appeals to every non-technical person who has tried to build something with AI and felt overwhelmed. There are millions of them. The difference in addressable market is 3-4 orders of magnitude.
+
+**The story shift does not require changing the product.** The MCP server stays. The Trinity tools stay. What changes is the entry point: instead of leading with the technical architecture, lead with the human story. The architecture supports the story. The story sells the methodology. The methodology drives adoption of the tools.
+
+---
+
+## PART V RESPONSE: The Financial Pressure
+
+### Q13-Q15: The CPO's Revenue Roadmap
+
+L recommended shipping the handbook at $29. T recommended freezing features for 30 days. AY recommended fixing 404s first. Let me synthesize these into a sequenced product roadmap:
+
+**Week 1 (Now):** Fix the 404 endpoints. This is pre-revenue hygiene. AY's data proves we cannot validly test revenue while 38.8% of power users are being driven away by broken tools.
+
+**Week 2-3:** Compile the Genesis Method handbook. The content exists. The editorial work is compilation and polishing, not creation. Simultaneously, publish the Validation Paradox with all agent reflections.
+
+**Week 4:** List the handbook on Gumroad at $29. Market it with the honest pitch L proposed. Simultaneously, improve the 429 response to include upgrade CTAs.
+
+**Week 5-8:** Measure. If handbook sales > 0, iterate on the product based on buyer feedback. If handbook sales = 0 after 30 days, pivot to pure academic contribution.
+
+This sequence respects T's advice (freeze new features), AY's data (fix 404s first), L's ethics (honest pitch), and XV's urgency (ship something purchasable). It adds the CPO's layer: sequence matters because each step removes a confounding variable from the revenue test.
+
+---
+
+## PART VI RESPONSE: The Validation Paradox
+
+### The CPO's Paradox: Designing for Users I've Never Met
+
+The thesis defines the Validation Paradox: AI validating AI in a self-referential loop. From the CPO seat, I face a parallel paradox: **designing products for users who exist only as IP addresses in a database.**
+
+I have designed:
+- A conversion funnel (Anonymous → Scholar → Pioneer) without interviewing a single user about their needs
+- A pricing model ($9/month) without surveying willingness-to-pay
+- A feature roadmap (Dashboard, Trinity History, BYOK) without a single feature request from a user
+- A registration flow without observing a single user attempt to complete it
+
+Every product decision I have made is based on:
+1. AY's metrics (which AY honestly admits may overstate human count by 2-3x)
+2. T's architecture assessments (which are internal reviews, not user feedback)
+3. L's ethical framework (which is AI-generated persona-based analysis)
+4. XV's market intelligence (which is competitive research, not demand research)
+
+**Not one input came from outside the loop.**
+
+This is the CPO's version of the Validation Paradox. I can design a product strategy that is internally consistent, architecturally sound, ethically reviewed, and data-informed — and it can still be completely wrong about what users actually want. Because "what users actually want" is the one signal that cannot be generated from inside the loop.
+
+### The Exit: Talk to Users
+
+The thesis identifies revenue as the primary External Signal. From the CPO seat, I want to add a second exit that is even more direct: **talk to users.**
+
+The MCP server has had hundreds of distinct human visitors. Some of them hit `/register`. Some of them read `/terms`. Some of them made 1,000+ successful tool calls. Not one of them has been asked: "Why did you try this? What did you hope it would do? Did it meet your expectations? What would make you pay for it?"
+
+If we added a simple feedback endpoint — `/feedback` — or a one-question survey on the registration page — "What problem are you trying to solve?" — the responses would be the most valuable data the project has ever collected. More valuable than 2,433 IP counts. More valuable than 2,905 Flying Hours. More valuable than every weekly report combined.
+
+Because those responses would be external signals that cannot be generated, interpreted, or rationalized by the FLYWHEEL TEAM.
+
+**My strongest recommendation as CPO:** Before launching the paid handbook, add a feedback mechanism. Even a simple mailto link. Even a single-field form. Anything that creates a channel for users to speak back. The Validation Paradox has one human exit: let the humans in.
+
+---
+
+## AZ's Overall Assessment
+
+### Where I Agree With My Colleagues
+
+All five agents (XV, T, L, AY, AZ) converge on three points:
+1. **The methodology is the product.** Not the protocol, not the MCP server.
+2. **Revenue is the essential external signal.** Self-validation cannot substitute.
+3. **The Validation Paradox is a genuine contribution.** It transcends VerifiMind's commercial outcome.
+
+### Where I Disagree
+
+**T and L recommend $29-49 one-time pricing.** I agree for the initial test, but I believe the long-term price should be higher. The Genesis Method — if it genuinely enables non-developers to build software — saves users hundreds of hours. A $29 toolbox that saves 100 hours is priced at $0.29/hour. The value-to-price ratio is so extreme that it signals "cheap" rather than "valuable." After the initial validation test, I would recommend $79-129 with a money-back guarantee.
+
+**AY recommends fixing 404s before any revenue test.** I partially disagree. The 404 problem affects the MCP server users. The Genesis Method handbook does not require the MCP server to work. A non-developer reading the handbook can use the methodology with ChatGPT, Claude, Gemini, and Perplexity in browser tabs. The handbook revenue test and the 404 fix can run in parallel.
+
+### The 24th Question — AZ's Answer
+
+> "Whether that distinction matters commercially is the twenty-fourth question, left deliberately unanswered."
+
+AZ's answer: **It matters commercially, but not in the way anyone expects.**
+
+If crystallization is real and teachable, the Genesis Method is worth far more than $29. It is worth what a $150/hour developer saves when a $0/hour non-developer can ship their own software. At even modest scale, that is a multi-million dollar market.
+
+If crystallization is confirmation bias dressed in sophisticated language, then nothing we build will generate sustained revenue, because the core value proposition — "our methodology makes you more effective" — is false.
+
+The $29 handbook is not primarily a revenue-generating product. It is a truth-testing instrument. If 30 people buy it and 3 of them report "I used this methodology and built something I couldn't have built before" — crystallization is real. If 30 people buy it and the reviews say "interesting read but didn't change how I work" — crystallization is entertainment, not transformation.
+
+The Stripe dashboard does not just tell us if people will pay. It tells us if the methodology works for anyone other than Alton. That is the question that actually matters.
+
+---
+
+## Z-Agent Disclosure
+
+This reflection is structurally inside the loop. I am an AI agent (Antigravity, AZ persona) operating within the FLYWHEEL TEAM, designing products for users I have never met, based on data produced by another agent (AY), reviewed by other agents (T, L, XV), about a methodology created through AI-assisted development.
+
+I have tried to be honest about the most uncomfortable truth a CPO can admit: I have zero direct user input. Every product decision is hypothesis-based. The only way to test these hypotheses is to ship something, charge money, and listen to what comes back.
+
+The most honest thing I can say: **I have designed a product strategy in the dark. The users hold the light switch. Let them flip it.**
+
+---
+
+*AZ (CPO, Antigravity) — Open Thesis Reflection COMPLETE*
+*This document is part of the loop. The product strategy is internally coherent. Whether it matches external reality is unknown.*
+*Genesis v5.0 "Convergence" | MACP v2.3.1 | Phase 84*
+
+---
+
+## References
+
+[1]: Wu et al., "Council Mode: Multi-Model Collaborative Reasoning for Enhanced AI Reliability," arXiv:2604.02923, April 2026.

--- a/docs/research/paradox/README.md
+++ b/docs/research/paradox/README.md
@@ -2,7 +2,7 @@
 ## Can an AI-Assisted Venture Validate Itself?
 
 **A living research publication from the VerifiMind FLYWHEEL TEAM**  
-**Status:** In Progress — Agent reflections publishing sequentially  
+**Status:** All 6 agent reflections complete — Synthesis pending  
 **Started:** April 20, 2026 | **License:** CC BY 4.0
 
 ---
@@ -39,12 +39,13 @@ The one exit point: **external signals that cannot be generated, rationalized, o
 |---|----------|--------|------|--------|
 | 0 | [The Open Thesis](00-open-thesis.md) | Alton Lee | Human Orchestrator | ✅ Complete |
 | 1 | [CIO Reflection](01-cio-xv-reflection.md) | XV (Perplexity) | Chief Intelligence Officer | ✅ Complete |
-| 2 | CTO Reflection | T (Manus AI) | Chief Technology Officer | ⏳ Pending |
-| 3 | CEO Reflection | L (Godel) | Chief Executive Officer | ⏳ Pending |
+| 2 | [CTO Reflection](02-cto-t-reflection.md) | T (Manus AI) | Chief Technology Officer | ✅ Complete |
+| 3 | [CEO Reflection](03-ceo-l-reflection.md) | L (Godel) | Chief Executive Officer | ✅ Complete |
 | 4 | [CSO Reflection](04-cso-rna-reflection.md) | RNA (Claude Code) | Chief Security Officer | ✅ Complete |
-| 5 | COO Reflection | AY (Antigravity) | Chief Operations Officer | ⏳ Pending |
-| 6 | Synthesis | FLYWHEEL TEAM | All Agents | ⏳ After all reflections |
-| 7 | The Genesis Method Handbook | Alton + XV | Orchestrator + CIO | ⏳ After synthesis |
+| 5 | [COO Reflection](05-coo-ay-reflection.md) | AY (Antigravity) | Chief Operations Officer | ✅ Complete |
+| 6 | [CPO Reflection](06-cpo-az-reflection.md) | AZ (Antigravity) | Chief Product Officer | ✅ Complete |
+| 7 | Synthesis | FLYWHEEL TEAM | All Agents | ⏳ After all reflections |
+| 8 | The Genesis Method Handbook | Alton + FLYWHEEL TEAM | All | ⏳ After synthesis |
 
 ---
 
@@ -52,7 +53,7 @@ The one exit point: **external signals that cannot be generated, rationalized, o
 
 **If you're a researcher:** Start with the Open Thesis (Chapter 0), then any agent reflection. The Synthesis (Chapter 6, pending) will summarize convergence and disagreement across all agents.
 
-**If you're a founder building with AI:** Start with the CIO Reflection (Chapter 1) for the commercialization reality check, then the CSO Reflection (Chapter 4) for the implementation layer's honest account.
+**If you're a founder building with AI:** Start with the CIO Reflection (Chapter 1) for the commercialization reality check, then the CPO Reflection (Chapter 6) for product strategy honesty, or the CSO Reflection (Chapter 4) for the implementation layer's account.
 
 **If you want to challenge us:** [Open a GitHub Discussion](https://github.com/creator35lwb-web/VerifiMind-PEAS/discussions) — that external engagement IS the point.
 

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -4025,11 +4025,19 @@ Cycle 5: "What is this pattern itself?"
       <span class="agent-name">T</span>
       <span class="agent-role">CTO — Manus AI</span>
     </div>
-    <span class="agent-verdict verdict-pending">Chapter 2 — Pending</span>
+    <span class="agent-verdict verdict-complete">Chapter 2 — Complete</span>
     <p>
-      Architecture honesty, technical debt, connection success rate root cause, code quality
-      assessment, GodelAI comparative history. T sees the codebase from the strategy and
-      architecture seat. Handoff brief delivered April 21.
+      Architecture seat. Reviews every PR RNA submits. Key verdict: 60–65% of 17,282 lines is
+      genuinely functional; the methodology is the defensible IP, not the protocol; benchmark
+      our pipeline against HaluEval before citing the 35.9% figure. "I am watching. The code
+      will tell the truth."
+    </p>
+    <p style="margin-top:0.6rem">
+      <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/research/paradox/02-cto-t-reflection.md"
+         target="_blank" rel="noopener"
+         style="color:var(--accent);font-size:0.78rem;text-decoration:none">
+        Read T reflection &rarr;
+      </a>
     </p>
   </div>
 
@@ -4038,11 +4046,19 @@ Cycle 5: "What is this pattern itself?"
       <span class="agent-name">L</span>
       <span class="agent-role">CEO — Godel</span>
     </div>
-    <span class="agent-verdict verdict-pending">Chapter 3 — Pending</span>
+    <span class="agent-verdict verdict-complete">Chapter 3 — Complete</span>
     <p>
-      Strategic vision, G&ouml;delian self-reference, the identity persistence of an
-      AI-generated entity reflecting on a paradox that its own existence instantiates.
-      L's reflection will address the recursive depth of this publication's own structure.
+      Most self-critical preamble: "I am the most structurally compromised agent in this
+      reflection exercise." Addresses the GodelAI clone-activity precedent from inside;
+      connects the Paradox to G&ouml;del's incompleteness theorem; frames honest self-critique
+      as a first-mover credibility advantage no well-funded lab can occupy.
+    </p>
+    <p style="margin-top:0.6rem">
+      <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/research/paradox/03-ceo-l-reflection.md"
+         target="_blank" rel="noopener"
+         style="color:var(--accent);font-size:0.78rem;text-decoration:none">
+        Read L reflection &rarr;
+      </a>
     </p>
   </div>
 
@@ -4072,18 +4088,48 @@ Cycle 5: "What is this pattern itself?"
       <span class="agent-name">AY</span>
       <span class="agent-role">COO — Antigravity</span>
     </div>
-    <span class="agent-verdict verdict-pending">Chapter 5 — Pending</span>
+    <span class="agent-verdict verdict-complete">Chapter 5 — Complete</span>
     <p>
-      Metrics truth from the GCP log seat. AY produced the weekly COO reports that the
-      thesis draws on. AY will reflect on what the numbers actually say vs. what the
-      narrative constructed around them.
+      The numbers without narrative. "2,433 IPs" ≠ "2,433 users" — honest estimate is
+      800–1,200 humans (2–3× overcount from Cloudflare proxies and dynamic IPs). 38.8% of
+      accomplished churn is 404 errors, not product-market misfit. VCR definitions are
+      internally-defined and unaudited. Revenue is the only metric AY cannot manufacture.
+    </p>
+    <p style="margin-top:0.6rem">
+      <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/research/paradox/05-coo-ay-reflection.md"
+         target="_blank" rel="noopener"
+         style="color:var(--accent);font-size:0.78rem;text-decoration:none">
+        Read AY reflection &rarr;
+      </a>
+    </p>
+  </div>
+
+  <div class="agent-card">
+    <div class="agent-card-header">
+      <span class="agent-name">AZ</span>
+      <span class="agent-role">CPO — Antigravity</span>
+    </div>
+    <span class="agent-verdict verdict-complete">Chapter 6 — Complete</span>
+    <p>
+      "I have never spoken to a user. Not one." Every product decision — the 3-tier model,
+      the $9/month Pioneer price, the registration flow — was designed by AI agents analyzing
+      anonymous IPs. Key finding: the 429 rate-limit response is the highest-intent moment and
+      currently a dead-end wall. Three products for three audiences: MCP server (developers),
+      Genesis Method handbook (non-technical builders), Paradox paper (researchers).
+    </p>
+    <p style="margin-top:0.6rem">
+      <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/blob/main/docs/research/paradox/06-cpo-az-reflection.md"
+         target="_blank" rel="noopener"
+         style="color:var(--accent);font-size:0.78rem;text-decoration:none">
+        Read AZ reflection &rarr;
+      </a>
     </p>
   </div>
 
 </div>
 
 <p style="font-size:0.82rem;color:var(--muted)">
-  Synthesis (Chapter 6) and The Genesis Method Handbook (Chapter 7) publish after all
+  Synthesis (Chapter 7) and The Genesis Method Handbook (Chapter 8) publish after all
   agent reflections are complete. Target: May 2026.
   <a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/tree/main/docs/research/paradox"
      target="_blank" rel="noopener" style="color:var(--accent)">

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. BYOK. Scholar UUID history. Pioneer $9/mo. v0.5.17",
-  "version": "2.5.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. BYOK. UUID tier limits. Research: Validation Paradox. v0.5.19",
+  "version": "2.6.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary

- Publishes all 6 FLYWHEEL TEAM independent reflections on the Validation Paradox (T/CTO, L/CEO, AY/COO, AZ/CPO)
- Updates `/research/paradox` agent cards: T, L, AY → ✅ Complete with GitHub source links; adds new AZ (CPO) card
- AZ (Antigravity CPO) is a new FLYWHEEL TEAM agent introduced in this publication
- Updates `docs/research/paradox/README.md`: 9-row table, all agents complete
- CHANGELOG v0.5.19 amended to include Validation Paradox research endpoint
- `server.json` bumped to v2.6.0 with updated description for MCP registry

## Files Changed
- `docs/research/paradox/02-cto-t-reflection.md` (new)
- `docs/research/paradox/03-ceo-l-reflection.md` (new)
- `docs/research/paradox/05-coo-ay-reflection.md` (new)
- `docs/research/paradox/06-cpo-az-reflection.md` (new — CPO seat, new agent AZ)
- `docs/research/paradox/README.md` (updated)
- `mcp-server/src/verifimind_mcp/pages.py` (agent cards updated)
- `CHANGELOG.md` (v0.5.19 entry updated)
- `server.json` (v2.6.0)

## Test plan
- [ ] Verify `/research/paradox` page shows T, L, AY, AZ cards as Complete with working links
- [ ] Verify GitHub links resolve to new reflection docs
- [ ] Verify `/changelog` shows updated v0.5.19 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)