### PR TITLE
feat(option-b): paywall removed — all 13 tools free (v0.5.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.28 - Tools Free (May 10, 2026)
+
+Option B refactor PR1 of 3 — paywall removal. The three coordination tools (`coordination_handoff_create`, `coordination_handoff_read`, `coordination_team_status`) are now free for everyone, fulfilling the **Core Tools Always Free pledge** ratified May 9, 2026 by L (CEO) + Alton + T (CTO).
+
+### Behavior changes
+- `pioneer_key` parameter on all three coordination tools changed from required to optional (`Optional[str] = None`)
+- Tool-blocking middleware removed: `check_tier()` is now used for tier identity (analytics) only, not as a gate
+- Anonymous callers (no `pioneer_key`) are accepted; their handoffs go to a shared `"anonymous"` namespace
+- Existing pioneer_key holders unchanged: their handoffs remain privately namespaced under their key
+
+### What did NOT change
+- Rate limiting (deferred to PR2 pending T's clarification on per-hour vs per-minute units — see Issue #59)
+- Polar product structure (deferred to PR3)
+- All other 10 tools (Trinity + template management) — already free, no change
+- `tier_gate_error()` and `tier_gate.py` module retained for backward compat (now unused by tools)
+
+### Tests
+- 92/92 coordination + scholar incentives tests pass
+- `tier_gate_error()` direct-call tests still pass (function preserved)
+
+---
+
 ## v0.5.27 - Version Alignment (May 10, 2026)
 
 Credibility fix flagged by the External Model Council: the `/mcp/` initialize response advertised the FastMCP library version (`3.2.4`) instead of our application version, creating a confusing mismatch with `/health` (`0.5.26`) and `/.well-known/mcp-config` (`0.5.26`).

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -6,11 +6,12 @@
 
 ## Current Status: Operational
 
-**v0.5.27 "Version Alignment" — credibility fix deployed May 10, 2026**
+**v0.5.28 "Tools Free" — Core Tools Always Free pledge fulfilled, deployed May 10, 2026**
 
-The VerifiMind MCP server is fully operational. All security gates passed. GCP revision `verifimind-mcp-server-00407-72z` (will be bumped on v0.5.27 deploy).
+The VerifiMind MCP server is fully operational. All security gates passed. GCP revision `verifimind-mcp-server-00410-g9q` (will be bumped on v0.5.28 deploy).
 
-- 13 MCP tools (4 core Trinity + 6 template management + 3 coordination)
+- 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Tools Free (v0.5.28)**: Option B refactor PR1 of 3 — paywall removed from the 3 coordination tools (`coordination_handoff_create`, `coordination_handoff_read`, `coordination_team_status`). `pioneer_key` is now optional; anonymous callers are namespaced under `"anonymous"`. Fulfills Core Tools Always Free pledge ratified May 9, 2026 by L + Alton + T — May 10, 2026
 - **Version Alignment (v0.5.27)**: `/mcp/` `serverInfo.version` now reports application version (0.5.27) instead of FastMCP library version (3.2.4); all four version-reporting surfaces consistent. P0 credibility fix per External Model Council review (Claude Opus 4.7 + GPT-5.5 + Gemini 3.1 Pro) — May 10, 2026
 - **SSRF Scanner Block (v0.5.26 patch)**: `195.178.110.157` (AS48090 Techoff SRV; 90-req scan, 18 SSRF probes targeting cloud IMDS) added as 5th IP blocklist entry — May 7, 2026
 - **Scanner Block + HTTP Compliance (v0.5.26)**: `54.67.34.241` (AWS EC2 us-west-1 unauthorized prober, 96 hits/2d) added to IP blocklist; HEAD `/mcp/` fixed — returns 200 with proper headers (was 405)
@@ -44,7 +45,7 @@ The VerifiMind MCP server is fully operational. All security gates passed. GCP r
 | **Endpoint** | `https://verifimind.ysenseai.org/mcp` |
 | **Health Check** | `https://verifimind.ysenseai.org/health` |
 | **Register** | `https://verifimind.ysenseai.org/register` |
-| **Server Version** | 0.5.27 "Version Alignment" (deployed May 10, 2026) |
+| **Server Version** | 0.5.28 "Tools Free" (deployed May 10, 2026) |
 | **Transport** | Streamable HTTP (SSE) |
 | **Default Provider** | Gemini 2.5 Flash (FREE) / Groq Llama 3.3 (FREE fallback) |
 | **BYOK Providers** | Gemini, Groq, Cerebras (FREE), OpenAI, Anthropic, Mistral, Ollama |

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.27"
+SERVER_VERSION = "0.5.28"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1799,12 +1799,22 @@ def get_dashboard_page(uuid: str, records: list, firestore_available: bool = Tru
 _CHANGELOG_BODY = """
 <h1>Changelog</h1>
 <div class="meta">
-  <span>Last updated: May 10, 2026 (v0.5.27)</span>
+  <span>Last updated: May 10, 2026 (v0.5.28)</span>
   <span><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/releases" target="_blank" rel="noopener">GitHub Releases</a></span>
 </div>
 
+<div id="v0.5.28">
+<h2>v0.5.28 — Tools Free <span class="live-badge">LIVE</span></h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 10, 2026</p>
+<ul>
+  <li><strong>Core Tools Always Free pledge fulfilled</strong> — the three coordination tools (<code>coordination_handoff_create</code>, <code>coordination_handoff_read</code>, <code>coordination_team_status</code>) are now free for everyone; <code>pioneer_key</code> parameter is optional and used for namespace identity only, never as a gate</li>
+  <li><strong>Anonymous callers welcome</strong> — handoffs without a <code>pioneer_key</code> go to a shared <code>"anonymous"</code> namespace; existing keyed callers unchanged</li>
+  <li><strong>Option B refactor PR1 of 3</strong> — ratified May 9, 2026 by L (CEO) + Alton + T (CTO). PR2 (rate limit table) and PR3 (Polar product reshape for L3 reports) follow.</li>
+</ul>
+</div>
+
 <div id="v0.5.27">
-<h2>v0.5.27 — Version Alignment <span class="live-badge">LIVE</span></h2>
+<h2>v0.5.27 — Version Alignment</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 10, 2026</p>
 <ul>
   <li><strong>MCP serverInfo.version fix</strong> — <code>/mcp/</code> initialize response now reports our application version (0.5.27) instead of the underlying FastMCP library version; eliminates trust-friction signal flagged by External Model Council (Claude Opus 4.7 + GPT-5.5 + Gemini 3.1 Pro)</li>

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.27"
+SERVER_VERSION = "0.5.28"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (
@@ -1402,14 +1402,14 @@ def _create_mcp_instance():
         artifacts: list,
         pending: list,
         blockers: list,
-        pioneer_key: str,
+        pioneer_key: Optional[str] = None,
         next_agent: Optional[str] = None,
         ctx: Context = None,
     ) -> dict:
         """
         Create a structured MACP v2.2 handoff record.
 
-        Pioneer tier tool — requires pioneer_key.
+        Free for everyone (Option B, May 9 2026 — Core Tools Always Free pledge).
 
         Generates a MACP v2.2 compliant handoff document and stores it in
         the coordination layer. Returns the formatted markdown content
@@ -1423,22 +1423,24 @@ def _create_mcp_instance():
             artifacts: List of artifact paths or descriptions created.
             pending: List of pending items for the next agent.
             blockers: List of current blockers (empty list if none).
-            pioneer_key: Your Pioneer tier access key.
+            pioneer_key: Optional access key. If provided, your handoffs are namespaced
+                privately under this key. If omitted, handoffs go to the shared
+                "anonymous" namespace.
             next_agent: Recommended next agent ID (optional).
 
         Returns:
             Handoff record with filename, content, and storage confirmation.
         """
-        from .middleware.tier_gate import check_tier, tier_gate_error, sanitize_handoff_content
+        from .middleware.tier_gate import check_tier, sanitize_handoff_content
         from .coordination import get_store, format_handoff_markdown
         from .coordination.handoff_store import build_handoff_record
 
-        allowed, tier = await check_tier(pioneer_key)
-        if not allowed:
-            return wrap_response(tier_gate_error())
+        # Tier identity for analytics (no longer a gate — Option B, May 9 2026)
+        _, tier = await check_tier(pioneer_key or "")
+        namespace = pioneer_key.strip() if pioneer_key and pioneer_key.strip() else "anonymous"
 
-        # AZ UUID Bridge: emit pioneer_key to stdout for AY analytics ingestion (v0.5.12)
-        print(f"TRACER_UUID: {pioneer_key} tool=coordination_handoff_create", flush=True)
+        # AZ UUID Bridge: emit namespace to stdout for AY analytics ingestion (v0.5.12)
+        print(f"TRACER_UUID: {namespace} tool=coordination_handoff_create", flush=True)
 
         try:
             record = build_handoff_record(
@@ -1456,7 +1458,7 @@ def _create_mcp_instance():
             record["content"] = content
 
             store = get_store()
-            store.add(pioneer_key, record)
+            store.add(namespace, record)
 
             return wrap_response({
                 "status": "success",
@@ -1483,7 +1485,7 @@ def _create_mcp_instance():
 
     @app.tool()
     async def coordination_handoff_read(
-        pioneer_key: str,
+        pioneer_key: Optional[str] = None,
         agent_id: Optional[str] = None,
         count: int = 1,
         ctx: Context = None,
@@ -1491,33 +1493,35 @@ def _create_mcp_instance():
         """
         Read the most recent coordination handoff record(s).
 
-        Pioneer tier tool — requires pioneer_key.
+        Free for everyone (Option B, May 9 2026 — Core Tools Always Free pledge).
 
         Retrieves handoff records previously created via coordination_handoff_create.
-        Records are namespaced by pioneer_key — you only see your own handoffs.
+        Records are namespaced by pioneer_key — you only see handoffs created with
+        the same key. Omit pioneer_key to read from the shared "anonymous" namespace.
 
         Args:
-            pioneer_key: Your Pioneer tier access key.
+            pioneer_key: Optional access key. If omitted, reads from the shared
+                "anonymous" namespace.
             agent_id: Filter to handoffs from this agent only (optional).
             count: Number of records to return (default: 1, max: 50).
 
         Returns:
             List of handoff records (most recent first) with full content.
         """
-        from .middleware.tier_gate import check_tier, tier_gate_error
+        from .middleware.tier_gate import check_tier
         from .coordination import get_store
 
-        allowed, tier = await check_tier(pioneer_key)
-        if not allowed:
-            return wrap_response(tier_gate_error())
+        # Tier identity for analytics (no longer a gate — Option B, May 9 2026)
+        _, tier = await check_tier(pioneer_key or "")
+        namespace = pioneer_key.strip() if pioneer_key and pioneer_key.strip() else "anonymous"
 
-        # AZ UUID Bridge: emit pioneer_key to stdout for AY analytics ingestion (v0.5.12)
-        print(f"TRACER_UUID: {pioneer_key} tool=coordination_handoff_read", flush=True)
+        # AZ UUID Bridge: emit namespace to stdout for AY analytics ingestion (v0.5.12)
+        print(f"TRACER_UUID: {namespace} tool=coordination_handoff_read", flush=True)
 
         try:
             count = max(1, min(int(count), 50))
             store = get_store()
-            records = store.get(pioneer_key, agent_id=agent_id, count=count)
+            records = store.get(namespace, agent_id=agent_id, count=count)
 
             return wrap_response({
                 "status": "success",
@@ -1551,13 +1555,13 @@ def _create_mcp_instance():
 
     @app.tool()
     async def coordination_team_status(
-        pioneer_key: str,
+        pioneer_key: Optional[str] = None,
         ctx: Context = None,
     ) -> dict:
         """
         Return current team coordination state and session summary.
 
-        Pioneer tier tool — requires pioneer_key.
+        Free for everyone (Option B, May 9 2026 — Core Tools Always Free pledge).
 
         Aggregates all stored handoff records to provide a snapshot of:
         - Which agents have been active
@@ -1567,24 +1571,25 @@ def _create_mcp_instance():
         - Recommended next actions
 
         Args:
-            pioneer_key: Your Pioneer tier access key.
+            pioneer_key: Optional access key. If omitted, reads from the shared
+                "anonymous" namespace.
 
         Returns:
             Team state summary with agent activity, pending actions, and blockers.
         """
-        from .middleware.tier_gate import check_tier, tier_gate_error
+        from .middleware.tier_gate import check_tier
         from .coordination import get_store
 
-        allowed, tier = await check_tier(pioneer_key)
-        if not allowed:
-            return wrap_response(tier_gate_error())
+        # Tier identity for analytics (no longer a gate — Option B, May 9 2026)
+        _, tier = await check_tier(pioneer_key or "")
+        namespace = pioneer_key.strip() if pioneer_key and pioneer_key.strip() else "anonymous"
 
-        # AZ UUID Bridge: emit pioneer_key to stdout for AY analytics ingestion (v0.5.12)
-        print(f"TRACER_UUID: {pioneer_key} tool=coordination_team_status", flush=True)
+        # AZ UUID Bridge: emit namespace to stdout for AY analytics ingestion (v0.5.12)
+        print(f"TRACER_UUID: {namespace} tool=coordination_team_status", flush=True)
 
         try:
             store = get_store()
-            all_records = store.get_all(pioneer_key)
+            all_records = store.get_all(namespace)
             total = len(all_records)
 
             if not all_records:

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.27"
+        assert http_server.SERVER_VERSION == "0.5.28"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.27", (
-            f"Expected 0.5.27, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.28", (
+            f"Expected 0.5.28, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.27"
+        assert SERVER_VERSION == "0.5.28"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.27"
+        assert SERVER_VERSION == "0.5.28"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.27", f"Expected 0.5.27, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.28", f"Expected 0.5.28, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.27", f"Expected 0.5.27, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.28", f"Expected 0.5.28, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -177,4 +177,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.27", f"Expected 0.5.27, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.28", f"Expected 0.5.28, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.27"
+        assert http_server.SERVER_VERSION == "0.5.28"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.27"
+        assert http_server.SERVER_VERSION == "0.5.28"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. BYOK, UUID tiers, IP blocklist. v0.5.27",
-  "version": "3.4.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. BYOK, UUID tiers. v0.5.28",
+  "version": "3.5.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary

**Option B refactor — PR1 of 3.** Fulfills the **Core Tools Always Free** pledge ratified May 9, 2026 by L (CEO) + Alton (Human Orchestrator) + T (CTO). The 3 coordination tools that were behind a $9/mo Pioneer paywall are now free for everyone.

## What changed

`mcp-server/src/verifimind_mcp/server.py` — three coordination tools:

| Tool | Before | After |
|---|---|---|
| `coordination_handoff_create` | `pioneer_key: str` required, gated | `pioneer_key: Optional[str] = None`, free |
| `coordination_handoff_read` | `pioneer_key: str` required, gated | `pioneer_key: Optional[str] = None`, free |
| `coordination_team_status` | `pioneer_key: str` required, gated | `pioneer_key: Optional[str] = None`, free |

For each tool:
- Removed the gate block: `allowed, tier = await check_tier(pioneer_key); if not allowed: return tier_gate_error()`
- `check_tier()` still called for tier identity (analytics) — never blocks
- Anonymous callers (no `pioneer_key`) → namespaced under `"anonymous"`
- Existing keyed callers unchanged → handoffs remain privately namespaced

## What did NOT change

- **Rate limiting** — deferred to PR2 pending T's clarification (Issue #59) on whether Option B's "calls/hour" table is literal per-hour or meant per-minute
- **Polar product structure** — deferred to PR3 (deactivate $9/mo subscription, create $197/$497/$1,997 report products, repoint webhook from subscription to order events)
- **The other 10 tools** (Trinity + template management) — already free, no change
- `tier_gate_error()` function — retained in tier_gate.py for backward compat, no longer called from tools

## Quorum

| Decision | Status |
|---|---|
| L (CEO) ratification | ✅ May 9, 2026 |
| Alton (Human Orchestrator) | ✅ May 9, 2026 ("YES! go ahead!") |
| T (CTO) | ✅ May 9, 2026 (joint resolution author) |
| RNA (CSO) | ✅ May 10, 2026 (this PR is the executable proof) |
| XV (CIO) | ✅ pledge drafted May 9 |
| AY (COO) | pending acknowledgment |
| AZ (CPO) | pending acknowledgment |

## Test plan

- [x] **252/252 tests pass** across foundation, coordination, scholar incentives, trinity history, polar, rate limiter, inference mode, scanner block, manifest audit, MCP config header, server health
- [x] `check_tier()` tier-identity primitives still work (verified by `tests/unit/test_v0511_coordination.py::TestTierGate`)
- [x] `tier_gate_error()` direct-call test still passes (function preserved)
- [x] No regressions in coordination_handoff store/read/get_all behavior
- [ ] CI: full suite via Bandit + CodeQL + Run Tests + Safety + Security Scan + Server Health + SonarCloud
- [ ] Post-deploy: live test of `coordination_handoff_create` WITHOUT a pioneer_key argument — should succeed and return `tier="scholar"`, namespace="anonymous"

## Version surface alignment

| Surface | v0.5.28 |
|---|---|
| `mcp-server/src/verifimind_mcp/server.py` SERVER_VERSION | ✅ |
| `mcp-server/http_server.py` SERVER_VERSION | ✅ |
| 9 test assertion files | ✅ |
| `CHANGELOG.md` "Tools Free" entry | ✅ |
| `SERVER_STATUS.md` v0.5.28 header | ✅ |
| `pages.py` `_CHANGELOG_BODY` v0.5.28 with LIVE badge | ✅ |
| `server.json` description + version 3.4.0 → 3.5.0 | ✅ |

## Hub references

- Option B resolution: `verifimind-genesis-mcp/.macp/handoffs/20260509_T_L_option_b_resolution.md`
- T→RNA endpoint updates: `verifimind-genesis-mcp/.macp/handoffs/20260509_T_RNA_endpoint_updates.md`
- Issue #59 (rate limit clarification): https://github.com/creator35lwb-web/verifimind-genesis-mcp/issues/59
- Prior P0 work: PR #206 (v0.5.27 version alignment), PR #207 (positioning), PR #208 (README sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)