### PR TITLE
feat(security): block 85.121.126.250 config scanner — v0.5.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.30 - Config Scanner Block (May 12, 2026)
+
+Security hardening: blocked a new config/secret enumeration scanner identified via GCP forensic analysis.
+
+### IP Blocklist Addition
+- **`85.121.126.250`** — Config/Secret Enumeration Scanner. ~25 req/sec on May 11; probed `/api/env`, `/firebase-config.json`, `/swagger.json`, `/openapi.json`, `/.well-known/jwks.json`, `/api/v1/config`, `/api/account`, `/__env.js`, `/__/firebase/init.json`, `/manifest.webmanifest`, and ~20 more secret/config paths. Rotating User-Agents (different browser/OS per request — botnet pattern). Mostly 429-rate-limited but adding to blocklist for defense-in-depth.
+
+### Why blocklist, not Cloud Armor
+Cloud Armor pricing (~$5/mo per policy + per-rule + per-request) is not cost-justified for a solo-builder MCP server. App-layer IP blocklist in `ip_blocklist.py` is free, deployed at the outermost middleware layer, and effective. 6 IPs blocked total.
+
+---
+
 ## v0.5.29 - Growth-First Pages (May 12, 2026)
 
 T (CTO) directive ([handoff](/) 2026-05-12): align GCP-served pages with the strategic pivot ratified May 11 in Session 13/14. All public pages now reflect "Growth First, Monetization Later" — no current paid services, no pricing on display, all 13 tools free for everyone.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -6,11 +6,12 @@
 
 ## Current Status: Operational
 
-**v0.5.29 "Growth-First Pages" — public surfaces aligned with growth-first pivot, deployed May 12, 2026**
+**v0.5.30 "Config Scanner Block" — 6th IP added to blocklist, deployed May 12, 2026**
 
-The VerifiMind MCP server is fully operational. All security gates passed. GCP revision `verifimind-mcp-server-00412-6xs` (will be bumped on v0.5.29 deploy).
+The VerifiMind MCP server is fully operational. All security gates passed. GCP revision `verifimind-mcp-server-00415-5n6` (will be bumped on v0.5.30 deploy).
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Config Scanner Block (v0.5.30)**: `85.121.126.250` added to IP blocklist — config/secret enumeration scanner probed ~25 secret/config paths in 1 second (`/api/env`, `/firebase-config.json`, `/swagger.json`, `/openapi.json`, `/.well-known/jwks.json`, etc.) with rotating user agents. Cost-effective defense for solo builder — Cloud Armor pricing not justified at our scale. 6 IPs blocked total — May 12, 2026
 - **Growth-First Pages (v0.5.29)**: `/terms` → v2.1, `/privacy` → v2.2, `/register` benefit cards updated. All pricing removed from public-facing pages. No current paid services. "Growth First, Monetization Later" pledge now consistent across server and landing page. Polar payment infrastructure preserved for future services — May 12, 2026
 - **Tools Free (v0.5.28)**: Option B refactor PR1 of 3 — paywall removed from the 3 coordination tools (`coordination_handoff_create`, `coordination_handoff_read`, `coordination_team_status`). `pioneer_key` is now optional; anonymous callers are namespaced under `"anonymous"`. Fulfills Core Tools Always Free pledge ratified May 9, 2026 by L + Alton + T — May 10, 2026
 - **Version Alignment (v0.5.27)**: `/mcp/` `serverInfo.version` now reports application version (0.5.27) instead of FastMCP library version (3.2.4); all four version-reporting surfaces consistent. P0 credibility fix per External Model Council review (Claude Opus 4.7 + GPT-5.5 + Gemini 3.1 Pro) — May 10, 2026
@@ -46,7 +47,7 @@ The VerifiMind MCP server is fully operational. All security gates passed. GCP r
 | **Endpoint** | `https://verifimind.ysenseai.org/mcp` |
 | **Health Check** | `https://verifimind.ysenseai.org/health` |
 | **Register** | `https://verifimind.ysenseai.org/register` |
-| **Server Version** | 0.5.29 "Growth-First Pages" (deployed May 12, 2026) |
+| **Server Version** | 0.5.30 "Config Scanner Block" (deployed May 12, 2026) |
 | **Transport** | Streamable HTTP (SSE) |
 | **Default Provider** | Gemini 2.5 Flash (FREE) / Groq Llama 3.3 (FREE fallback) |
 | **BYOK Providers** | Gemini, Groq, Cerebras (FREE), OpenAI, Anthropic, Mistral, Ollama |

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.29"
+SERVER_VERSION = "0.5.30"
 
 # Track server start time for uptime reporting (v0.5.0 health v2)
 _SERVER_START_TIME = time.time()

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -35,6 +35,10 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     ("54.67.34.241", "UNAUTHORIZED_SCANNER", "2026-05-06", "RNA_CSO"),
     # SSRF Scanner — AS48090 Techoff SRV Ltd; 90-req automated scan, 18 SSRF probes targeting cloud IMDS
     ("195.178.110.157", "SSRF_SCANNER", "2026-05-07", "RNA_CSO"),
+    # Config / Secret Enumeration Scanner — ~25 req/sec on May 11; probed /api/env, /firebase-config.json,
+    # /swagger.json, /openapi.json, /.well-known/jwks.json, /api/v1/config, /api/account, /__env.js, etc.
+    # Rotating User-Agents (different browser/OS per request — botnet pattern). Mostly 429-rate-limited.
+    ("85.121.126.250", "CONFIG_SCANNER", "2026-05-12", "RNA_CSO"),
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1738,12 +1738,22 @@ def get_dashboard_page(uuid: str, records: list, firestore_available: bool = Tru
 _CHANGELOG_BODY = """
 <h1>Changelog</h1>
 <div class="meta">
-  <span>Last updated: May 12, 2026 (v0.5.29)</span>
+  <span>Last updated: May 12, 2026 (v0.5.30)</span>
   <span><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/releases" target="_blank" rel="noopener">GitHub Releases</a></span>
 </div>
 
+<div id="v0.5.30">
+<h2>v0.5.30 — Config Scanner Block <span class="live-badge">LIVE</span></h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 12, 2026</p>
+<ul>
+  <li><strong>IP blocked:</strong> <code>85.121.126.250</code> — config/secret enumeration scanner probing <code>/api/env</code>, <code>/firebase-config.json</code>, <code>/swagger.json</code>, <code>/openapi.json</code>, <code>/.well-known/jwks.json</code>, and ~20 more secret/config paths at ~25 req/sec with rotating user agents (botnet pattern)</li>
+  <li><strong>Defense-in-depth:</strong> mostly 429-rate-limited already, but adding to blocklist eliminates server-side processing entirely</li>
+  <li><strong>Cost rationale:</strong> Cloud Armor (~$5/mo + per-rule + per-request) is not cost-justified at solo-builder scale; app-layer blocklist in <code>ip_blocklist.py</code> is free and equally effective. 6 IPs blocked total.</li>
+</ul>
+</div>
+
 <div id="v0.5.29">
-<h2>v0.5.29 — Growth-First Pages <span class="live-badge">LIVE</span></h2>
+<h2>v0.5.29 — Growth-First Pages</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 12, 2026</p>
 <ul>
   <li><strong><code>/terms</code> &rarr; v2.1</strong> — pricing tier table removed (Pioneer row gone); Payment and Refund sections rewritten as forward-looking placeholders; Section 6 (Beta) and Section 8 (Acceptable Use) updated to drop Pioneer-specific language</li>

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.29"
+SERVER_VERSION = "0.5.30"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.29"
+        assert http_server.SERVER_VERSION == "0.5.30"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.29", (
-            f"Expected 0.5.29, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.30", (
+            f"Expected 0.5.30, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.29"
+        assert SERVER_VERSION == "0.5.30"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.29"
+        assert SERVER_VERSION == "0.5.30"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.29", f"Expected 0.5.29, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.30", f"Expected 0.5.30, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.29", f"Expected 0.5.29, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.30", f"Expected 0.5.30, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -177,4 +177,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.29", f"Expected 0.5.29, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.30", f"Expected 0.5.30, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.29"
+        assert http_server.SERVER_VERSION == "0.5.30"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.29"
+        assert http_server.SERVER_VERSION == "0.5.30"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.29",
-  "version": "3.6.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.30",
+  "version": "3.7.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary

Adds the 6th IP to `BLOCKED_IPS` in `ip_blocklist.py` after May 11 forensic observation. Standard pattern from v0.5.22 + v0.5.26-patch.

## Forensics

`85.121.126.250` — 25 requests in 1 second at 22:06-22:07 UTC May 11, 2026:
- `/api/env` · `/.env` · `/__env.js` · `/__/firebase/init.json`
- `/firebase-config.json` · `/config.json` · `/app-config.json` · `/runtime-config.js`
- `/api/account` · `/api/settings` · `/api/v1/config` · `/api/v2/config` · `/api/v1/settings`
- `/swagger.json` · `/openapi.json` · `/api/openapi.json`
- `/.well-known/jwks.json` · `/manifest.webmanifest`
- ~10 more secret/config paths

Rotating User-Agents (iPad, Mac Safari, Pixel 9 Chrome, Windows Chrome, Linux Chrome, iPhone Safari, all different per request — botnet/bot framework simulating real users).

**Rate limiter caught most (429)** — adding blocklist entry eliminates server-side processing entirely.

## Why blocklist, not Cloud Armor

Alton's question (May 12): is Cloud Armor cost-justified for a solo builder?

| Cost component | Estimate |
|---|---|
| Cloud Armor policy | $5/month base |
| Per-rule (each blocked IP/UA is a rule) | $0.75/month each |
| Per-million requests | $0.75 |
| **Total for our 6 IPs + 1 UA** | **~$10-15/month** |

App-layer `ip_blocklist.py`:
- Cost: **$0**
- Latency: ~0.5ms per request (frozenset lookup)
- Maintained alongside the codebase
- Same effectiveness — outermost middleware layer, rejects before any other processing

**Conclusion:** App-layer blocklist remains the right tool. Re-evaluate Cloud Armor only if (a) scale grows 100x, or (b) we get a DDoS attack that exceeds rate-limiter capacity.

## Test plan
- [x] 78/78 tests pass (scanner_block_head, ip_blocklist, foundation, server_health)
- [x] `BLOCKED_IPS` list now has 6 entries
- [x] Surface alignment v0.5.30 across server.py, http_server.py, 9 test asserts, CHANGELOG, SERVER_STATUS, pages.py changelog, server.json
- [ ] CI: Bandit + CodeQL + Run Tests + Safety + Security Scan + Server Health + SonarCloud
- [ ] Post-deploy: curl `https://verifimind.ysenseai.org/health` from blocked IP returns 403 (can't easily verify in PR; tested in unit suite)

## Hub references

- Housekeeping addendum: `verifimind-genesis-mcp/.macp/handoffs/20260512_RNA_housekeeping_addendum.md`
- Prior IP block (v0.5.22): 3 IPs added 2026-04-27
- Prior IP block (v0.5.26): `54.67.34.241` added 2026-05-06
- Prior IP block (v0.5.26 SSRF patch): `195.178.110.157` added 2026-05-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)