### PR TITLE
fix(tests): CI now covers all 589 tests — registration tests added, stale assertion fixed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,13 @@ jobs:
         env:
           VERIFIMIND_TEST_MODE: "true"
 
+      - name: Run registration tests
+        run: |
+          cd mcp-server
+          pytest tests/test_registration.py tests/test_registration_ui.py -v --tb=short --no-cov
+        env:
+          VERIFIMIND_TEST_MODE: "true"
+
       - name: Run integration tests
         run: |
           cd mcp-server

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -8,7 +8,7 @@
 
 **v0.5.20 "Root UX + BYOK v0.4.0" deployed successfully on April 27, 2026**
 
-The VerifiMind MCP server is fully operational. All security gates passed. 487 tests, 0 CodeQL medium+ alerts. GCP revision `verifimind-mcp-server-00369-7cf`.
+The VerifiMind MCP server is fully operational. All security gates passed. 510 tests (CI), 0 CodeQL medium+ alerts. GCP revision `verifimind-mcp-server-00369-7cf`.
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination)
 - **BYOK v0.4.0**: Cerebras provider (llama3.1-70b, 1M tokens/day FREE), `claude-sonnet-4-6` / `claude-opus-4-7` defaults, `gpt-4.1-mini` default, smart fallback chain (BYOK → Groq → Cerebras → mock)
@@ -62,7 +62,7 @@ The VerifiMind MCP server is fully operational. All security gates passed. 487 t
 | **GCP Uptime Check** | ✅ Active | 5-minute intervals, email alerts |
 | **Error Rate Alert** | ✅ Active | Threshold: >50 errors in 5 minutes |
 | **Traffic Spike Alert** | ✅ Active | Threshold: >500 requests in 1 hour |
-| **CI/CD Pipeline** | ✅ Passing | Unit tests, Bandit, Safety |
+| **CI/CD Pipeline** | ✅ Passing | 510 tests (CI), Bandit, Safety |
 
 ---
 
@@ -70,7 +70,7 @@ The VerifiMind MCP server is fully operational. All security gates passed. 487 t
 
 | Version | Blind Tests | Gate | Released |
 |---------|-------------|------|---------|
-| **v0.5.20 "Root UX + BYOK v0.4.0"** | CI gate — 487 tests, 0 CodeQL alerts; PRs #168 #169 | ✅ **PASSED** | April 27, 2026 |
+| **v0.5.20 "Root UX + BYOK v0.4.0"** | CI gate — 510 tests, 0 CodeQL alerts; PRs #168 #169 | ✅ **PASSED** | April 27, 2026 |
 | **v0.5.19 "Validation Paradox"** | UUID rate limiter + 404 fixes + research publication | ✅ **PASSED** | April 21, 2026 |
 | **v0.5.14–v0.5.18** | Coordination layer, UUID tracer, Scholar dashboard chain | ✅ **PASSED** | April 2026 |
 | **v0.5.13 "Fortify"** | Security gate — 485 tests, 0 CodeQL alerts, X-Agent 4/4 conditions met | ✅ **PASSED** | April 12, 2026 |

--- a/mcp-server/tests/test_registration.py
+++ b/mcp-server/tests/test_registration.py
@@ -75,7 +75,7 @@ class TestPolicyDocuments:
         assert "opt" in PRIVACY_POLICY.lower()
 
     def test_privacy_policy_version_set(self):
-        assert PRIVACY_POLICY_VERSION == "2.0"  # Updated v0.5.12 — Polar MOR
+        assert PRIVACY_POLICY_VERSION == "2.1"
 
     def test_terms_not_empty(self):
         assert len(TERMS_AND_CONDITIONS) > 100


### PR DESCRIPTION
## Root Cause

Investigation triggered by apparent 15% test count drop between v0.5.19 and v0.5.20.

**Finding: no tests were dropped.** The reported counts (574, 487) were both documentation errors. Actual CI output is 510 passing, identical across both versions.

## Changes

### 1. Registration tests added to CI (`test.yml`)
`test_registration.py` and `test_registration_ui.py` (79 tests) were never executed by CI — `test.yml` only ran `tests/unit/` and `tests/integration/`. These are now a dedicated CI step between unit and integration.

### 2. Stale assertion fixed (`test_registration.py`)
`TestPolicyDocuments::test_privacy_policy_version_set` asserted `PRIVACY_POLICY_VERSION == "2.0"` but `privacy_policy.py` has been `"2.1"` since at least v0.5.12. Was silently broken, hidden by CI exclusion.

### 3. SERVER_STATUS.md corrected
Test count: 487 → **510 (CI)** (493 unit + 17 integration). Post-merge CI will show ~589 once registration tests are included.

## Test plan
- [ ] CI passes with all 3 test steps (unit, registration, integration)
- [ ] New total: ~589 passing across all 3 steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)