### PR TITLE
feat(security): v0.5.38 Scanner Block — add 2 forensically-confirmed scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.38 - Scanner Block (May 29, 2026)
+
+Adds two scanners to the application-layer IP blocklist after GCP log forensic analysis (Sentinel investigation, 2026-05-29). Defense layers caught everything; zero data leak on either actor.
+
+### What changed
+
+- **`4.228.83.111` (Azure/Microsoft)** — added as **CMS_WEBSHELL_SCANNER**. Two bursts (2026-05-21 + 2026-05-26 14:40–14:42 UTC); ~310 req/7d; **null User-Agent** on every request. WordPress and generic PHP webshell dictionary: `wp-login.php`, `xmlrpc.php`, `wp-admin/alfa.php`, `wp-content/uploads/goods.php`, `wso.php`, `gecko.php`, `chosen.php`, `lock360.php`, `god4m.php`, ~140 additional PHP webshell names (one mixed-case `randkeyword.PhP7` — extension-case evasion attempt). Defense breakdown: 50% caught by HTTP→HTTPS redirect (Layer 3), 37% rate-limited (429, Layer 2), 13% returned 404. **Zero 200 responses.** No VerifiMind handler was reached; scanner is unaware it is hitting a Python/FastAPI service — indiscriminate spray.
+
+- **`2602:fb54:99a::` (IPv6)** — added as **SECRET_SCANNER** (same class as `195.178.110.199`, blocked 2026-05-13). Single 15-second burst 2026-05-25 19:13:03–19:13:18 UTC, 65 requests at ~4.3 req/s. **Rotating User-Agent across 18+ distinct browser/OS strings** per request (Windows/Chrome v145–147, Edge v146–147, macOS/Safari, Linux/Firefox v149–150, iOS/Safari) — botnet / distributed-proxy pattern, distinguishing this actor from the static-UA SECRET_SCANNER blocked 2026-05-13. Three-phase probe: (1) GCP-specific service-account JSON files (`serviceAccountKey.json` was literally the first probe — GCP-aware attacker), then 20+ credential JSON names; (2) `.env` variant tree across 28 paths including `.env.production.*` / `.env.local.*` backup variants; (3) `.git` internals (`HEAD`, `config`, `logs/HEAD`, `refs/heads/main`, `refs/heads/master`). Defense breakdown: 60% rate-limited (429), 34% returned 404, **3× 200 — all on the public root `/`** (known-safe surface, zero leak). Address-only block, not `/48`: the prefix scan returned only the base address, no multi-host rotation evidence.
+
+- **Cross-correlation:** the two actors operated **19 hours apart** with different tooling (null UA vs rotating UA) and different target classes (CMS vs secrets) — **independent actors, not coordinated infrastructure.**
+
+- **`BLOCKED_IPS`:** 9 entries total (was 7).
+
+### Files
+- `mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py` — 2 new entries with forensic comments
+
+---
+
 ## v0.5.37 - Tier Clarity (May 26, 2026)
 
 Branches the 429 rate-limit CTA so the response fits *why* the caller is anonymous, and surfaces `uuid_status` for diagnosis. Driven by a tier-setup audit (findings T1–T6).

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** May 26, 2026
+**Last Updated:** May 29, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.37 "Tier Clarity" — deployed May 26, 2026**
+**v0.5.38 "Scanner Block" — deployed May 29, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Scanner Block (v0.5.38)**: 2 additional scanners added to application-layer IP blocklist (9 entries total) — `4.228.83.111` (CMS_WEBSHELL_SCANNER, Azure; null UA, 310 req/7d in 2 bursts, WordPress + PHP webshell dictionary) and `2602:fb54:99a::` (SECRET_SCANNER, IPv6; rotating UA across 18+ browser strings — botnet pattern; 65 req single 15-sec burst probing GCP service-account JSON + .env tree + .git internals). GCP forensic analysis (Sentinel investigation): zero 200 on any sensitive endpoint, zero data leak on either actor; defense layers caught everything (50–60% rate-limited, 13–34% 404). Independent actors (19h apart, different tooling). Address-only block on the IPv6 — no /48 rotation evidence — May 29, 2026
 - **Tier Clarity (v0.5.37)**: 429 rate-limit CTA now branches on `uuid_status` — a *misconfigured Scholar* (UUID header present but invalid) gets a recovery hint (`VERIFIMIND_UUID` / `/setup`), while a true anonymous caller gets the register-for-Scholar acquisition CTA (+ BYOK + dashboard, Privacy-Doctrine-v1.0 line, founder/feedback note). `uuid_status` surfaced in the body + warning log. Shipped from a tier-setup audit (T1–T6); the T3/T6 reconciliation (rate-limiter reads empty `ea_registrations` vs real `early_adopters`; single source of truth for caller tier) routed to T (CTO) — May 26, 2026
 - **Changelog Hygiene (v0.5.33)**: Retroactively sanitized public `/changelog` to remove specific blocked-IP addresses from v0.5.30 and v0.5.32 entries; matches v0.5.22 / v0.5.26 disclosure pattern. Full forensics preserved in internal `CHANGELOG.md`, PR bodies, and commit history. Added disclosure-policy header to internal CHANGELOG. PR# links added to public v0.5.30 / v0.5.32 entries — May 13, 2026
 - **Secret Scanner Block + SonarCloud P1 (v0.5.32)**: 7th IP added to application-layer blocklist — credential/secret enumeration scanner, 788 req single burst on May 12 (probed `.env` variants, `.git/*`, `.terraform.*`, `.stripe/`, `?phpinfo=1`, CI configs). 77% caught by rate limiter; zero leak (4 served 200 = safe root response only). SonarCloud P1 cleanup: extracted `MCP_ENDPOINT_PATH`/`MCP_SERVER_URL`/`MCP_REMOTE_QUICKSTART` constants (removed 13 duplicate literals); refactored `http_exception_handler` cognitive complexity 23 → ≤15; CodeQL `py/empty-except` × 2 resolved; logger.exception() in registration 500 path — May 13, 2026

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.37"
+SERVER_VERSION = "0.5.38"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -44,6 +44,22 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # CI configs (.gitlab-ci, .github/workflows), Next.js/SharePoint paths. Static Chrome/131 UA.
     # 611/788 (77%) caught by rate limiter as 429; 4 served 200 (safe root/register, zero leak).
     ("195.178.110.199", "SECRET_SCANNER", "2026-05-13", "RNA_CSO"),
+    # CMS Webshell Scanner — Azure/Microsoft range; null UA on every request; ~310 req/7d in 2 bursts
+    # (2026-05-21 + 2026-05-26 14:40-14:42 UTC); WordPress + PHP webshell dictionary (wp-login.php,
+    # xmlrpc.php, wp-admin/alfa.php, wp-content/uploads/goods.php, wso.php, gecko.php, chosen.php,
+    # lock360.php, god4m.php, ~140 PHP webshell names incl. mixed-case randkeyword.PhP7 evasion);
+    # 50% redirected (Layer 3), 37% rate-limited (429), 13% 404; zero 200; no VerifiMind handler hit.
+    ("4.228.83.111", "CMS_WEBSHELL_SCANNER", "2026-05-29", "RNA_CSO"),
+    # Secret / Credential Scanner — IPv6; single 15-second burst 2026-05-25 19:13:03-19:13:18 UTC;
+    # 65 req @ ~4.3 req/s; rotating UA across 18+ distinct browser/OS strings per request (Windows/
+    # Chrome v145-147, Edge v146-147, macOS/Safari, Linux/Firefox v149-150, iOS/Safari — botnet/
+    # distributed-proxy pattern); 3-phase probe: (1) GCP service-account JSON files (serviceAccount
+    # Key.json was the first probe — GCP-aware attacker), (2) .env variant tree across 28 paths
+    # incl. .env.production.*/.env.local.* backup variants, (3) .git internals (HEAD/config/
+    # logs/HEAD/refs/heads/main/master); 60% rate-limited, 34% 404, 3x 200 ALL on public root /;
+    # zero leak. Same SECRET_SCANNER class as 195.178.110.199 (2026-05-13). Address-only block —
+    # /48 prefix scan returned only the base address, no multi-host rotation observed.
+    ("2602:fb54:99a::", "SECRET_SCANNER", "2026-05-29", "RNA_CSO"),
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.37"
+SERVER_VERSION = "0.5.38"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.37"
+        assert http_server.SERVER_VERSION == "0.5.38"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.37", (
-            f"Expected 0.5.37, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.38", (
+            f"Expected 0.5.38, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.37"
+        assert SERVER_VERSION == "0.5.38"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.37"
+        assert SERVER_VERSION == "0.5.38"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.37", f"Expected 0.5.37, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.38", f"Expected 0.5.38, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.37", f"Expected 0.5.37, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.38", f"Expected 0.5.38, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -171,7 +171,7 @@ class TestResolveUuidTier:
 
 
 # ---------------------------------------------------------------------------
-# v0.5.37 — 429 CTA branching (tier-audit T4/T5)
+# v0.5.38 — 429 CTA branching (tier-audit T4/T5)
 # ---------------------------------------------------------------------------
 
 class TestBuildRateLimitCta:
@@ -214,4 +214,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.37", f"Expected 0.5.37, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.38", f"Expected 0.5.38, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.37"
+        assert http_server.SERVER_VERSION == "0.5.38"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.37"
+        assert http_server.SERVER_VERSION == "0.5.38"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.37",
-  "version": "3.14.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.38",
+  "version": "3.15.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"
@@ -34,19 +34,19 @@
       "tools": [
         {
           "name": "consult_agent_x",
-          "description": "Innovation & Strategy Analysis — X Agent v4.2 with competitive positioning vs LangChain, CrewAI, AutoGen, OpenAI Swarm"
+          "description": "Innovation & Strategy Analysis \u00e2\u20ac\u201d X Agent v4.2 with competitive positioning vs LangChain, CrewAI, AutoGen, OpenAI Swarm"
         },
         {
           "name": "consult_agent_z",
-          "description": "Ethics & Compliance Review — Z Guardian v4.2 Sentinel-Verified with 21-framework, 4-tier jurisdictional coverage (International / EU / US / ASEAN)"
+          "description": "Ethics & Compliance Review \u00e2\u20ac\u201d Z Guardian v4.2 Sentinel-Verified with 21-framework, 4-tier jurisdictional coverage (International / EU / US / ASEAN)"
         },
         {
           "name": "consult_agent_cs",
-          "description": "Security Validation — CS Security v1.1 Sentinel-Verified: 6-stage pipeline, 12 dimensions, OWASP Agentic AI Top 10, reasoning-layer audit"
+          "description": "Security Validation \u00e2\u20ac\u201d CS Security v1.1 Sentinel-Verified: 6-stage pipeline, 12 dimensions, OWASP Agentic AI Top 10, reasoning-layer audit"
         },
         {
           "name": "run_full_trinity",
-          "description": "Complete X → Z → CS Trinity validation with Chain of Thought. Each agent sees prior reasoning. Returns unified assessment with scores."
+          "description": "Complete X \u00e2\u2020\u2019 Z \u00e2\u2020\u2019 CS Trinity validation with Chain of Thought. Each agent sees prior reasoning. Returns unified assessment with scores."
         },
         {
           "name": "list_prompt_templates",
@@ -82,7 +82,7 @@
         },
         {
           "name": "coordination_team_status",
-          "description": "Get current FLYWHEEL TEAM status — active agents, pending handoffs, last session summary"
+          "description": "Get current FLYWHEEL TEAM status \u00e2\u20ac\u201d active agents, pending handoffs, last session summary"
         }
       ]
     }


### PR DESCRIPTION
## v0.5.38 — Scanner Block (security patch)

Adds two scanners to the application-layer IP blocklist after **Sentinel forensic investigation** of GCP Cloud Logs (2026-05-29, 7-day window). **Zero data leak on either actor** — defense layers caught everything.

### Blocks (`BLOCKED_IPS`: 7 → 9)
| IP | Class | Signal | Defense outcome |
|---|---|---|---|
| `4.228.83.111` (Azure) | **CMS_WEBSHELL_SCANNER** | Null UA, 2 bursts (May 21 + May 26), ~310 req/7d, WordPress + PHP webshell dictionary (`wp-login.php`, `xmlrpc.php`, `alfa.php`, `wso.php`, ~140 names incl. mixed-case `randkeyword.PhP7`) | 50% redirected, 37% rate-limited, 13% 404, **0 × 200** |
| `2602:fb54:99a::` (IPv6) | **SECRET_SCANNER** | **Rotating UA across 18+ browser/OS strings** (botnet), single 15-sec burst @ 4.3 req/s, 3-phase probe: GCP service-account JSON → `.env` tree (28 paths) → `.git` internals | 60% rate-limited, 34% 404, 3× 200 **all on public `/`** (zero leak) |

**Cross-correlation:** independent actors (19h apart, different tooling, different targets — CMS vs secrets). IPv6 blocked at **address only** — `/48` prefix scan showed no rotation.

### Deploy contract — all version surfaces synced
- ✅ `SERVER_VERSION = "0.5.38"` in `http_server.py` + `server.py`
- ✅ 9 test files' SERVER_VERSION assertions bumped
- ✅ `server.json` version `3.14.0` → `3.15.0`, description carries `v0.5.38` (79/100 chars)
- ✅ `CHANGELOG.md` v0.5.38 internal entry (full forensics, per disclosure policy v0.5.33)
- ✅ `SERVER_STATUS.md` header + new bullet
- ✅ Branch off `76be557`, explicit `git add` (no `-A`)

### Post-merge
Run `/verifimind-deploy 0.5.38` (full skill — no bypass), then verify `/health` and cut **GitHub Release `v0.5.38`** with full-SHA target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)