### PR TITLE
fix(security): SonarCloud P0 — env-driven host + Docker hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 WORKDIR /app
 
 # Install curl for healthcheck
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 # Copy mcp-server source code
 COPY mcp-server/ .

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 WORKDIR /app
 
 # Install curl for healthcheck
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 # Copy all source code (needed for package installation)
 COPY . .

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -1831,7 +1831,7 @@ if __name__ == "__main__":
     # container network. External access is controlled by Cloud Run ingress, not by this bind.
     uvicorn.run(
         app,
-        host="0.0.0.0",  # NOSONAR
+        host=os.getenv("HOST", "0.0.0.0"),  # NOSONAR: 0.0.0.0 default required by Cloud Run; override via HOST env
         port=port,
         log_level="info"
     )


### PR DESCRIPTION
## SonarCloud P0 (security) — first remediation pass

Careful, professional review of the security-critical issues. **The codebase posture is already sound** — most of SonarCloud's 462 are maintainability code smells (P1–P3), and the security hotspots are dominated by *intentional* design.

### Fixed in code (this PR)
| Issue | Sev | Fix |
|---|---|---|
| **S8392** `http_server.py` | BLOCKER/VULN | Bind host → `os.getenv("HOST","0.0.0.0")` — default unchanged (Cloud Run needs `0.0.0.0`), now configurable. (This is the `__main__` local path; prod binds via the Dockerfile CMD.) |
| **S6471** ×2 (both Dockerfiles) | Hotspot | `apt-get install --no-install-recommends curl` — smaller image, fewer packages; healthcheck unaffected. |

### Reviewed = intentional / by-design → recommend mark **"Safe"** in SonarCloud UI (no code change)
- **S8414** (CORSMiddleware not last): IPBlocklist is **deliberately** outermost ("reject rogue IPs before any processing"); CORS still wraps RateLimit, so `429` responses get CORS headers — which is exactly what makes the v0.5.37 browser rate-limit CTA work. Reordering would weaken the design.
- **35× S1313** (hardcoded IP): the IP **blocklist** and its tests legitimately contain specific rogue IPs — that's the feature.

### Deferred (need a controlled environment → separate PRs)
- **S8565** (no dependency lock file): run `uv lock` in the python3.12 build env and commit `uv.lock`. (`uv` isn't available locally; a mismatched lock could break the Docker build — won't hand-roll it.)
- **S6470** (non-root container user): real hardening, but needs a Docker build test before changing the runtime user.

### Next
P1 (30 BUGS) → P2 (109 CRITICAL complexity) → P3 (430 code smells, batchable), per the agreed plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)