### PR TITLE
v0.5.36 — /changelog redirects to GitHub Releases (single-source)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.36 - Changelog Endpoint Redirect (May 21, 2026)
+
+Single-sources the changelog to end dual-maintenance drift.
+
+### What changed
+- **`/changelog` endpoint now 302-redirects to GitHub Releases** (`github.com/creator35lwb-web/VerifiMind-PEAS/releases`). The hand-curated `pages.py _CHANGELOG_BODY` HTML page is retired. GitHub Releases are the single source of truth for the public changelog.
+- The JSON variant (`Accept: application/json`) returns the Releases URL + a note.
+- Removed the now-unused `get_changelog_page` import from `http_server.py`.
+- Version bump 0.5.35 → 0.5.36 (both SERVER_VERSION surfaces + 9 test files); `server.json` 3.12.0 → 3.13.0.
+
+### Why
+On 2026-05-21 the `/changelog` endpoint drifted — `CHANGELOG.md` got the v0.5.35 entry but `pages.py _CHANGELOG_BODY` did not (third two-sources-of-truth drift this month). Rather than keep dual-maintaining, the endpoint now points to GitHub Releases — the single source.
+
+**Disclosure-policy note:** redirecting to Releases (not to `CHANGELOG.md`) is deliberate. GitHub Releases are already sanitized (no forensic IPs), preserving the v0.5.33 disclosure policy. A redirect to `CHANGELOG.md` would have exposed the internal forensic IPs (v0.5.30 / v0.5.32 entries) on the customer-facing path.
+
+### Process note
+This deploy ran through the full `/verifimind-deploy` skill (v2.5) — including the Phase 2 9-test-file bump and Phase 7 full-SHA release — after v0.5.34/v0.5.35 bypassed the skill via direct `gcloud` and accumulated drift. Anti-bypass warning added to the skill.
+
+---
+
 ## v0.5.35 - Honest-Baseline Metrics Sync (May 21, 2026)
 
 Phase 90 "Adoption First" metrics publication sync — surfaces the post-forensic-rebuild honest baseline on the public Library timeline.

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -51,7 +51,7 @@ from verifimind_mcp.registration import (
     register_user,
 )
 from verifimind_mcp.policies import PRIVACY_POLICY, TERMS_AND_CONDITIONS
-from verifimind_mcp.pages import get_register_page, get_optout_page, get_privacy_page, get_terms_page, get_changelog_page, get_research_page, get_library_page, get_dashboard_page, get_paradox_page, get_cowork_page, get_evaluation_roadmap_page
+from verifimind_mcp.pages import get_register_page, get_optout_page, get_privacy_page, get_terms_page, get_research_page, get_library_page, get_dashboard_page, get_paradox_page, get_cowork_page, get_evaluation_roadmap_page
 from verifimind_mcp.utils.trinity_history import read_trinity_history
 from verifimind_mcp.llm.provider import PROVIDER_CONFIGS
 from verifimind_mcp.registration import _get_firestore
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.35"
+SERVER_VERSION = "0.5.36"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32
@@ -1317,16 +1317,27 @@ async def optout_page_handler(request):
     return HTMLResponse(get_optout_page())
 
 
+CHANGELOG_RELEASES_URL = "https://github.com/creator35lwb-web/VerifiMind-PEAS/releases"
+
+
 async def changelog_handler(request):
-    """GET /changelog — Version history (HTML by default, JSON if requested)."""
+    """GET /changelog — redirects to GitHub Releases (single source of truth).
+
+    v0.5.36: the hand-curated /changelog HTML page was retired to end
+    dual-maintenance drift (CHANGELOG.md vs pages.py _CHANGELOG_BODY).
+    GitHub Releases are already sanitized (no forensic IPs), so this also
+    preserves the v0.5.33 disclosure policy — unlike redirecting to
+    CHANGELOG.md, which retains internal forensics.
+    """
     accept = request.headers.get("accept", "")
     if "application/json" in accept:
         return JSONResponse({
             "title": "VerifiMind-PEAS Changelog",
             "current_version": SERVER_VERSION,
-            "url": "https://verifimind.ysenseai.org/changelog",
+            "url": CHANGELOG_RELEASES_URL,
+            "note": "Changelog is maintained as GitHub Releases (single source of truth).",
         })
-    return HTMLResponse(get_changelog_page())
+    return RedirectResponse(url=CHANGELOG_RELEASES_URL, status_code=302)
 
 
 async def research_handler(request):

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.35"
+SERVER_VERSION = "0.5.36"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.35"
+        assert http_server.SERVER_VERSION == "0.5.36"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.35", (
-            f"Expected 0.5.35, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.36", (
+            f"Expected 0.5.36, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.35"
+        assert SERVER_VERSION == "0.5.36"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.35"
+        assert SERVER_VERSION == "0.5.36"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -159,4 +159,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.35", f"Expected 0.5.35, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.36", f"Expected 0.5.36, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.35", f"Expected 0.5.35, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.36", f"Expected 0.5.36, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -177,4 +177,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.35", f"Expected 0.5.35, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.36", f"Expected 0.5.36, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.35"
+        assert http_server.SERVER_VERSION == "0.5.36"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.35"
+        assert http_server.SERVER_VERSION == "0.5.36"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.35",
-  "version": "3.12.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.36",
+  "version": "3.13.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary
Single-sources the changelog. `/changelog` endpoint now 302-redirects to GitHub Releases — ending the dual-maintenance drift (CHANGELOG.md vs pages.py _CHANGELOG_BODY) that surfaced on 2026-05-21.

- 302 redirect → `github.com/creator35lwb-web/VerifiMind-PEAS/releases`; JSON variant returns Releases URL.
- Removed unused `get_changelog_page` import.
- v0.5.35 → v0.5.36 (SERVER_VERSION ×2 + **9 test files** + server.json 3.13.0).

## Disclosure-safe by design
Redirect targets **Releases** (sanitized), NOT CHANGELOG.md (forensic IPs). Preserves v0.5.33 disclosure policy.

## Process note
Ran through the full `/verifimind-deploy` skill v2.5 — Phase 2 9-test-file bump done up front (v0.5.34/v0.5.35 bypassed the skill → drift). Anti-bypass warning added.

## Test plan
- [x] 11 version tests pass locally; all 9 test files at 0.5.36
- [x] changelog_handler returns RedirectResponse 302; import removed
- [x] server.json desc 79 chars
- [ ] After deploy: `curl -sI /changelog` shows 302 → Releases; `/health` = 0.5.36