### PR TITLE
fix(registry): trim server.json description to fit MCP Registry 100-char limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.33",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.33",
   "version": "3.10.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",


### PR DESCRIPTION
## Summary

Fixes 5 failed \`publish-mcp-registry.yml\` workflow runs since v0.5.29. Root cause: \`server.json\` \`description\` field is 103 chars; MCP Registry hard limit is 100.

### Registry state (before fix)
- Latest published: \`3.5.0\` (from v0.5.28 backfill on 2026-05-13 01:53:38)
- Current \`server.json\`: \`3.10.0\` — 5 attempts to publish all failed with 422
- Public URL: https://registry.modelcontextprotocol.io/?q=verifimind shows v3.5.0

### Workflow failure log (PR #215 / v0.5.32 attempt)
\`\`\`
Error: publish failed: server returned status 422:
{"title":"Unprocessable Entity","status":422,"detail":"validation failed",
 "errors":[{"message":"expected length <= 100",
            "location":"body._meta.io.description",
            "value":"Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.33"}]}
\`\`\`

### Fix
Trim description from 103 → 79 chars while preserving all key signals:
- **Before:** \`Multi-Agent AI Validation: X-Z-CS Trinity. All 13 tools FREE. Growth first, monetization later. v0.5.33\`
- **After:** \`Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.33\`

21-char headroom for future versions.

### Post-merge plan
1. \`gh workflow run publish-mcp-registry.yml --repo creator35lwb-web/VerifiMind-PEAS\` (manual trigger; workflow has \`workflow_dispatch\` input)
2. Verify \`curl https://registry.modelcontextprotocol.io/v0/servers?search=verifimind\` shows \`3.10.0\` with \`isLatest: true\`
3. Document the 100-char rule explicitly in \`/verifimind-deploy v2.3\` pre-flight + Known Pitfalls (already in memory, but didn't prevent v0.5.32 violation — needs to be a mechanical pre-flight check)

### No deploy required
\`server.json\` is registry-only metadata. Cloud Run service unchanged.

## Test plan
- [x] Description verified 79 chars (server.json change only)
- [ ] CI green
- [ ] Post-merge \`workflow_dispatch\` succeeds
- [ ] Registry shows 3.10.0 as \`isLatest: true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)