### PR TITLE
docs(security): refresh Supported Versions table v0.4.x → v0.5.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| v0.4.x  | ✅ Active | Current release — full security support |
-| v0.3.x  | ⚠️ Critical fixes only | Security patches only, no new features |
-| < v0.3  | ❌ End of life | No longer supported — please upgrade |
+| v0.5.x  | ✅ Active | Current release — full security support |
+| v0.4.x  | ⚠️ Critical fixes only | Security patches only, no new features |
+| < v0.4  | ❌ End of life | No longer supported — please upgrade |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
M1 governance freshness fix. The `SECURITY.md` Supported Versions table was stale — it claimed `v0.4.x` is the current release, but the server is on **v0.5.36**.

## What changed
- Supported Versions table shifted up one minor: `v0.5.x` Active / `v0.4.x` critical-fixes / `< v0.4` EOL.

## What did NOT change
- The 90-day coordinated-disclosure window, response timeline (48h ack / 7d assessment / severity-tiered fixes), GitHub Security Advisories channel, and reachable disclosure email are unchanged — these already satisfy the North Star **M1** governance requirement.

## Context
Part of the Phase 90 M1 governance pass (due 2026-05-31). Verified that SECURITY.md and GOVERNANCE.md already contain their M1-critical substance; remaining M1 work (MAINTAINERS.md + GOVERNANCE.md Core Team refresh) is routed to T (CTO) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)