### PR TITLE
chore(version): bump v0.5.23 → v0.5.24 — Cowork Research Publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.24 - Cowork Research Publication (April 30, 2026)
+
+XV's strategic analysis of Anthropic Cowork on 3P, reviewed and approved by L (CEO/Godel), published as a live research document.
+
+### New Research Publication: `/research/cowork`
+- Full 10-section strategic analysis: competitive assessment, China market thesis, the Woozle Effect argument, 4-tier product line, 14 academic and primary sources
+- **Section 5 (Self-Correction as Substance)** — real-time case study of the Validation Paradox exit node: XV's v1.0 error (claimed Cowork was Claude-only) caught by the human Orchestrator, corrected within 24 hours, version-controlled and republished
+- Version history table prominent in the document — v1.0 error preserved, v1.1 correction current
+- CORRECTED callout badge, self-correction highlight box, competitive capability tables
+- SEO meta + Open Graph tags for social sharing
+
+### Research Hub Navigation
+- Featured Cowork Analysis card on `/research` index (accent border, NEW badge, CTA button)
+- 4-pill nav strip across all research pages: Published Research · The Validation Paradox · Cowork Analysis · Evidence Library
+- `/research/index.json` updated to v1.3 with cowork entry
+- Robots.txt + sitemap updated for `/research/cowork`
+
+### Pull Requests
+- PR #193 (Cowork research publication)
+
+---
+
 ## v0.5.23 - BYOK Provider Hardening + Research Navigation (April 30, 2026)
 
 Provider audit and bug fixes from live BYOK testing, plus full interconnection of the Research/Library/Paradox public pages.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -6,11 +6,12 @@
 
 ## Current Status: Operational
 
-**v0.5.23 "BYOK Provider Hardening + Research Navigation" deployed successfully on April 30, 2026**
+**v0.5.24 "Cowork Research Publication" deployed successfully on April 30, 2026**
 
-The VerifiMind MCP server is fully operational. All security gates passed. 631 tests (CI), 0 CodeQL medium+ alerts. GCP revision `verifimind-mcp-server-00393-skq`.
+The VerifiMind MCP server is fully operational. All security gates passed. 631 tests (CI), 0 CodeQL medium+ alerts. GCP revision pending.
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination)
+- **Cowork Research (v0.5.24)**: XV's strategic analysis of Anthropic Cowork on 3P published at `/research/cowork` — 10 sections, self-correction as Section 5 (real-time Validation Paradox case study), L (CEO) approved; 4-pill research nav across all pages
 - **BYOK Hardening (v0.5.23)**: All 7 providers audited — Cerebras key prefix fix (`csk-`), model update (`llama-3.3-70b`), Anthropic JSON fence stripping, Mistral package added, mock transparency (`_warning` field, `"synthetic"` overall_quality)
 - **Research Navigation (v0.5.23)**: `/research`, `/library`, `/research/paradox` fully interlinked with consistent `site-nav` + section pill strips
 - **IP Blocklist (v0.5.22)**: 3 rogue IPs blocked at application layer (T Security Directive 2026-04-27) — AWS IPv6 fuzzing bot, content scraper (2,007 AbuseIPDB reports), unauthorized YellowMCP scanner; `[IP_BLOCKED]` / `[UA_BLOCKED]` audit logging to GCP log stream
@@ -39,7 +40,7 @@ The VerifiMind MCP server is fully operational. All security gates passed. 631 t
 | **Endpoint** | `https://verifimind.ysenseai.org/mcp` |
 | **Health Check** | `https://verifimind.ysenseai.org/health` |
 | **Register** | `https://verifimind.ysenseai.org/register` |
-| **Server Version** | 0.5.23 "BYOK Provider Hardening + Research Navigation" (deployed April 30, 2026) |
+| **Server Version** | 0.5.24 "Cowork Research Publication" (deployed April 30, 2026) |
 | **Transport** | Streamable HTTP (SSE) |
 | **Default Provider** | Gemini 2.5 Flash (FREE) / Groq Llama 3.3 (FREE fallback) |
 | **BYOK Providers** | Gemini, Groq, Cerebras (FREE), OpenAI, Anthropic, Mistral, Ollama |

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -63,7 +63,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.23"
+SERVER_VERSION = "0.5.24"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1799,12 +1799,22 @@ def get_dashboard_page(uuid: str, records: list, firestore_available: bool = Tru
 _CHANGELOG_BODY = """
 <h1>Changelog</h1>
 <div class="meta">
-  <span>Last updated: April 30, 2026</span>
+  <span>Last updated: April 30, 2026 (v0.5.24)</span>
   <span><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/releases" target="_blank" rel="noopener">GitHub Releases</a></span>
 </div>
 
+<div id="v0.5.24">
+<h2>v0.5.24 — Cowork Research Publication <span class="live-badge">LIVE</span></h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 30, 2026</p>
+<ul>
+  <li><strong>Cowork Analysis Published</strong> — XV&rsquo;s 10-section strategic analysis of Anthropic Cowork on 3P at <a href="/research/cowork">/research/cowork</a> (L-approved); corrects v1.0 error inline, with <strong>Section 5 (Self-Correction as Substance)</strong> as the featured section — a real-time Validation Paradox case study</li>
+  <li><strong>Research Hub Navigation</strong> — Featured card on /research index, 4-pill nav strip (Published Research · The Validation Paradox · Cowork Analysis · Evidence Library) across all research pages</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/193" target="_blank" rel="noopener">PR #193</a></li>
+</ul>
+</div>
+
 <div id="v0.5.23">
-<h2>v0.5.23 — BYOK Provider Hardening + Research Navigation <span class="live-badge">LIVE</span></h2>
+<h2>v0.5.23 — BYOK Provider Hardening + Research Navigation</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 30, 2026</p>
 <ul>
   <li><strong>BYOK Fixes</strong> — Cerebras key prefix corrected (<code>csk-</code>), model updated to <code>llama-3.3-70b</code>, Anthropic JSON fence stripping added, Mistral package added to dependencies, mistralai v2.x import path updated</li>

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.23"
+SERVER_VERSION = "0.5.24"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.23"
+        assert http_server.SERVER_VERSION == "0.5.24"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.23", (
+        assert SERVER_VERSION == "0.5.24", (
             f"Expected 0.5.22, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.23"
+        assert SERVER_VERSION == "0.5.24"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.23"
+        assert SERVER_VERSION == "0.5.24"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.23", f"Expected 0.5.22, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.24", f"Expected 0.5.22, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.23", f"Expected 0.5.22, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.24", f"Expected 0.5.22, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -177,4 +177,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.23", f"Expected 0.5.22, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.24", f"Expected 0.5.22, got {SERVER_VERSION}"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. BYOK, UUID tiers, IP blocklist. v0.5.23",
-  "version": "3.0.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. BYOK, UUID tiers, IP blocklist. v0.5.24",
+  "version": "3.1.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary
Version bump for the Cowork Research Publication (PR #193 already merged).

- `SERVER_VERSION` → `0.5.24` in `server.py` + `http_server.py`
- All 7 test assertions updated to `0.5.24`
- `CHANGELOG.md`: v0.5.24 entry
- `SERVER_STATUS.md`: version + feature bullet updated
- `pages.py`: v0.5.24 LIVE badge, v0.5.23 badge removed
- `server.json`: `3.0.0` → `3.1.0`, description updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)