### PR TITLE
fix(quality): SonarCloud P1 — 11 live-server float-equality bugs (S1244)

### DIFF
--- a/mcp-server/src/verifimind_mcp/middleware/polar_adapter.py
+++ b/mcp-server/src/verifimind_mcp/middleware/polar_adapter.py
@@ -191,8 +191,11 @@ class PolarAdapter:
         """
         now = time.time()
 
-        # Start a fresh window if the last failure was outside the window
-        if self._first_failure_at == 0.0 or now - self._first_failure_at > _CIRCUIT_WINDOW_SECONDS:
+        # Start a fresh window if there are no recorded failures, or the last
+        # window is outside the time bound. (_consecutive_failures == 0 is the
+        # integer-equality equivalent of the _first_failure_at == 0.0 sentinel —
+        # they are always reset together — and avoids a float equality check.)
+        if self._consecutive_failures == 0 or now - self._first_failure_at > _CIRCUIT_WINDOW_SECONDS:
             self._consecutive_failures = 1
             self._first_failure_at = now
         else:

--- a/mcp-server/tests/unit/llm/test_providers.py
+++ b/mcp-server/tests/unit/llm/test_providers.py
@@ -256,8 +256,8 @@ class TestJsonExtraction:
         text = '{"innovation_score": 8.5, "confidence": 0.9}'
         result = GeminiProvider._extract_best_json(text, ["innovation_score", "confidence"])
         assert result is not None
-        assert result["innovation_score"] == 8.5
-        assert result["confidence"] == 0.9
+        assert result["innovation_score"] == pytest.approx(8.5)
+        assert result["confidence"] == pytest.approx(0.9)
 
     def test_extract_best_json_multiple_objects(self):
         """Test extracting best match from multiple JSON objects."""
@@ -265,7 +265,7 @@ class TestJsonExtraction:
         text = '{"step_number": 1, "thought": "test"} {"innovation_score": 8.5, "confidence": 0.9, "recommendation": "go"}'
         result = GeminiProvider._extract_best_json(text, ["innovation_score", "confidence", "recommendation"])
         assert result is not None
-        assert result["innovation_score"] == 8.5
+        assert result["innovation_score"] == pytest.approx(8.5)
         assert "recommendation" in result
 
     def test_extract_best_json_no_match(self):
@@ -296,8 +296,8 @@ class TestJsonExtraction:
         }
         data = {}
         result = GeminiProvider._fill_schema_defaults(data, schema)
-        assert result["score"] == 5.0
-        assert result["confidence"] == 0.5
+        assert result["score"] == pytest.approx(5.0)
+        assert result["confidence"] == pytest.approx(0.5)
 
     def test_fill_schema_defaults_preserves_existing(self):
         """Test that existing fields are not overwritten."""
@@ -311,7 +311,7 @@ class TestJsonExtraction:
         }
         data = {"score": 8.5}
         result = GeminiProvider._fill_schema_defaults(data, schema)
-        assert result["score"] == 8.5  # preserved
+        assert result["score"] == pytest.approx(8.5)  # preserved
         assert "name" in result  # filled
 
     def test_fill_schema_defaults_boolean_and_array(self):

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -11,6 +11,8 @@ Coverage:
 
 import inspect
 
+import pytest
+
 import verifimind_mcp.server as _srv_module
 
 _SERVER_SOURCE = inspect.getsource(_srv_module)
@@ -35,7 +37,7 @@ class TestBuildRecord:
             "_overall_quality": "full",
         }
         rec = self._build("run_full_trinity", raw)
-        assert rec["overall_score"] == 8.2
+        assert rec["overall_score"] == pytest.approx(8.2)
         assert rec["recommendation"] == "PROCEED"
         assert rec["veto_triggered"] is False
         assert rec["session_id"] == "abc12345"
@@ -56,7 +58,7 @@ class TestBuildRecord:
     def test_consult_agent_x_extracts_score(self):
         raw = {"innovation_score": 7.5, "recommendation": "PROCEED"}
         rec = self._build("consult_agent_x", raw)
-        assert rec["score"] == 7.5
+        assert rec["score"] == pytest.approx(7.5)
         assert rec["recommendation"] == "PROCEED"
         assert rec["tool"] == "consult_agent_x"
 
@@ -69,13 +71,13 @@ class TestBuildRecord:
     def test_consult_agent_z_extracts_ethics_score(self):
         raw = {"ethics_score": 8.0, "recommendation": "PROCEED", "veto_triggered": False}
         rec = self._build("consult_agent_z", raw)
-        assert rec["score"] == 8.0
+        assert rec["score"] == pytest.approx(8.0)
         assert rec["veto_triggered"] is False
 
     def test_consult_agent_cs_extracts_security_score(self):
         raw = {"security_score": 6.5, "recommendation": "REVISE"}
         rec = self._build("consult_agent_cs", raw)
-        assert rec["score"] == 6.5
+        assert rec["score"] == pytest.approx(6.5)
         assert rec["tool"] == "consult_agent_cs"
 
     def test_record_always_has_uuid_tool_timestamp(self):


### PR DESCRIPTION
## SonarCloud P1 (bugs) — live-server float-equality

Resolves all **11 `S1244` BUG-class issues in `mcp-server/`** (the live server).

| File | Fix |
|---|---|
| `src/.../middleware/polar_adapter.py:195` (**production**) | Circuit-breaker fresh-window check used a float sentinel `_first_failure_at == 0.0`. Replaced with the equivalent integer check `_consecutive_failures == 0` (they're always reset together) — **behavior-identical**, no float equality. |
| `tests/unit/test_v0516_trinity_history.py` (4) | Float assertions → `pytest.approx(...)`; added `import pytest`. |
| `tests/unit/llm/test_providers.py` (6) | Float assertions → `pytest.approx(...)` (pytest already imported). |

### Scope (careful triage)
Of SonarCloud's 30 BUG findings, only these **11 are in the live server**. The other **19 are in `examples/` (14 demo scripts) + legacy `src/` (2) + root `tests/` (3)** — not production. Those are flagged for a **fix-or-archive decision** (the legacy/example code may be archival candidates, like the root cleanup) rather than reflexively patched.

### Next
P2 (109 CRITICAL — mostly cognitive-complexity refactors) → P3 (430 code smells, batchable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)