### PR TITLE
v0.5.33: Changelog Hygiene — sanitize public /changelog IP disclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the VerifiMind PEAS project will be documented in this fi
 
 Full version history also available at [verifimind.ysenseai.org/changelog](https://verifimind.ysenseai.org/changelog).
 
+> **Disclosure policy (since v0.5.33):** The internal `CHANGELOG.md` retains full forensic details (specific blocked IPs, probe paths, request counts, UA strings) for attribution and audit trail. The public-facing `/changelog` rendered by the server intentionally omits specific IP addresses to avoid signalling to attackers and to keep customer-facing copy clean. PRs and commits remain the canonical source for forensic detail.
+
+---
+
+## v0.5.33 - Changelog Hygiene (May 13, 2026)
+
+Disclosure policy clarification + retroactive sanitization of the public-facing `/changelog` page.
+
+### What changed
+- Sanitized the v0.5.30 and v0.5.32 entries in `mcp-server/src/verifimind_mcp/pages.py` to remove specific blocked-IP addresses from the public surface. Wording now matches the v0.5.22 / v0.5.26 pattern (attack-type only, no specific identifier).
+- Added a "Disclosure policy" header to this internal `CHANGELOG.md` documenting the split: full forensics live here and in PR history; public `/changelog` carries the security narrative without operational leakage.
+- Added a v0.5.33 entry to public `/changelog` explaining the hygiene retroactively (transparency about the fix itself).
+- Added PR# links to v0.5.30 and v0.5.32 public entries (matches v0.5.23 / v0.5.24 pattern).
+
+### Why
+Disclosing specific blocked IPs in a public changelog (a) signals to attackers what triggered the block, (b) tells the blocked actor they're caught and should rotate, (c) looks reactive in customer-facing copy. Internal records keep the full forensic record for attribution; the public surface keeps the trust signal ("we caught it, we blocked it") without operational leakage. This brings v0.5.30 and v0.5.32 in line with the existing v0.5.22 / v0.5.26 disclosure pattern.
+
+### Expected impact
+- Public `/changelog` at `verifimind.ysenseai.org/changelog` no longer surfaces `195.178.110.199` or `85.121.126.250`.
+- Internal `CHANGELOG.md`, PR #213 / #215 bodies, and commit messages continue to carry the full forensic record (these are public on GitHub but require explicit drill-in vs being rendered into the live customer-facing page).
+- No functional / API surface change. Version bump preserves the deploy-tracker convention.
+
 ---
 
 ## v0.5.32 - Secret Scanner Block + SonarCloud P1 (May 13, 2026)

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -6,12 +6,13 @@
 
 ## Current Status: Operational
 
-**v0.5.32 "Secret Scanner Block + SonarCloud P1" — deployed May 13, 2026**
+**v0.5.33 "Changelog Hygiene" — deployed May 13, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed.
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
-- **Secret Scanner Block + SonarCloud P1 (v0.5.32)**: 7th IP `195.178.110.199` blocked — credential/secret enumeration scanner, 788 req single burst on May 12 (probed `.env` variants, `.git/*`, `.terraform.*`, `.stripe/`, `?phpinfo=1`, CI configs). 77% caught by rate limiter; zero leak (4 served 200 = safe root response only). SonarCloud P1 cleanup: extracted `MCP_ENDPOINT_PATH`/`MCP_SERVER_URL`/`MCP_REMOTE_QUICKSTART` constants (removed 13 duplicate literals); refactored `http_exception_handler` cognitive complexity 23 → ≤15; CodeQL `py/empty-except` × 2 resolved; logger.exception() in registration 500 path — May 13, 2026
+- **Changelog Hygiene (v0.5.33)**: Retroactively sanitized public `/changelog` to remove specific blocked-IP addresses from v0.5.30 and v0.5.32 entries; matches v0.5.22 / v0.5.26 disclosure pattern. Full forensics preserved in internal `CHANGELOG.md`, PR bodies, and commit history. Added disclosure-policy header to internal CHANGELOG. PR# links added to public v0.5.30 / v0.5.32 entries — May 13, 2026
+- **Secret Scanner Block + SonarCloud P1 (v0.5.32)**: 7th IP added to application-layer blocklist — credential/secret enumeration scanner, 788 req single burst on May 12 (probed `.env` variants, `.git/*`, `.terraform.*`, `.stripe/`, `?phpinfo=1`, CI configs). 77% caught by rate limiter; zero leak (4 served 200 = safe root response only). SonarCloud P1 cleanup: extracted `MCP_ENDPOINT_PATH`/`MCP_SERVER_URL`/`MCP_REMOTE_QUICKSTART` constants (removed 13 duplicate literals); refactored `http_exception_handler` cognitive complexity 23 → ≤15; CodeQL `py/empty-except` × 2 resolved; logger.exception() in registration 500 path — May 13, 2026
 - **SonarCloud P0 (v0.5.31)**: Resolved 14 SonarCloud Vulnerabilities + 15 BLOCKER severity items per XV's May 12 audit. Workflow permissions scoped to job level; TLS 1.2 explicit minimum; broken `__all__` in templates/library removed; 8 false-positive suppressions with NOSONAR + justification comments; deprecated `datetime.utcnow()` replaced. Expected impact: Security count 14 → 1, BLOCKER 15 → 0 — May 13, 2026
 - **Config Scanner Block (v0.5.30)**: `85.121.126.250` added to IP blocklist — config/secret enumeration scanner probed ~25 secret/config paths in 1 second (`/api/env`, `/firebase-config.json`, `/swagger.json`, `/openapi.json`, `/.well-known/jwks.json`, etc.) with rotating user agents. Cost-effective defense for solo builder — Cloud Armor pricing not justified at our scale. 6 IPs blocked total — May 12, 2026
 - **Growth-First Pages (v0.5.29)**: `/terms` → v2.1, `/privacy` → v2.2, `/register` benefit cards updated. All pricing removed from public-facing pages. No current paid services. "Growth First, Monetization Later" pledge now consistent across server and landing page. Polar payment infrastructure preserved for future services — May 12, 2026
@@ -49,7 +50,7 @@ The VerifiMind MCP server is fully operational. All security gates passed.
 | **Endpoint** | `https://verifimind.ysenseai.org/mcp` |
 | **Health Check** | `https://verifimind.ysenseai.org/health` |
 | **Register** | `https://verifimind.ysenseai.org/register` |
-| **Server Version** | 0.5.32 "Secret Scanner Block + SonarCloud P1" (deployed May 13, 2026) |
+| **Server Version** | 0.5.33 "Changelog Hygiene" (deployed May 13, 2026) |
 | **Transport** | Streamable HTTP (SSE) |
 | **Default Provider** | Gemini 2.5 Flash (FREE) / Groq Llama 3.3 (FREE fallback) |
 | **BYOK Providers** | Gemini, Groq, Cerebras (FREE), OpenAI, Anthropic, Mistral, Ollama |

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.32"
+SERVER_VERSION = "0.5.33"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -1738,20 +1738,30 @@ def get_dashboard_page(uuid: str, records: list, firestore_available: bool = Tru
 _CHANGELOG_BODY = """
 <h1>Changelog</h1>
 <div class="meta">
-  <span>Last updated: May 13, 2026 (v0.5.32)</span>
+  <span>Last updated: May 13, 2026 (v0.5.33)</span>
   <span><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/releases" target="_blank" rel="noopener">GitHub Releases</a></span>
 </div>
 
-<div id="v0.5.32">
-<h2>v0.5.32 — Secret Scanner Block + SonarCloud P1 <span class="live-badge">LIVE</span></h2>
+<div id="v0.5.33">
+<h2>v0.5.33 — Changelog Hygiene <span class="live-badge">LIVE</span></h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 13, 2026</p>
 <ul>
-  <li><strong>IP blocked (7th):</strong> <code>195.178.110.199</code> — credential/secret enumeration scanner, 788 req single burst on May 12 probing <code>.env</code> variants, <code>.git/*</code> tree, <code>.terraform.*</code>, <code>.stripe/</code>, <code>.s3cfg</code>, <code>.wp-config.php.swp</code>, <code>?phpinfo=1</code>, <code>?pp=env&amp;pp=env</code>, CI configs, Next.js/SharePoint paths. Static Chrome/131 UA. 611/788 (77%) caught by rate limiter as 429; 4 served 200 (safe root/register page, zero leak).</li>
+  <li><strong>Public surface hygiene:</strong> retroactively sanitized prior security entries (v0.5.30, v0.5.32) to remove specific blocked-IP addresses from the public-facing changelog. Forensic details (specific IPs, probe paths, request counts, UA strings) are preserved in the internal repo <code>CHANGELOG.md</code>, PR history, and audit trail for attribution and operational continuity. This brings v0.5.30 and v0.5.32 in line with the v0.5.22 / v0.5.26 disclosure pattern.</li>
+  <li><strong>Why this matters:</strong> disclosing specific blocked IPs in a public changelog signals to attackers what worked, tells the blocked actor they're caught (accelerating rotation), and looks reactive in customer-facing copy. Internal records keep the full forensics for attribution and post-mortem; the public surface keeps the security narrative without operational leakage.</li>
+</ul>
+</div>
+
+<div id="v0.5.32">
+<h2>v0.5.32 — Secret Scanner Block + SonarCloud P1</h2>
+<p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 13, 2026</p>
+<ul>
+  <li><strong>Security:</strong> blocked a credential / secret enumeration scanner identified via GCP forensic analysis; 7 rogue IPs now blocked at the application layer. 77% of the burst was already absorbed by the rate limiter as 429; zero leak verified (only the safe public root/register pages were served).</li>
   <li><strong>SonarCloud P1 cleanup:</strong> Extracted <code>MCP_ENDPOINT_PATH</code>, <code>MCP_SERVER_URL</code>, <code>MCP_REMOTE_QUICKSTART</code> as module constants in <code>http_server.py</code> — removed ~13 duplicate string literals across JSON/dict responses (URL changes now propagate from a single source).</li>
   <li><strong>Cognitive complexity refactor:</strong> <code>http_exception_handler</code> 404 branch — extracted <code>_extract_tool_call_metadata()</code> and <code>_client_ip_from_request()</code> helpers. Complexity 23 → ≤15.</li>
   <li><strong>Empty-except cleanups (CodeQL <code>py/empty-except</code>):</strong> <code>http_server.py</code> JSON parse caught specifically as <code>(ValueError, UnicodeDecodeError)</code> with rationale comment; <code>trinity_history.py</code> <code>RuntimeError</code> branch now logs at <code>debug</code> level instead of bare <code>pass</code>.</li>
   <li><strong>Logging hygiene:</strong> Lightweight-registration 500 path uses <code>logger.exception()</code> (full traceback) instead of <code>logger.error(..., e)</code>.</li>
   <li><strong>Expected impact:</strong> SonarCloud Critical Code Smells 13 → ~6, CodeQL open 15 → 13. Security count unchanged at 3 (already clean).</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/215" target="_blank" rel="noopener">PR #215</a></li>
 </ul>
 </div>
 
@@ -1772,9 +1782,9 @@ _CHANGELOG_BODY = """
 <h2>v0.5.30 — Config Scanner Block</h2>
 <p style="color:var(--muted);font-size:0.875rem;margin-bottom:0.75rem">May 12, 2026</p>
 <ul>
-  <li><strong>IP blocked:</strong> <code>85.121.126.250</code> — config/secret enumeration scanner probing <code>/api/env</code>, <code>/firebase-config.json</code>, <code>/swagger.json</code>, <code>/openapi.json</code>, <code>/.well-known/jwks.json</code>, and ~20 more secret/config paths at ~25 req/sec with rotating user agents (botnet pattern)</li>
-  <li><strong>Defense-in-depth:</strong> mostly 429-rate-limited already, but adding to blocklist eliminates server-side processing entirely</li>
-  <li><strong>Cost rationale:</strong> Cloud Armor (~$5/mo + per-rule + per-request) is not cost-justified at solo-builder scale; app-layer blocklist in <code>ip_blocklist.py</code> is free and equally effective. 6 IPs blocked total.</li>
+  <li><strong>Security:</strong> blocked a config / secret enumeration scanner identified via GCP forensic analysis; added to the application-layer IP filter. 6 rogue IPs blocked total at this point. Mostly absorbed by the rate limiter prior to the block; adding to the filter eliminates server-side processing entirely.</li>
+  <li><strong>Cost rationale:</strong> Cloud Armor (~$5/mo + per-rule + per-request) is not cost-justified at solo-builder scale; the app-layer blocklist in <code>ip_blocklist.py</code> is free and equally effective at this volume.</li>
+  <li><a href="https://github.com/creator35lwb-web/VerifiMind-PEAS/pull/213" target="_blank" rel="noopener">PR #213</a></li>
 </ul>
 </div>
 

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.32"
+SERVER_VERSION = "0.5.33"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.32"
+        assert http_server.SERVER_VERSION == "0.5.33"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.32", (
-            f"Expected 0.5.32, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.33", (
+            f"Expected 0.5.33, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.32"
+        assert SERVER_VERSION == "0.5.33"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.32"
+        assert SERVER_VERSION == "0.5.33"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.32", f"Expected 0.5.32, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.33", f"Expected 0.5.33, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.32", f"Expected 0.5.32, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.33", f"Expected 0.5.33, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -177,4 +177,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.32", f"Expected 0.5.32, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.33", f"Expected 0.5.33, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.32"
+        assert http_server.SERVER_VERSION == "0.5.33"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.32"
+        assert http_server.SERVER_VERSION == "0.5.33"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.32",
-  "version": "3.9.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.33",
+  "version": "3.10.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary

Retroactively sanitizes the public-facing `/changelog` to remove specific blocked-IP addresses from v0.5.30 and v0.5.32 entries. Brings them in line with the v0.5.22 / v0.5.26 professional disclosure pattern (attack-type only, no specific identifier).

**Internal forensics preserved** in `CHANGELOG.md`, PR bodies (#213, #215), and commit history. PRs and commits are the canonical drill-in source for attribution.

## Why

Disclosing specific blocked IPs in a public changelog (a) signals to attackers what triggered the block, (b) tells the blocked actor they're caught and should rotate, (c) looks reactive in customer-facing copy. The internal/public split keeps the trust signal ("we caught it, we blocked it") without operational leakage.

## Changes

### `pages.py` /changelog (public surface)
- **v0.5.30 entry:** dropped IP; reworded to "blocked a config/secret enumeration scanner identified via GCP forensic analysis; 6 rogue IPs blocked total." Added PR #213 link.
- **v0.5.32 entry:** dropped IP + probe-path enumeration; reworded to "blocked a credential/secret enumeration scanner identified via GCP forensic analysis; 7 rogue IPs blocked at the application layer." SonarCloud P1 cleanup section preserved. Added PR #215 link.
- **v0.5.33 entry** added documenting the hygiene change itself (transparency about the policy change).

### `CHANGELOG.md` (internal, repo-only)
- Disclosure policy header added at top of file documenting the split: internal CHANGELOG retains full forensics; public `/changelog` carries the security narrative without operational leakage.
- v0.5.33 entry explaining the rationale.

### Version artifacts
- `SERVER_VERSION` 0.5.32 → 0.5.33 (both http_server.py + server.py)
- `server.json` description + registry version 3.9.0 → 3.10.0
- 9 test files SERVER_VERSION assertions bumped
- `SERVER_STATUS.md` current version + latest entry

## Test plan
- [x] All unit tests pass — 566 passed, 3 skipped
- [ ] CI green
- [ ] Post-merge: deploy and verify `/changelog` no longer renders specific IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)