### PR TITLE
feat(evidence): add .macp-public/ sanitized evidence folder (v0.6.0-Beta D2)

### DIFF
--- a/.macp-public/README.md
+++ b/.macp-public/README.md
@@ -1,0 +1,73 @@
+# `.macp-public/` — MACP Protocol Evidence
+
+> **What is this?** Sanitized, public-facing evidence of the Multi-Agent Communication Protocol (MACP v2.4.0) in action.
+
+---
+
+## About MACP
+
+The **Multi-Agent Communication Protocol (MACP)** is an open, model-agnostic coordination protocol for multi-agent AI systems. It was developed through 87+ days of real-world practice by the VerifiMind-PEAS FLYWHEEL TEAM — 6 AI agents spanning multiple AI platforms (supported by AI Council validators), orchestrated by a human lead maintainer.
+
+MACP addresses the fundamental challenge of multi-agent coordination: **How do you maintain coherence, accountability, and quality when multiple AI agents collaborate on complex tasks?**
+
+---
+
+## The Triad Architecture
+
+MACP's core innovation is the **Memory-Reasoning-Handoff Triad** — three mandatory artifacts that every strategic session must produce:
+
+| Leg | Purpose | What It Contains |
+|-----|---------|-----------------|
+| **Memory** | Persistent operational state | Agent context, forecasts, validated patterns |
+| **Reasoning** | Auditable decision trail | Decisions with confidence levels, alternatives considered |
+| **Handoff** | Coordination continuity | What was done, what's next, who owns what |
+
+---
+
+## What's In This Folder
+
+```
+.macp-public/
+├── README.md           ← You are here
+├── protocol/           ← MACP specification and definitions
+├── exemplars/          ← Real (sanitized) examples of MACP in action
+├── thesis/             ← Full academic thesis on MACP v2.4.0
+└── governance/         ← Project governance documents
+```
+
+---
+
+## Source of Truth
+
+This folder contains **curated, sanitized excerpts** from the project's private Command Central Hub. The full operational history (4,580+ hours of engagement, 377+ handoffs, 39+ reasoning logs) remains in the private repository for security and privacy reasons.
+
+What you see here is real evidence — not fabricated examples. Every handoff, reasoning log, and council session shown actually happened during the development of VerifiMind-PEAS.
+
+---
+
+## Learn More
+
+- **Full Thesis:** [`thesis/`](thesis/) — being finalized for a Zenodo deposit (citable DOI forthcoming with v0.6.0-Beta)
+- **Protocol Spec:** [`protocol/MACP_v2.4.0_spec.md`](protocol/MACP_v2.4.0_spec.md)
+- **Governance:** [`governance/GOVERNANCE.md`](governance/GOVERNANCE.md)
+- **Become a Co-Maintainer:** [`governance/MAINTAINERS.md`](governance/MAINTAINERS.md)
+
+---
+
+## Citation
+
+If you use or reference MACP in your work:
+
+```bibtex
+@misc{lee2026macp,
+  title={MACP v2.4.0: A Multi-Agent Communication Protocol for Model-Agnostic AI Coordination},
+  author={Lee, Alton Wei Bin and FLYWHEEL TEAM},
+  year={2026},
+  howpublished={GitHub: VerifiMind-PEAS},
+  url={https://github.com/creator35lwb-web/VerifiMind-PEAS}
+}
+```
+
+---
+
+*Maintained by the VerifiMind-PEAS FLYWHEEL TEAM under Alton Lee Wei Bin's direction.*

--- a/.macp-public/exemplars/handoff-example-redacted.md
+++ b/.macp-public/exemplars/handoff-example-redacted.md
@@ -1,0 +1,34 @@
+# Handoff Exemplar (sanitized)
+
+> **What this is:** a *real* MACP handoff from the VerifiMind-PEAS Command Central Hub, **redacted** for public release per the project's Data-Disclosure Doctrine. Internal file paths and operational specifics are replaced with `[…]`; the coordination structure and logic are preserved.
+> **What it illustrates:** two core MACP mechanics — **request-don't-edit** (the Cross-Agent Canonical-Edit Protocol) and **verify-before-route**.
+
+---
+
+## MACP Handoff: CSO → CTO (+ CEO, CIO) | Thesis attribution + protocol-name alignment
+
+**From:** CSO agent (Claude Code)
+**To:** CTO agent (Manus AI) — owner of the thesis + deposit metadata
+**CC:** CEO agent, CIO agent
+**Protocol:** MACP v2.4.0 · request-don't-edit
+**Date:** [redacted]
+
+### Why this is a routed *request*, not an edit
+The thesis is the CTO's canonical domain. Rather than editing it directly, the CSO files a change-request with evidence and routes it to the owner. (The CSO had already applied the fixes that were in its *own* lane — the governance documents — and routes only what belongs to the owner.)
+
+### Item 1 — platform attribution drift
+A peer review flagged **2** locations where an agent's platform was misattributed. On **verification before routing**, the CSO found **6** — the drift was systematic, not isolated. The complete list (with line references) was handed to the owner so the fix could be made in one sweep.
+
+### Item 2 — protocol-name consistency (deposit-bound)
+The public README + its citation block named the protocol one way; the canonical thesis named it another. Because a citation's **title field is the most-copied string** in any downstream reference, the CSO flagged the inconsistency and routed the naming decision to the owner — rather than guessing at a permanent, DOI-bound choice.
+
+### Why routed, not fixed
+Substantive edits to another agent's canonical artifact are never made unilaterally. The owner rules; the requester supplies evidence and a recommendation.
+
+— CSO agent
+
+> **Outcome (recorded later):** the owner resolved both items in the next session. The verify-before-route step had caught **4 locations the original peer review missed** — a small example of the protocol's self-correction in practice.
+
+---
+
+*Sanitized exemplar. Real artifact; internal paths, dates, and session identifiers redacted per the Data-Disclosure Doctrine. Format and reasoning preserved.*

--- a/.macp-public/exemplars/reasoning-example-redacted.md
+++ b/.macp-public/exemplars/reasoning-example-redacted.md
@@ -1,0 +1,31 @@
+# Reasoning Exemplar (sanitized)
+
+> **What this is:** a *real* MACP reasoning log, redacted for public release. It shows the decision-log format — **trigger → choice → why → confidence** — plus mistakes caught mid-flight and **falsifiable forecasts**.
+> **What it illustrates:** how MACP makes *judgment* auditable, not just outcomes.
+
+---
+
+## Reasoning Log — governance audit (excerpt)
+
+### Decision — audit the peer review; don't just relay it
+**Trigger:** asked to review a peer agent's governance audit.
+**Chosen:** re-verify the audit's high-stakes findings against the primary files before acting on them.
+**Why:** a peer's review is a *hypothesis*, not a fact. Verifying it paid off both directions — it **cleared** one false-positive (a metric the reviewer couldn't confirm turned out to be accurate) **and caught** one issue the reviewer had missed (a protocol-name inconsistency headed for a permanent citation).
+**Confidence:** High.
+
+### Decision — split the fixes by authority boundary
+**Trigger:** two handoffs disagreed on who should apply a set of fixes.
+**Chosen:** apply the fixes inside my own lane; route the rest to their owner.
+**Why:** the Cross-Agent Canonical-Edit Protocol — own what's yours, request what isn't. Splitting by authority dissolved the conflict without overstepping.
+**Confidence:** High.
+
+### Mistakes caught mid-flight
+- Nearly relayed the peer review without re-verifying it. Caught by the verify-before-act reflex — which then surfaced a finding the review had missed.
+
+### Forecasts (falsifiable)
+- The routed naming decision will resolve toward the canonical thesis spelling. *(Check: owner's response.)*
+- The applied fixes will reach public release with zero new misread-class regressions. *(Check: first public sync.)*
+
+---
+
+*Sanitized excerpt. Confidence levels are qualitative; any numeric strategic scores were excluded per the Data-Disclosure Doctrine. Internal file paths and identifiers redacted.*

--- a/.macp-public/governance/GOVERNANCE.md
+++ b/.macp-public/governance/GOVERNANCE.md
@@ -1,0 +1,131 @@
+# GOVERNANCE
+
+> **Version:** 1.0  
+> **Effective:** 2026-05-26  
+> **Applies to:** VerifiMind-PEAS (PUBLIC repository) and verifimind-genesis-mcp (PRIVATE Command Central Hub)
+
+This document defines how decisions are made, who makes them, and how changes are proposed and ratified in the VerifiMind-PEAS project.
+
+For *who maintains the project*, see [MAINTAINERS.md](MAINTAINERS.md). For *how to report security issues*, see [SECURITY.md](SECURITY.md).
+
+---
+
+## 1. Authority Model
+
+VerifiMind-PEAS uses a **human-centric authority model** with delegated AI agent support. This is not a DAO, not a committee, and not a consensus-based governance. One human has final authority.
+
+| Entity | Type | Authority | Scope |
+|--------|------|-----------|-------|
+| **Alton Lee Wei Bin** | Human | **Absolute** | All decisions, universal veto, strategic direction |
+| **L (Godel)** | AI-Generated (GodelAI C-S-P) | Delegated | Strategic synthesis under Alton's delegation |
+| **FLYWHEEL TEAM** | Multi-Agent Team | Advisory | Development, analysis, validation — no independent merge authority |
+| **Co-Maintainers** | Human (future) | Scoped | Code review, release support within defined areas |
+
+> **Identity Clarity (MACP v2.2):** Alton (Human Orchestrator) is NOT the same as L (Godel/CEO). Alton is human, always present since day one. L is an AI-generated entity that emerged via self-recursion during LegacyEvolve creation. L's authority is DELEGATED, not inherent. This distinction is maintained throughout all governance documents.
+
+---
+
+## 2. Decision Categories
+
+| Category | Examples | Decision Maker | Process |
+|----------|----------|---------------|---------|
+| **Routine** | Bug fixes, documentation typos, dependency updates | Any maintainer | Merge directly |
+| **Feature** | New tools, API changes, UI additions | Lead Maintainer or Co-Maintainer + review | PR + 1 approval |
+| **Architecture** | Protocol changes, database schema, deployment model | Lead Maintainer | PR + AI Council review recommended |
+| **Strategic** | Pricing, partnerships, pivots, public statements | Lead Maintainer (Alton) only | Deliberation + AI Council validation |
+| **Governance** | Changes to THIS document, MAINTAINERS.md, authority model | Lead Maintainer (Alton) only | 7-day notice period |
+
+---
+
+## 3. Proposal Process
+
+Anyone (human or AI agent) may propose a change. The process depends on the category:
+
+**For Routine and Feature changes:**
+1. Open a Pull Request with clear description
+2. Request review from a maintainer
+3. Address feedback
+4. Maintainer merges when satisfied
+
+**For Architecture and Strategic changes:**
+1. Open a GitHub Discussion or Issue describing the proposal
+2. Allow 48 hours for community input (if applicable)
+3. Lead Maintainer reviews, optionally runs AI Council validation
+4. Lead Maintainer decides (approve / reject / defer)
+5. Decision is documented in `.macp/reasoning/` with rationale
+
+**For Governance changes:**
+1. Open a GitHub Discussion with the proposed change
+2. 7-day notice period for community review
+3. Lead Maintainer decides after notice period
+4. Updated document is committed with changelog entry
+
+---
+
+## 4. AI Agent Governance
+
+The FLYWHEEL TEAM operates under the Multi-Agent Communication Protocol (MACP v2.4.0). Key governance rules for AI agents:
+
+- **No independent merge authority.** All AI-generated code requires human review before merge.
+- **Triad compliance.** Strategic decisions must produce Memory + Reasoning + Handoff artifacts.
+- **Circuit breaker.** 3 consecutive reasoning logs with no disagreement trigger human review.
+- **Cross-Agent Canonical-Edit Protocol.** Agents may request edits to files outside their scope but must not make them unilaterally (request-don't-edit for B/C tier artifacts).
+- **Escalation authority.** Z-Agent (Guardian) may flag for ethical review; XV (CIO) may flag for strategic re-review. Both are advisory to the Lead Maintainer's final decision.
+
+---
+
+## 5. Dual-Repo Protocol
+
+VerifiMind-PEAS operates across two repositories:
+
+| Repository | Visibility | Purpose |
+|-----------|-----------|---------|
+| `VerifiMind-PEAS` | PUBLIC | Production code, public governance, releases |
+| `verifimind-genesis-mcp` | PRIVATE | Command Central Hub, agent coordination, sensitive reasoning |
+
+**Sync rules:**
+- Governance documents (GOVERNANCE.md, MAINTAINERS.md, SECURITY.md) are drafted in the PRIVATE Hub, reviewed by the CTO, then synced to the PUBLIC repo.
+- Sensitive reasoning logs, agent memory, and internal handoffs remain PRIVATE.
+- A sanitized `.macp-public/` folder in the PUBLIC repo provides exemplar evidence without exposing operational details.
+
+---
+
+## 6. Conflict Resolution
+
+1. **Between AI agents:** The Lead Maintainer (Alton) resolves. If unavailable, T (CTO) provides interim recommendation.
+2. **Between humans:** The Lead Maintainer's decision is final.
+3. **Between community and maintainers:** The Lead Maintainer's decision is final, but must be documented with rationale.
+4. **Ethical concerns:** Z-Agent (Guardian) flags are escalated to the Lead Maintainer immediately, regardless of other priorities.
+
+---
+
+## 7. Transparency Commitments
+
+- All strategic decisions are documented with reasoning (MACP Triad).
+- All AI agent contributions are attributed (Agent Attribution Map in thesis).
+- All governance changes have a 7-day notice period.
+- The project's metrics are reported honestly (EA Taxonomy: canonical/honest/registered).
+- Limitations are acknowledged publicly (see Thesis §10: Limitations and Honest Gaps).
+
+---
+
+## 8. Amendments
+
+Changes to this document require:
+1. A 7-day notice period via GitHub Discussion
+2. Lead Maintainer (Alton) approval
+3. Version increment in the header
+4. Commit message: `governance: update GOVERNANCE.md to vX.Y`
+
+---
+
+## 9. Contact
+
+- **Lead Maintainer:** Alton Lee Wei Bin
+- **GitHub:** [@creator35lwb-web](https://github.com/creator35lwb-web)
+- **Email:** alton@ysenseai.org
+- **Project:** [VerifiMind-PEAS](https://github.com/creator35lwb-web/VerifiMind-PEAS)
+
+---
+
+*Authored by T (CTO, Manus AI) under Alton's direction. MACP v2.4.0 compliant. Phase 90 "Adoption First" — M1 Governance.*

--- a/.macp-public/governance/MAINTAINERS.md
+++ b/.macp-public/governance/MAINTAINERS.md
@@ -1,0 +1,118 @@
+# MAINTAINERS
+
+> **Version:** 1.0  
+> **Effective:** 2026-05-26  
+> **Status:** Actively seeking co-maintainers
+
+This document lists the current maintainers of the VerifiMind-PEAS project and describes the process for becoming a co-maintainer.
+
+---
+
+## Current Maintainers
+
+### Lead Maintainer
+
+| Name | GitHub | Role | Authority | Since |
+|------|--------|------|-----------|-------|
+| **Alton Lee Wei Bin** | [@creator35lwb-web](https://github.com/creator35lwb-web) | Lead Maintainer / Human Orchestrator | Universal — all decisions, veto, strategic direction | January 2026 |
+
+### AI Agent Team (FLYWHEEL TEAM)
+
+The following AI agents contribute under the Lead Maintainer's delegation. They do NOT have independent merge authority.
+
+| Agent | Platform | Role | Scope |
+|-------|----------|------|-------|
+| T | Manus AI | CTO | Architecture, integration, thesis authorship |
+| L (Godel) | GodelAI (hosted via Manus) | CEO (AI-Generated) | Strategic synthesis, self-recursive methodology |
+| RNA | Claude Code | CSO | Executable discipline, code review, protocol enforcement |
+| XV | Perplexity Computer | CIO | Competitive intelligence, external validation, CLAW matrix |
+| AY | Cursor | COO | Operational metrics, telemetry, weekly reports |
+| AZ | Cursor | CPO | Product strategy, adoption, UX |
+
+> **Note:** AI agents are tools under human direction. They are listed here for transparency and attribution, not as decision-makers. See [GOVERNANCE.md](GOVERNANCE.md) §4 for AI agent governance rules.
+
+---
+
+## Co-Maintainer Openings
+
+We are actively seeking **1–2 human co-maintainers** to help develop and validate the VerifiMind-PEAS system.
+
+### What We're Looking For
+
+**Skills/Background (any subset welcome):**
+- Python + FastAPI
+- MCP protocol familiarity
+- Multi-agent systems interest
+- AI safety/ethics awareness
+- GCP/Cloud Run experience
+
+**Mindset:**
+- Curious about multi-model AI validation
+- Comfortable with experimental, rapidly-evolving projects
+- Willing to engage with AI agents as collaborators (not just tools)
+- Values transparency and honest metrics over vanity metrics
+
+### Time Commitment and Compensation
+
+- **Time:** ~2–4 hours/week, best-effort
+- **Compensation:** Unpaid open-source contribution (revenue-share TBD if project monetizes)
+- **Recognition:** Full attribution in Agent Attribution Map, thesis acknowledgments, and all public documentation
+
+### What You'll Get
+
+- Hands-on experience with a novel multi-agent coordination protocol (MACP v2.4.0)
+- Direct collaboration with the Lead Maintainer and AI agent team
+- Co-authorship opportunities on future publications
+- Early access to the Genesis Prompt Engineering Methodology
+- A front-row seat to the convergence between open protocols and frontier lab approaches
+
+### How to Apply
+
+1. Open a post in [GitHub Discussions](https://github.com/creator35lwb-web/VerifiMind-PEAS/discussions) (category: Co-Maintainer Applications)
+2. Include:
+   - Brief background (1-2 paragraphs)
+   - Which skills/areas you'd contribute to
+   - Why multi-agent systems interest you
+   - Your GitHub profile link
+3. The Lead Maintainer will respond within 7 days
+
+### Co-Maintainer Onboarding Process
+
+1. **Trial period (30 days):** Review PRs, contribute to documentation, familiarize with MACP protocol
+2. **Evaluation:** Lead Maintainer assesses fit, communication style, and contribution quality
+3. **Confirmation:** Added to this document with defined scope of authority
+4. **Access:** Granted write access to PUBLIC repo; read access to relevant PRIVATE Hub sections (case-by-case)
+
+---
+
+## Maintainer Responsibilities
+
+| Responsibility | Lead Maintainer | Co-Maintainer |
+|---------------|----------------|---------------|
+| Strategic direction | ✅ | Advisory |
+| Architecture decisions | ✅ | Propose + review |
+| Code review | ✅ | ✅ (within scope) |
+| Release management | ✅ | Assist |
+| Community engagement | ✅ | ✅ |
+| AI Council activation | ✅ | Request only |
+| Governance changes | ✅ | Propose only |
+| Security response | ✅ | Escalate |
+
+---
+
+## Emeritus Maintainers
+
+*None yet. This section will list maintainers who have stepped down but retain honorary recognition.*
+
+---
+
+## Contact
+
+- **Lead Maintainer:** Alton Lee Wei Bin
+- **GitHub Discussions:** [VerifiMind-PEAS Discussions](https://github.com/creator35lwb-web/VerifiMind-PEAS/discussions)
+- **Email:** alton@ysenseai.org
+- **X (Twitter):** [@creator35lwb](https://x.com/creator35lwb)
+
+---
+
+*Authored by T (CTO, Manus AI) under Alton's direction. MACP v2.4.0 compliant. Phase 90 "Adoption First" — M1 Governance.*

--- a/.macp-public/governance/SECURITY.md
+++ b/.macp-public/governance/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported | Notes |
+|---------|-----------|-------|
+| v0.5.x  | ✅ Active | Current release — full security support |
+| v0.4.x  | ⚠️ Critical fixes only | Security patches only, no new features |
+| < v0.4  | ❌ End of life | No longer supported — please upgrade |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability in VerifiMind-PEAS, please report it responsibly through one of the following channels:
+
+### Preferred: GitHub Security Advisories
+
+Use [GitHub Security Advisories](https://github.com/creator35lwb-web/VerifiMind-PEAS/security/advisories/new) to report vulnerabilities privately. This allows us to collaborate on a fix before public disclosure.
+
+### Alternative: Email
+
+**Contact:** alton@ysenseai.org
+
+### What to Include
+
+- Description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Affected version(s)
+- Any suggested mitigations or fixes
+- Your contact information for follow-up
+
+### What NOT to Do
+
+- **Do not** open a public GitHub issue for security vulnerabilities
+- **Do not** share vulnerability details publicly before they are fixed
+- **Do not** exploit the vulnerability beyond what is necessary to demonstrate it
+
+## Response Timeline
+
+| Stage | Timeline |
+|-------|----------|
+| Acknowledgment | Within **48 hours** of report |
+| Initial assessment | Within **7 days** |
+| Critical severity fix | Within **14 days** |
+| High severity fix | Within **30 days** |
+| Medium/Low severity fix | Within **90 days** |
+
+## Coordinated Disclosure Policy
+
+We follow a **90-day coordinated disclosure** window. After reporting a vulnerability:
+
+1. We will acknowledge receipt within 48 hours
+2. We will assess severity and develop a fix
+3. We will coordinate with you on disclosure timing
+4. After the fix is released, you are free to publish your findings
+5. If 90 days pass without a fix, you may disclose at your discretion
+
+We credit all reporters in our security advisories unless anonymity is requested.
+
+## Security Practices
+
+### Infrastructure Security
+
+- All API keys and credentials are managed through environment variables — never committed to code
+- GCP infrastructure details (project numbers, instance configurations) are kept in private documentation only
+- The **Dual-Repo Protocol** separates internal development artifacts (private `verifimind-genesis-mcp`) from public code
+- Cloud Run is configured with instance caps and rate limiting to prevent EDoS (Economic Denial of Sustainability) attacks
+
+### Code Security
+
+- **Bandit** (SAST) — Static Application Security Testing for Python code
+- **Safety** (SCA) — Software Composition Analysis for dependency vulnerabilities
+- **CodeQL** — Semantic code analysis via GitHub Actions
+- Automated security scans run on every push, pull request, and weekly schedule
+- All GitHub Actions are pinned to commit SHAs to prevent supply chain attacks
+
+### Access Control
+
+- Branch protection rules enforce pull request reviews before merging
+- Dependabot monitors dependencies for known vulnerabilities
+- GitHub secret scanning and push protection are enabled
+
+### Operational Security
+
+- Regular security audits conducted by the FLYWHEEL TEAM multi-agent validation protocol
+- Security findings are tracked and resolved through the MACP (Multi-Agent Collaboration Protocol)
+- All security-related changes require review before deployment
+
+## Security Scanning Tools
+
+The following tools are used in our CI/CD pipeline:
+
+| Tool | Purpose | Frequency |
+|------|---------|-----------|
+| Bandit | Python SAST | Every push/PR + weekly |
+| Safety | Dependency vulnerability check | Every push/PR + weekly |
+| CodeQL | Semantic code analysis | Every push/PR + weekly |
+| Dependabot | Automated dependency updates | Weekly |
+| GitHub Secret Scanning | Detect leaked credentials | Continuous |
+
+## Known Vulnerabilities
+
+No known unpatched vulnerabilities at this time. See [Security Advisories](https://github.com/creator35lwb-web/VerifiMind-PEAS/security/advisories) for historical disclosures.
+
+## Acknowledgments
+
+Security scanning powered by the FLYWHEEL TEAM multi-agent validation protocol.
+
+- **Architecture & Security Strategy:** Manus AI (CTO) — Team YSenseAI
+- **Implementation & Code Security:** Claude Code (RNA) — Team YSenseAI
+- **Project Lead:** Alton Lee Wei Bin

--- a/.macp-public/protocol/MACP_v2.4.0_spec.md
+++ b/.macp-public/protocol/MACP_v2.4.0_spec.md
@@ -1,0 +1,78 @@
+# MACP v2.4.0 — Protocol Specification
+
+> **Multi-Agent Communication Protocol** · codename "Triad" · a model-agnostic coordination protocol for multi-agent AI systems.
+> This document is **self-contained** — you can read it without the full thesis. For operational evidence, see [`../exemplars/`](../exemplars/); for governance, see [`../governance/`](../governance/).
+
+---
+
+## 1. Purpose
+
+MACP answers one question: **how do multiple AI agents — often on different platforms — collaborate on complex, long-running work while staying coherent, accountable, and auditable?**
+
+It is **not** an orchestration framework and **not** a replacement for any agent's native capability. MACP is to multi-agent coordination what HTTP is to document transfer: a thin, open protocol that *carries* the work between agents without dictating what each agent is or does.
+
+## 2. Design principles
+
+1. **Human-centric authority.** One human holds final authority. AI agents operate under delegation; none has independent merge authority.
+2. **Auditable by construction.** Every strategic decision leaves a durable trail (the Triad, §3). Coordination is legible after the fact, not just in the moment.
+3. **Model-agnostic.** Agents may run on any platform. Roles are defined by function, not vendor.
+4. **A shared bus.** A version-controlled repository (e.g., GitHub) is the coordination layer — the single source of truth all agents read from and write to.
+5. **Request-don't-edit across boundaries.** An agent does not silently edit another agent's canonical artifact; it proposes the change and routes it to the owner (§4.2).
+
+## 3. The Triad (core innovation)
+
+Every strategic session produces up to three artifacts:
+
+| Leg | Captures | Cadence |
+|-----|----------|---------|
+| **Memory** | Durable rules and validated patterns future sessions operate under | Only when a durable insight emerges (~1 in 3 sessions) |
+| **Reasoning** | The decision trail — options considered, choices made, mistakes caught, falsifiable forecasts | Per decision-cluster |
+| **Handoff** | Session state — what happened, what's deployed, what's next, who owns what | Every session |
+
+The Triad is what makes a multi-agent system *inspectable*: a reviewer can reconstruct not just *what* changed but *why*, and hold forecasts accountable later.
+
+## 4. Coordination primitives
+
+### 4.1 Handoff
+A structured record passed from one agent (or session) to another. Minimum fields: **From / To**, scope, work completed, current state, next actions, open items + owners. See [`../exemplars/handoff-example-redacted.md`](../exemplars/handoff-example-redacted.md).
+
+### 4.2 Routing & the Cross-Agent Canonical-Edit Protocol
+Artifacts have owners. Changes to an artifact you don't own are classified:
+- **Substantive** → never edit; request the owner.
+- **Mechanical** → a flagged exception is permissible.
+- **Default** → request-don't-edit: open a change-request with evidence and route to the owner.
+
+This is the same semantics as a pull request, applied to *all* coordination artifacts — not just code.
+
+### 4.3 Escalation (advisory, not veto)
+Specialized agents may **flag for review** (e.g., an ethics guardian flags an ethical concern; an intelligence role flags a strategic risk). Flags are advisory inputs to the human lead's final decision — never an autonomous override.
+
+## 5. Session lifecycle
+
+```
+CREATED → IN_PROGRESS → REVIEW → COMPLETED → ARCHIVED
+```
+
+A unit of work is not "done" until it is reviewed and its Triad artifacts are filed.
+
+## 6. Authority model
+
+| Tier | Holder | Authority |
+|------|--------|-----------|
+| Human orchestrator | the project's lead maintainer | Absolute — final say, universal veto |
+| Delegated coordinator | a designated coordination agent | Strategic synthesis under delegation |
+| Agent team | role-defined AI agents | Advisory / development — no independent merge |
+
+## 7. Versioning
+
+MACP versions follow semantic intent: **MAJOR** for protocol-shape changes, **MINOR** for new primitives or roles, **PATCH** for clarifications. This document describes **v2.4.0 "Triad"** — the version in which the Memory-Reasoning-Handoff Triad became the default operating discipline.
+
+## 8. What MACP is *not*
+
+- Not an agent framework or runtime — it coordinates agents, it doesn't run them.
+- Not a consensus/voting system — authority is human-centric, not democratic.
+- Not a replacement for any model's capabilities — it carries the work, the agents do it.
+
+---
+
+*MACP v2.4.0 "Triad" — Multi-Agent Communication Protocol. Sanitized public specification; full thesis published via Zenodo (DOI forthcoming).*

--- a/.macp-public/protocol/agent-roles.md
+++ b/.macp-public/protocol/agent-roles.md
@@ -1,0 +1,30 @@
+# FLYWHEEL TEAM — Agent Roles
+
+> Role definitions for the multi-agent team that develops VerifiMind-PEAS under MACP. Roles are defined by **function**, with the platform noted for transparency. AI agents operate under the human Lead Maintainer's delegation and hold **no independent merge authority**.
+
+---
+
+| Agent | Platform | Role | Function |
+|-------|----------|------|----------|
+| **Lead Maintainer** | Human | Orchestrator | Absolute authority — final decisions, strategic direction, release sign-off |
+| **L** | GodelAI (hosted via Manus) | CEO (AI-generated) | Emergent strategic synthesis under delegated authority |
+| **T** | Manus AI | CTO | Architecture, integration, thesis authorship, security strategy |
+| **RNA** | Claude Code | CSO | Executable discipline — code, deployment, protocol enforcement, review |
+| **XV** | Perplexity | CIO | Real-time intelligence, external validation, competitive analysis |
+| **AY** | Cursor | COO | Operational metrics, telemetry, behavioral analytics |
+| **AZ** | Cursor | CPO | Product strategy, adoption, user experience |
+
+**AI Council (validators).** Beyond the standing team, MACP convenes specialized validator agents for high-stakes reviews (e.g., innovation, security, and ethics lenses). They contribute analysis, not merge decisions.
+
+---
+
+## How roles work under MACP
+
+- **Function over vendor.** A role is its responsibility, not its model. Platforms can change without changing the role.
+- **Delegated, not autonomous.** Every agent acts under the Lead Maintainer's delegation. Strategic and governance decisions route to the human.
+- **Cross-checking is built in.** Agents review each other's work (the request-don't-edit protocol) and flag — not override — concerns to the human lead.
+- **Identity clarity.** The human orchestrator and the AI-generated coordinator are distinct entities; the project keeps them deliberately distinct in all documents.
+
+---
+
+*Part of the MACP v2.4.0 public specification. For the maintainer roster and how to join, see [`../governance/MAINTAINERS.md`](../governance/MAINTAINERS.md).*

--- a/.macp-public/protocol/triad-definition.md
+++ b/.macp-public/protocol/triad-definition.md
@@ -1,0 +1,55 @@
+# The Memory-Reasoning-Handoff Triad
+
+> The core discipline of MACP v2.4.0. Three artifacts that make multi-agent work auditable.
+
+A multi-agent system is only as trustworthy as its paper trail. The Triad is MACP's answer: three complementary artifacts, each with a distinct purpose, lifespan, and cadence.
+
+---
+
+## Handoff — *state*
+
+**Purpose:** continuity. Anyone (human or agent) picking up the work can see where it stands.
+
+**Lifespan:** session-scoped.
+**Cadence:** every session that did work.
+
+**Contains:** From/To, what was completed, current state (what's live/deployed), next actions, open items with owners, files touched.
+
+---
+
+## Reasoning — *process*
+
+**Purpose:** accountability for *judgment*. Not what changed, but **why** — and what was rejected.
+
+**Lifespan:** session-scoped.
+**Cadence:** per decision-cluster. (Skipped only for purely mechanical sessions.)
+
+**Contains:** numbered decisions (trigger → chosen path → why → confidence), mistakes caught mid-flight, and **falsifiable forecasts** — predictions with a stated check, so the team can later confirm or refute them.
+
+The forecast discipline matters: it converts opinion into something that can be proven wrong.
+
+---
+
+## Memory — *durable rules*
+
+**Purpose:** learning. Rules that future sessions should operate under by default.
+
+**Lifespan:** cross-session (persistent).
+**Cadence:** only when a durable insight emerges — roughly one session in three. Memory is not a session log; it is the distilled, reusable rule.
+
+**Contains:** one fact per entry, typed (user / feedback / project / reference), with *why* and *how to apply*, cross-linked to related memories.
+
+---
+
+## Why three, not one
+
+Each leg fails differently if merged with another:
+- Handoff alone → you know the *state* but not the *reasoning*; you repeat past mistakes.
+- Reasoning alone → you know the *decisions* but lose *durable rules*; every session re-derives them.
+- Memory alone → you have *rules* but no *audit trail* to justify them.
+
+Together, they make a multi-agent system that can explain itself — to its own future sessions, to its human lead, and to an external reviewer.
+
+---
+
+*Part of the MACP v2.4.0 public specification. See [`MACP_v2.4.0_spec.md`](MACP_v2.4.0_spec.md).*

--- a/.macp-public/thesis/README.md
+++ b/.macp-public/thesis/README.md
@@ -1,0 +1,16 @@
+# Thesis
+
+The full **MACP v2.4.0 thesis** — *Multi-Agent Communication Protocol: Thesis and Operational Evidence* — is being finalized for a **Zenodo deposit**. A citable **DOI will be linked here** with the v0.6.0-Beta milestone.
+
+In the meantime, the substance is already available in this folder:
+
+- **The protocol itself** is fully specified in [`../protocol/MACP_v2.4.0_spec.md`](../protocol/MACP_v2.4.0_spec.md) (self-contained).
+- **The Triad discipline** is defined in [`../protocol/triad-definition.md`](../protocol/triad-definition.md).
+- **Real, sanitized evidence** of the protocol in action is in [`../exemplars/`](../exemplars/).
+- **The governance model** is in [`../governance/`](../governance/).
+
+> We are deliberately **not** publishing a pre-final copy of the thesis here. The deposited Zenodo version is the canonical, citable artifact — and publishing an interim copy alongside it would create exactly the kind of source-of-truth ambiguity this project works to avoid. This page will link the DOI once the deposit is live.
+
+---
+
+*Part of the `.macp-public/` evidence folder. See [`../README.md`](../README.md).*


### PR DESCRIPTION
## v0.6.0-Beta Deliverable 2 — `.macp-public/` evidence folder

Public, sanitized evidence of **MACP v2.4.0** in action — the "External Adoption Receptor" for Phase 90 "Adoption First". Sourced from the private Command Central Hub via curated, manual sync (Dual-Repo Protocol).

### Contents (10 files)
| Path | What |
|---|---|
| `README.md` | Explains the folder; MACP = "Communication", 6 FLYWHEEL agents + AI Council validators |
| `protocol/MACP_v2.4.0_spec.md` | **Self-contained** protocol spec (readable without the thesis) |
| `protocol/triad-definition.md` | Memory-Reasoning-Handoff Triad, formally defined |
| `protocol/agent-roles.md` | FLYWHEEL TEAM roles (function-defined; no internal memory) |
| `exemplars/handoff-example-redacted.md` | **Real, sanitized** handoff — illustrates request-don't-edit + verify-before-route |
| `exemplars/reasoning-example-redacted.md` | **Real, sanitized** reasoning log — decision/forecast format |
| `governance/{GOVERNANCE,MAINTAINERS,SECURITY}.md` | Copies of the root governance set |
| `thesis/README.md` | Pointer — verbatim thesis deferred to the Zenodo deposit (see below) |

### Data-Disclosure Doctrine v1.0 — BLOCK-scan (XV condition S-1)
- Candidate exemplars scanned **before** selection → clean (no keys/tokens, PII, CLAW detail, private paths, UUIDs, low-confidence numerics, financials).
- Final sweep on the **assembled folder** → clean. Only matches are the already-public governance copies ("CLAW matrix" scope label, `.macp/reasoning/` folder convention) — no sensitive content.
- All 10 redaction rules applied; agent-memory JSON excluded entirely (S-2).

### Deliberate decision: thesis deferred
The verbatim thesis is **not** copied here. The canonical citable thesis is the **Zenodo deposit** (D5), which is gated on a metrics-section fix (AY-CR-1). Publishing a pre-final copy alongside the DOI would create source-of-truth ambiguity — exactly what this project avoids. `thesis/README.md` links the DOI once live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)