### PR TITLE
docs(d3): wire live Zenodo DOI + refresh README badges

### DIFF
--- a/.macp-public/thesis/README.md
+++ b/.macp-public/thesis/README.md
@@ -1,6 +1,8 @@
 # Thesis
 
-The full **MACP v2.4.0 thesis** — *Multi-Agent Communication Protocol: Thesis and Operational Evidence* — is being finalized for a **Zenodo deposit**. A citable **DOI will be linked here** with the v0.6.0-Beta milestone.
+The full **MACP v2.4.0 thesis** — *Multi-Agent Communication Protocol: Thesis and Operational Evidence* — is published on **Zenodo** with a permanent, citable DOI:
+
+**📄 DOI: [10.5281/zenodo.20399789](https://doi.org/10.5281/zenodo.20399789)**  ·  [Zenodo record](https://zenodo.org/record/20399789)
 
 In the meantime, the substance is already available in this folder:
 
@@ -9,7 +11,7 @@ In the meantime, the substance is already available in this folder:
 - **Real, sanitized evidence** of the protocol in action is in [`../exemplars/`](../exemplars/).
 - **The governance model** is in [`../governance/`](../governance/).
 
-> We are deliberately **not** publishing a pre-final copy of the thesis here. The deposited Zenodo version is the canonical, citable artifact — and publishing an interim copy alongside it would create exactly the kind of source-of-truth ambiguity this project works to avoid. This page will link the DOI once the deposit is live.
+> The canonical, citable version lives on **Zenodo** (DOI above) — a single source of truth. We deliberately don't duplicate the full thesis text here; please cite the DOI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 
   Three specialized agents — Innovation, Ethics, Security — review your concept before you build it. Multi-vendor (Gemini · Claude · GPT · Groq · Cerebras · Mistral · Ollama). Free, open-source, MCP-native.
 
-  [![Version](https://img.shields.io/badge/version-v0.5.34-blue.svg)](CHANGELOG.md)
+  [![Version](https://img.shields.io/badge/version-v0.5.37-blue.svg)](CHANGELOG.md)
   [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
   [![Status](https://img.shields.io/badge/status-Operational-success.svg)](SERVER_STATUS.md)
   [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-Listed-purple)](https://registry.modelcontextprotocol.io/?q=verifimind)
   [![Health](https://img.shields.io/badge/Health-LIVE-success)](https://verifimind.ysenseai.org/health)
   [![Genesis DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17972751.svg)](https://doi.org/10.5281/zenodo.17972751)
+  [![MACP Thesis DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20399789.svg)](https://doi.org/10.5281/zenodo.20399789)
 </div>
 
 ---


### PR DESCRIPTION
Propagates the published MACP v2.4.0 thesis DOI **10.5281/zenodo.20399789** now that D5 is live.

- `.macp-public/thesis/README.md`: replaces the 'forthcoming' pointer with the live DOI + Zenodo record link.
- `README.md`: adds the **MACP Thesis DOI** badge; fixes the stale version badge (v0.5.34 → **v0.5.37**, current live server).

Part of D3 (final M1 step). The co-maintainer Discussion post itself is ready (DOI filled, AZ-approved) and awaiting the go to post+pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)