### PR TITLE
v0.5.35 — Honest-Baseline Metrics Sync (Library timeline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.35 - Honest-Baseline Metrics Sync (May 21, 2026)
+
+Phase 90 "Adoption First" metrics publication sync — surfaces the post-forensic-rebuild honest baseline on the public Library timeline.
+
+### What changed
+- **`pages.py` Library timeline:** added a "May 2026" milestone surfacing the honest post-rebuild baseline — **4,139.1 flying hours** (Success-Gated, aggregate; owner-IP + bot/scraper traffic excluded). The dated April 17 milestone is preserved as history; the new milestone signals the audit-and-correct discipline ("we audit our own numbers the same way we ask others to audit theirs").
+- **Version bump** 0.5.34 → 0.5.35 (both SERVER_VERSION surfaces); `server.json` 3.11.0 → 3.12.0.
+
+### Data-Disclosure compliance (Doctrine v1.0)
+- Published numbers are **aggregate only** (flying hours, methodology) — no per-user behavioral facts, no named individuals. The forensic-rebuild finding (owner-IP rotation overcounting) is described as methodology, not per-user data.
+- The EA Cohort Taxonomy (34 active / 92 honest-baseline / 1 registered) and AY's paradox-page reflection update are routed through AY (domain owner) via change-request handoff — NOT edited by RNA, per the Cross-Agent Canonical-Edit Protocol.
+
+### Why
+The April 17 timeline showed pre-rebuild numbers (2,162 endpoints / 2,634 flying hours) as the last data point. AY's 2026-05-18 forensic DB rebuild established the honest baseline (4,139.1h aggregate, owner-IP leakage corrected). This sync surfaces the corrected number publicly, demonstrating the cross-architectural meta-principle: our internal metrics are held to the same audit rigor we apply to external AI claims.
+
+### Not changed
+- README + v0.5.34 docs verified already Data-Disclosure-clean (no per-user/cohort numbers) — no edits needed.
+- AY's paradox-page reflection (`pages.py` L4336 + `docs/research/paradox/05-coo-ay-reflection.md`) is AY-canonical — change-request handoff sent, AY applies in her session.
+
+---
+
 ## v0.5.34 - Evaluation Roadmap v1.0 (May 15, 2026)
 
 Phase 90 strategic spine: Alton's Decision #1 + #2 from the May 13 Recursive Paradox session (`.macp/handoffs/20260513_T_L_recursive_paradox_analysis_and_decisions.md`) shipped as a single bundled release.

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.34"
+SERVER_VERSION = "0.5.35"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -3526,6 +3526,11 @@ _LIBRARY_BODY = """
 <span class="milestone">Apr 17, 2026</span> <strong>THIS LIBRARY COMPILED</strong>
                  2,162 endpoints | 2,634 flying hours | 20+ validating papers
                  From defensive publication to independently validated system
+                 &#x2193;
+<span class="milestone">May 2026</span>      Forensic database rebuild &mdash; honest baseline established
+                 4,139.1 flying hours (Success-Gated, aggregate) | owner-IP + bot/scraper traffic excluded
+                 Endpoint counts corrected for IP-rotation overcounting &mdash; we audit our own numbers
+                 the same way we ask others to audit theirs
 </div>
 """
 

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.34"
+SERVER_VERSION = "0.5.35"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.33"
+        assert http_server.SERVER_VERSION == "0.5.35"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.33", (
-            f"Expected 0.5.33, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.35", (
+            f"Expected 0.5.35, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.33"
+        assert SERVER_VERSION == "0.5.35"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.33"
+        assert SERVER_VERSION == "0.5.35"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.33", f"Expected 0.5.33, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.35", f"Expected 0.5.35, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.33", f"Expected 0.5.33, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.35", f"Expected 0.5.35, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -177,4 +177,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.33", f"Expected 0.5.33, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.35", f"Expected 0.5.35, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.33"
+        assert http_server.SERVER_VERSION == "0.5.35"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.33"
+        assert http_server.SERVER_VERSION == "0.5.35"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.34",
-  "version": "3.11.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.35",
+  "version": "3.12.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary

Phase 90 metrics publication sync. Surfaces the post-forensic-rebuild honest baseline on the public Library timeline.

- **`pages.py` Library timeline:** new "May 2026" milestone — **4,139.1 flying hours** (Success-Gated, aggregate; owner-IP + bot/scraper excluded). April 17 milestone preserved as history. New line: *"we audit our own numbers the same way we ask others to audit theirs."*
- SERVER_VERSION 0.5.34 → 0.5.35; server.json 3.11.0 → 3.12.0; CHANGELOG entry.

## Data-Disclosure Doctrine v1.0 compliance

- ✅ Aggregate only — flying hours + methodology. NO per-user behavioral facts, NO named individuals.
- ✅ EA Cohort Taxonomy (34/92/1) + AY's paradox reflection routed through AY (domain owner) via change-request handoff — NOT edited by RNA, per the proposed Cross-Agent Canonical-Edit Protocol.

## Not changed (verified clean)

- README + v0.5.34 docs (MCP_SERVER_FEATURES, Troubleshooting) — confirmed no per-user/cohort numbers; RNA's earlier "docs cite ~98 EAs" flag was inaccurate (caught via grep before editing).

## Test plan

- [x] `get_library_page()` renders; "4,139.1 flying hours" + audit-ethos line present
- [x] SERVER_VERSION 0.5.35 in both surfaces
- [x] server.json description 79 chars (≤100 MCP Registry limit)
- [ ] After merge + deploy: `/library` shows the May 2026 milestone live
- [ ] After deploy: `/health` reports 0.5.35

🤖 Generated with [Claude Code](https://claude.com/claude-code)