### PR TITLE
fix(connector): add iconUrl to /.well-known/mcp-config for Claude.ai connector icon

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -125,6 +125,7 @@ async def mcp_config_handler(request):
         "mcpServers": {
             "verifimind-genesis": {
                 "url": f"{base_url}/mcp/",
+                "iconUrl": f"{base_url}/logo.png",
                 "description": "VerifiMind PEAS Genesis Methodology MCP Server - Multi-Model AI Validation with RefleXion Trinity",
                 "version": SERVER_VERSION,
                 "transport": "streamable-http",


### PR DESCRIPTION
## Problem

Claude.ai extracts the **base domain** from the MCP server URL (`ysenseai.org` from `verifimind.ysenseai.org`) and resolves the connector icon via Google Favicon service:

`https://www.google.com/s2/favicons?domain=ysenseai.org&sz=48`

`ysenseai.org/favicon.ico` returns **404** (the YSenseAI site uses an inline SVG data-URL emoji favicon that Google cannot cache/index). Result: Claude.ai shows a generic placeholder icon instead of the VerifiMind brand logo.

## Fix

Add `iconUrl` field to the `/.well-known/mcp-config` response pointing to `/logo.png`. If Claude.ai reads this endpoint for connector configuration (which it does to get the MCP URL), it may use the explicit `iconUrl` instead of falling back to Google Favicon.

```json
{
  "mcpServers": {
    "verifimind-genesis": {
      "url": "https://verifimind.ysenseai.org/mcp/",
      "iconUrl": "https://verifimind.ysenseai.org/logo.png",
      ...
    }
  }
}
```

`/logo.png` already serves a valid 57KB branded PNG at HTTP 200.

## Remaining gap (requires YSenseAI platform — Alton)

The definitive fix for Google Favicon service is adding a real `/favicon.ico` file to `ysenseai.org` root. Currently the site has only an inline SVG emoji (`🧠`) as its favicon, which Google Favicon service cannot serve. Action needed on `ysense-ai/ysense-core`.

## Test plan
- [ ] CI passes
- [ ] After merge + deploy: `curl -s https://verifimind.ysenseai.org/.well-known/mcp-config | python -c "import json,sys; d=json.load(sys.stdin); print(d['mcpServers']['verifimind-genesis']['iconUrl'])"` returns `https://verifimind.ysenseai.org/logo.png`
- [ ] Remove and re-add the VerifiMind connector in Claude.ai to test if icon updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)