### PR TITLE
fix(security): SonarQube S1313 + S2631 + changelog IP redaction

### DIFF
--- a/mcp-server/src/verifimind_mcp/llm/provider.py
+++ b/mcp-server/src/verifimind_mcp/llm/provider.py
@@ -37,45 +37,29 @@ logger = logging.getLogger(__name__)
 
 
 def strip_markdown_code_fences(text: str) -> str:
-    """
-    Strip markdown code fences from LLM responses.
-
-    Many LLMs wrap JSON output in markdown code blocks like:
-    ```json
-    {...}
-    ```
-
-    This function removes those fences to get clean JSON.
-    Handles cases where text appears before/after the code fence.
-    """
-    import re
+    """Strip markdown code fences from LLM responses to extract clean JSON."""
     text = text.strip()
+    lines = text.splitlines()
 
-    # Method 1: Extract content from ANY code fence in the text (not just at start)
-    # This handles "Here is the analysis:\n```json\n{...}\n```"
-    fence_pattern = r'```(?:json|JSON)?\s*\n([\s\S]*?)\n```'
-    fence_match = re.search(fence_pattern, text)
-    if fence_match:
-        return fence_match.group(1).strip()
+    # Find the first line that opens a code fence (e.g. ```json, ```JSON, ```)
+    open_idx = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('```'):
+            open_idx = i
+            break
 
-    # Method 2: Full fence pattern (strict match — text IS the fence)
-    pattern = r'^```(?:json|JSON)?\s*\n?([\s\S]*?)\n?```\s*$'
-    match = re.match(pattern, text)
-    if match:
-        return match.group(1).strip()
+    if open_idx is None:
+        return text
 
-    # Method 3: Remove leading fence and trailing fence separately
-    if text.startswith('```'):
-        first_newline = text.find('\n')
-        if first_newline != -1:
-            text = text[first_newline + 1:]
-        else:
-            text = re.sub(r'^```(?:json|JSON)?\s*', '', text)
+    # Find the matching closing fence (search backwards so nested fences work)
+    close_idx = None
+    for i in range(len(lines) - 1, open_idx, -1):
+        if lines[i].strip() == '```':
+            close_idx = i
+            break
 
-    if text.rstrip().endswith('```'):
-        text = re.sub(r'\n?```\s*$', '', text)
-
-    return text.strip()
+    content = lines[open_idx + 1 : close_idx] if close_idx is not None else lines[open_idx + 1:]
+    return '\n'.join(content).strip()
 
 
 # ============================================================================

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -24,17 +24,15 @@ logger = logging.getLogger(__name__)
 
 # Blocked IPs — updated by T (CTO) + AY (COO) forensic scans
 # Format: (ip_address, reason_code, date_added, added_by)
-# NOSONAR(python:S1313): these are intentional security controls (attacker IPs),
-# not hardcoded connection endpoints. Git history is the audit trail.
 BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # Erratic Node Bot — 454 req/day, 63% error rate, AWS us-east-1 (IPv6)
-    ("2600:1f18:5a5b:3400:2f1e:c9d2:567b:76bc", "ERRATIC_BOT", "2026-04-27", "T_CTO"),  # NOSONAR(python:S1313)
-    # Content Scraper — AbuseIPDB + VirusTotal flagged, AWS us-west-2
-    ("35.161.55.221", "CONTENT_SCRAPER", "2026-04-27", "T_CTO"),  # NOSONAR(python:S1313)
+    ("2600:1f18:5a5b:3400:2f1e:c9d2:567b:76bc", "ERRATIC_BOT", "2026-04-27", "T_CTO"),
+    # Content Scraper — 2,007 AbuseIPDB reports, VirusTotal flagged, AWS us-west-2
+    ("35.161.55.221", "CONTENT_SCRAPER", "2026-04-27", "T_CTO"),
     # Unauthorized MCP Scanner — YellowMCP, no consent given, Hostinger NL (IPv6)
-    ("2a02:4780:4:2ad9::1", "UNAUTHORIZED_SCANNER", "2026-04-27", "T_CTO"),  # NOSONAR(python:S1313)
-    # Unauthorized MCP Prober — AWS EC2 us-west-1, no UA, repeated HEAD/POST scan
-    ("54.67.34.241", "UNAUTHORIZED_SCANNER", "2026-05-06", "RNA_CSO"),  # NOSONAR(python:S1313)
+    ("2a02:4780:4:2ad9::1", "UNAUTHORIZED_SCANNER", "2026-04-27", "T_CTO"),
+    # Unauthorized MCP Prober — AWS EC2 us-west-1, no UA, 35-min interval HEAD/POST scan (2d, 96 hits)
+    ("54.67.34.241", "UNAUTHORIZED_SCANNER", "2026-05-06", "RNA_CSO"),
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -24,15 +24,17 @@ logger = logging.getLogger(__name__)
 
 # Blocked IPs — updated by T (CTO) + AY (COO) forensic scans
 # Format: (ip_address, reason_code, date_added, added_by)
+# NOSONAR(python:S1313): these are intentional security controls (attacker IPs),
+# not hardcoded connection endpoints. Git history is the audit trail.
 BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # Erratic Node Bot — 454 req/day, 63% error rate, AWS us-east-1 (IPv6)
-    ("2600:1f18:5a5b:3400:2f1e:c9d2:567b:76bc", "ERRATIC_BOT", "2026-04-27", "T_CTO"),
-    # Content Scraper — 2,007 AbuseIPDB reports, VirusTotal flagged, AWS us-west-2
-    ("35.161.55.221", "CONTENT_SCRAPER", "2026-04-27", "T_CTO"),
+    ("2600:1f18:5a5b:3400:2f1e:c9d2:567b:76bc", "ERRATIC_BOT", "2026-04-27", "T_CTO"),  # NOSONAR(python:S1313)
+    # Content Scraper — AbuseIPDB + VirusTotal flagged, AWS us-west-2
+    ("35.161.55.221", "CONTENT_SCRAPER", "2026-04-27", "T_CTO"),  # NOSONAR(python:S1313)
     # Unauthorized MCP Scanner — YellowMCP, no consent given, Hostinger NL (IPv6)
-    ("2a02:4780:4:2ad9::1", "UNAUTHORIZED_SCANNER", "2026-04-27", "T_CTO"),
-    # Unauthorized MCP Prober — AWS EC2 us-west-1, no UA, 35-min interval HEAD/POST scan (2d, 96 hits)
-    ("54.67.34.241", "UNAUTHORIZED_SCANNER", "2026-05-06", "RNA_CSO"),
+    ("2a02:4780:4:2ad9::1", "UNAUTHORIZED_SCANNER", "2026-04-27", "T_CTO"),  # NOSONAR(python:S1313)
+    # Unauthorized MCP Prober — AWS EC2 us-west-1, no UA, repeated HEAD/POST scan
+    ("54.67.34.241", "UNAUTHORIZED_SCANNER", "2026-05-06", "RNA_CSO"),  # NOSONAR(python:S1313)
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1807,8 +1807,9 @@ _CHANGELOG_BODY = """
 <h2>v0.5.26 — Scanner Block + HTTP Compliance <span class="live-badge">LIVE</span></h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 6, 2026</p>
 <ul>
-  <li><strong>IP Blocked:</strong> <code>54.67.34.241</code> — unauthorized AWS EC2 MCP prober (96 hits over 2 days, ~35-min interval, no User-Agent); added to blocklist with <code>UNAUTHORIZED_SCANNER</code> reason</li>
+  <li><strong>Security:</strong> blocked an unauthorized MCP prober identified via GCP forensic analysis; added to IP security layer</li>
   <li><strong>HEAD /mcp/ fix</strong> — added explicit HEAD handler returning 200; previously returned 405 Method Not Allowed (HTTP compliance gap in Mount routing)</li>
+  <li><strong>CORS hardening</strong> — removed <code>allow_credentials</code> wildcard combination (CWE-942)</li>
 </ul>
 </div>
 
@@ -1848,9 +1849,9 @@ _CHANGELOG_BODY = """
 <h2>v0.5.22 — IP Blocklist Security Layer</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">April 30, 2026</p>
 <ul>
-  <li><strong>IP Blocklist Middleware</strong> — 3 rogue IPs blocked at application level (T Security Directive 2026-04-27): AWS IPv6 fuzzing bot (63% error rate), content scraper (2,007 AbuseIPDB reports), unauthorized YellowMCP scanner; 403 response with minimal disclosure</li>
-  <li><strong>X-Forwarded-For Chain Check</strong> — all hops inspected, not just the first (GFE proxy-aware); blocks blocked IPs anywhere in the chain</li>
-  <li><strong>User-Agent Blocklist</strong> — <code>YellowMCP-SecurityScanner</code> substring blocked (case-insensitive); legitimate MCP clients unaffected</li>
+  <li><strong>IP Blocklist Middleware</strong> — application-level IP security layer blocking unauthorized access attempts; 403 response with minimal disclosure; added after GCP forensic analysis</li>
+  <li><strong>X-Forwarded-For Chain Check</strong> — all hops inspected, not just the first (GFE proxy-aware); blocks across the full request chain</li>
+  <li><strong>User-Agent Blocklist</strong> — unauthorized scanner UA patterns blocked (case-insensitive substring match); legitimate MCP clients unaffected</li>
   <li><strong>Audit Logging</strong> — <code>[IP_BLOCKED] ip= reason= path= ua= ts=</code> and <code>[UA_BLOCKED] pattern= ip= path= ua= ts=</code> in GCP log stream for AY forensic analysis</li>
   <li>32 new tests, 574 unit tests pass, 0 CodeQL medium+ alerts</li>
   <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/182" target="_blank" rel="noopener">PR #182</a></li>


### PR DESCRIPTION
## Summary

- **S2631 (ReDoS) — FIXED in code:** Replaced two `[\s\S]*?` regex patterns in `provider.py` (lines 56 & 62) with a line-split parser. The new implementation is O(n) with zero backtracking risk. All 3 existing \`TestStripMarkdownCodeFences\` tests pass.
- **Changelog IP redaction — FIXED in code:** Removed blocked IP and attack timing details from the public \`/changelog\` page (v0.5.26 and v0.5.22 entries). Exposing your blocklist publicly tells attackers which IPs are flagged — replaced with generic security improvement descriptions.
- **S1313 (hardcoded IP) — ACTION REQUIRED in SonarCloud UI:** \`# NOSONAR\` does NOT suppress Security Hotspots (only Issues). Adding inline comments touched the IP lines, causing SonarCloud to treat previously-acknowledged hotspots as 4 new unreviewed ones — worsening the quality gate. The correct resolution is to open [SonarCloud → Security Hotspots](https://sonarcloud.io/project/security_hotspots?id=creator35lwb-web_VerifiMind-PEAS) and mark all 4 ip_blocklist.py entries as **"Safe"** (they are intentional security controls, not connection endpoints).

## Action required before merge

- [ ] Open SonarCloud → Security Hotspots for this PR and mark all 4 \`ip_blocklist.py\` hotspots as **"Safe"**
- [ ] Quality Gate will pass once those 4 are reviewed

## Test plan

- [x] \`TestStripMarkdownCodeFences\` — 3/3 pass (fence strip, fence with preamble, no fence)
- [x] \`TestScannerIPBlock\` — 5/5 pass (IP in blocklist, reason, date, set, count)
- [x] \`TestIPBlocklistMiddlewareDispatch\` — all dispatch tests pass
- [x] CI green required before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)