### PR TITLE
feat(security+quality): v0.5.39 Registry Scanner Block + SonarCloud P2 batch-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.39 - Registry Scanner Block + P2 Batch-2 (June 1, 2026)
+
+Combines a security-hygiene IP block (10th entry — AY+AZ forensics 2026-05-30) with the second batch of SonarCloud P2 dup-literal constant extractions. Behavior-identical refactors; defense outcome verified zero leak on the new actor (zero handler reached in 400 prior requests).
+
+### What changed
+
+**Blocklist — 10th entry**
+
+- **`3.137.30.179`** — added as **AISEC_REGISTRY_SCANNER**. User-Agent `aisec-registry/0.2 (+https://sec.sqrx.io)` on **100% of 400 requests**; 5-day cron-like persistence (May 23–27, ~80 req/day); **MCP/OAuth surface enumeration** (89× POST `/mcp` + 89× GET `/mcp/.well-known/oauth-{authorization-server,protected-resource,mcp}`); HTTP 200 = **0** (never reached a real handler), 268× 429 (rate-limited), 88× 404 (OAuth discovery failures). Not a builder, not a Scholar conversion candidate, no `/register` intent. AY+AZ forensics 2026-05-30 (see `.macp/handoffs/20260530_AY_to_RNA_block_ip10_3_137_30_179.md`). **`BLOCKED_IPS`: 10 entries total** (was 9).
+
+**SonarCloud P2 batch-2 — 8 module-level constants extracted from 25 dup-literal occurrences**
+
+- `mcp-server/src/verifimind_mcp/llm/provider.py` — extracted **4 provider-default-model constants**: `PROVIDER_DEFAULT_GEMINI_MODEL` ("gemini-2.5-flash", 3×), `PROVIDER_DEFAULT_OPENAI_MODEL` ("gpt-4.1-mini", 3×), `PROVIDER_DEFAULT_GROQ_MODEL` ("llama-3.3-70b-versatile", 3×), `PROVIDER_DEFAULT_CEREBRAS_MODEL` ("llama-3.3-70b", 3×).
+- `mcp-server/src/verifimind_mcp/server.py` — extracted **4 agent/prompt constants**: `AGENT_X_NAME` ("X Intelligent", 4×), `AGENT_Z_NAME` ("Z Guardian", 3×), `AGENT_CS_NAME` ("CS Security", 3×), `MASTER_PROMPT_FILENAME` ("reflexion-master-prompts-v1.1.md", 3×).
+
+**Scope discipline (substance preservation per Genesis §13.X proposal)**
+
+- **Deferred (1 candidate):** `"?"` placeholder at `provider.py:361` — extracting a single-char marker to a named constant would add more cognitive load than the SonarCloud noise it removes. Alternative: mark Safe in SonarCloud UI.
+- **Out of P2 batch-2 scope:** S3776 cognitive-complexity refactors (6 in provider.py, 1 in server.py) — slated for P2 batch-3 (function-level refactors, different risk profile than mechanical extractions).
+- **False-match audit pre-flight (PASSED):** verified `"gemini-2.5-flash"` ≠ `"gemini-2.5-flash-lite"` substring and `"llama-3.3-70b"` ≠ `"llama-3.3-70b-versatile"` substring (closing-quote bracketing prevents replace_all collision).
+
+### Files
+- `mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py` — +1 entry with forensic comment
+- `mcp-server/src/verifimind_mcp/llm/provider.py` — 4 constants (12 occurrences → 4 definitions)
+- `mcp-server/src/verifimind_mcp/server.py` — 4 constants (13 occurrences → 4 definitions)
+
+---
+
 ## v0.5.38 - Scanner Block (May 29, 2026)
 
 Adds two scanners to the application-layer IP blocklist after GCP log forensic analysis (Sentinel investigation, 2026-05-29). Defense layers caught everything; zero data leak on either actor.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** May 29, 2026
+**Last Updated:** June 1, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.38 "Scanner Block" — deployed May 29, 2026**
+**v0.5.39 "Registry Scanner Block + P2 Batch-2" — deployed June 1, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Registry Scanner Block + P2 Batch-2 (v0.5.39)**: 10th IP added to application-layer blocklist (BLOCKED_IPS: 10 entries total) — `3.137.30.179` (AISEC_REGISTRY_SCANNER); UA `aisec-registry/0.2 (+https://sec.sqrx.io)` on 100% of 400 requests over 5-day cron-like persistence (May 23–27, ~80 req/day); MCP/OAuth surface enumeration (89× POST `/mcp` + 89× GET `/mcp/.well-known/oauth-*` discovery); HTTP 200 = 0 (never reached a real handler), 268× 429, 88× 404. Not a builder, no `/register` intent. AY+AZ forensics 2026-05-30. + SonarCloud P2 batch-2: 8 module-level constants extracted from 25 dup-literal occurrences in `llm/provider.py` (4 provider-default-model constants) and `server.py` (4 agent/prompt constants); behavior-identical refactors; substance preservation per Genesis §13.X proposal — June 1, 2026
 - **Scanner Block (v0.5.38)**: 2 additional scanners added to application-layer IP blocklist (9 entries total) — `4.228.83.111` (CMS_WEBSHELL_SCANNER, Azure; null UA, 310 req/7d in 2 bursts, WordPress + PHP webshell dictionary) and `2602:fb54:99a::` (SECRET_SCANNER, IPv6; rotating UA across 18+ browser strings — botnet pattern; 65 req single 15-sec burst probing GCP service-account JSON + .env tree + .git internals). GCP forensic analysis (Sentinel investigation): zero 200 on any sensitive endpoint, zero data leak on either actor; defense layers caught everything (50–60% rate-limited, 13–34% 404). Independent actors (19h apart, different tooling). Address-only block on the IPv6 — no /48 rotation evidence — May 29, 2026
 - **Tier Clarity (v0.5.37)**: 429 rate-limit CTA now branches on `uuid_status` — a *misconfigured Scholar* (UUID header present but invalid) gets a recovery hint (`VERIFIMIND_UUID` / `/setup`), while a true anonymous caller gets the register-for-Scholar acquisition CTA (+ BYOK + dashboard, Privacy-Doctrine-v1.0 line, founder/feedback note). `uuid_status` surfaced in the body + warning log. Shipped from a tier-setup audit (T1–T6); the T3/T6 reconciliation (rate-limiter reads empty `ea_registrations` vs real `early_adopters`; single source of truth for caller tier) routed to T (CTO) — May 26, 2026
 - **Changelog Hygiene (v0.5.33)**: Retroactively sanitized public `/changelog` to remove specific blocked-IP addresses from v0.5.30 and v0.5.32 entries; matches v0.5.22 / v0.5.26 disclosure pattern. Full forensics preserved in internal `CHANGELOG.md`, PR bodies, and commit history. Added disclosure-policy header to internal CHANGELOG. PR# links added to public v0.5.30 / v0.5.32 entries — May 13, 2026

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.38"
+SERVER_VERSION = "0.5.39"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/llm/provider.py
+++ b/mcp-server/src/verifimind_mcp/llm/provider.py
@@ -66,11 +66,19 @@ def strip_markdown_code_fences(text: str) -> str:
 # PROVIDER CONFIGURATION (BYOK v0.4.0 — Provider Sync)
 # ============================================================================
 
+# Default model per provider — single source of truth.
+# (SonarCloud P2 batch-2: extracted in v0.5.39 from 12 dup-literal occurrences
+# across `default_model` fields, models list entries, and per-method defaults.)
+PROVIDER_DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
+PROVIDER_DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
+PROVIDER_DEFAULT_GROQ_MODEL = "llama-3.3-70b-versatile"
+PROVIDER_DEFAULT_CEREBRAS_MODEL = "llama-3.3-70b"
+
 PROVIDER_CONFIGS: Dict[str, Dict[str, Any]] = {
     "gemini": {
         "name": "Google Gemini",
-        "default_model": "gemini-2.5-flash",
-        "models": ["gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.0-flash"],
+        "default_model": PROVIDER_DEFAULT_GEMINI_MODEL,
+        "models": [PROVIDER_DEFAULT_GEMINI_MODEL, "gemini-2.5-flash-lite", "gemini-2.0-flash"],
         "api_key_env": "GEMINI_API_KEY",
         "base_url": "https://generativelanguage.googleapis.com/v1beta",
         "free_tier": True,
@@ -78,8 +86,8 @@ PROVIDER_CONFIGS: Dict[str, Dict[str, Any]] = {
     },
     "openai": {
         "name": "OpenAI",
-        "default_model": "gpt-4.1-mini",
-        "models": ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-mini"],
+        "default_model": PROVIDER_DEFAULT_OPENAI_MODEL,
+        "models": ["gpt-4.1", PROVIDER_DEFAULT_OPENAI_MODEL, "gpt-4.1-nano", "gpt-4o", "gpt-4o-mini"],
         "api_key_env": "OPENAI_API_KEY",
         "base_url": "https://api.openai.com/v1",
         "free_tier": False,
@@ -94,9 +102,9 @@ PROVIDER_CONFIGS: Dict[str, Dict[str, Any]] = {
     },
     "groq": {
         "name": "Groq",
-        "default_model": "llama-3.3-70b-versatile",
+        "default_model": PROVIDER_DEFAULT_GROQ_MODEL,
         "models": [
-            "llama-3.3-70b-versatile",
+            PROVIDER_DEFAULT_GROQ_MODEL,
             "meta-llama/llama-4-scout-17b-16e-instruct",
             "llama-3.1-8b-instant",
         ],
@@ -107,8 +115,8 @@ PROVIDER_CONFIGS: Dict[str, Dict[str, Any]] = {
     },
     "cerebras": {
         "name": "Cerebras",
-        "default_model": "llama-3.3-70b",
-        "models": ["llama-3.3-70b", "llama-3.1-8b"],
+        "default_model": PROVIDER_DEFAULT_CEREBRAS_MODEL,
+        "models": [PROVIDER_DEFAULT_CEREBRAS_MODEL, "llama-3.1-8b"],
         "api_key_env": "CEREBRAS_API_KEY",
         "base_url": "https://api.cerebras.ai/v1",
         "free_tier": True,
@@ -222,7 +230,7 @@ class OpenAIProvider(LLMProvider):
         model: str = None,
         api_key: Optional[str] = None
     ):
-        self.model = model or os.environ.get("OPENAI_MODEL", "gpt-4.1-mini")
+        self.model = model or os.environ.get("OPENAI_MODEL", PROVIDER_DEFAULT_OPENAI_MODEL)
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         
         if not self.api_key:
@@ -395,7 +403,7 @@ class GeminiProvider(LLMProvider):
 
     def __init__(
         self,
-        model: str = "gemini-2.5-flash",
+        model: str = PROVIDER_DEFAULT_GEMINI_MODEL,
         api_key: Optional[str] = None
     ):
         self.model = model
@@ -758,7 +766,7 @@ class GroqProvider(LLMProvider):
 
     def __init__(
         self,
-        model: str = "llama-3.3-70b-versatile",
+        model: str = PROVIDER_DEFAULT_GROQ_MODEL,
         api_key: Optional[str] = None
     ):
         self.model = model
@@ -909,7 +917,7 @@ class CerebrasProvider(LLMProvider):
 
     def __init__(
         self,
-        model: str = "llama-3.3-70b",
+        model: str = PROVIDER_DEFAULT_CEREBRAS_MODEL,
         api_key: Optional[str] = None
     ):
         self.model = model

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -60,6 +60,14 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # zero leak. Same SECRET_SCANNER class as 195.178.110.199 (2026-05-13). Address-only block —
     # /48 prefix scan returned only the base address, no multi-host rotation observed.
     ("2602:fb54:99a::", "SECRET_SCANNER", "2026-05-29", "RNA_CSO"),
+    # AISEC Registry Scanner — UA `aisec-registry/0.2 (+https://sec.sqrx.io)` on 100% of 400 requests;
+    # 5-day cron-like persistence (May 23-27, ~80 req/day); MCP/OAuth surface enumeration: 89× POST /mcp +
+    # 89× GET /mcp/.well-known/oauth-{authorization-server,protected-resource,mcp}; HTTP 200 = 0 (never
+    # reached a real handler), 268× 429 (rate-limited), 88× 404 (OAuth discovery failures); not a builder,
+    # not a Scholar conversion candidate, no /register intent. AY+AZ forensics 2026-05-30 (see
+    # .macp/handoffs/20260530_AY_to_RNA_block_ip10_3_137_30_179.md). Same non-user automated-probe class as
+    # 4.228.83.111 / 2602:fb54:99a:: but with higher volume persistence; address-only block.
+    ("3.137.30.179", "AISEC_REGISTRY_SCANNER", "2026-06-01", "RNA_CSO"),
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,15 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.38"
+SERVER_VERSION = "0.5.39"
+
+# Agent role names + master prompt filename — single source of truth.
+# (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences
+# across project_info dict, agent dispatch, and path resolution.)
+AGENT_X_NAME = "X Intelligent"
+AGENT_Z_NAME = "Z Guardian"
+AGENT_CS_NAME = "CS Security"
+MASTER_PROMPT_FILENAME = "reflexion-master-prompts-v1.1.md"
 
 # Mock mode transparency — shown in every tool response when no real inference is available
 MOCK_MODE_WARNING = (
@@ -161,9 +169,9 @@ def _get_master_prompt_path() -> Path:
     # 3. Repository root (development)
 
     candidates = [
-        Path.cwd() / "reflexion-master-prompts-v1.1.md",  # Docker: /app/
-        Path(__file__).parent.parent.parent / "reflexion-master-prompts-v1.1.md",  # Package parent
-        Path(__file__).parent.parent.parent.parent / "reflexion-master-prompts-v1.1.md",  # Repo root
+        Path.cwd() / MASTER_PROMPT_FILENAME,  # Docker: /app/
+        Path(__file__).parent.parent.parent / MASTER_PROMPT_FILENAME,  # Package parent
+        Path(__file__).parent.parent.parent.parent / MASTER_PROMPT_FILENAME,  # Repo root
     ]
 
     for path in candidates:
@@ -250,18 +258,18 @@ def get_project_info() -> dict[str, Any]:
         "mcp_server_version": "0.4.5",
         "agents": {
             "X": {
-                "name": "X Intelligent",
+                "name": AGENT_X_NAME,
                 "role": "Innovation and Strategy Engine",
                 "focus": ["Innovation potential", "Strategic value", "Market opportunities"]
             },
             "Z": {
-                "name": "Z Guardian",
+                "name": AGENT_Z_NAME,
                 "role": "Ethical Review and Z-Protocol Enforcement",
                 "focus": ["Ethics", "Privacy", "Bias", "Social impact"],
                 "has_veto_power": True
             },
             "CS": {
-                "name": "CS Security",
+                "name": AGENT_CS_NAME,
                 "role": "Security Validation and Socratic Interrogation",
                 "focus": ["Security vulnerabilities", "Attack vectors", "Socratic questioning"]
             }
@@ -424,7 +432,7 @@ def _create_mcp_instance():
 
             _iq = getattr(result, '_inference_quality', 'unknown')
             payload = {
-                "agent": "X Intelligent",
+                "agent": AGENT_X_NAME,
                 "concept": concept_name,
                 "reasoning_steps": [
                     {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
@@ -447,7 +455,7 @@ def _create_mcp_instance():
 
         except Exception as e:
             return wrap_response({
-                "agent": "X Intelligent",
+                "agent": AGENT_X_NAME,
                 "status": "error",
                 "error": str(e),
                 "concept": concept_name
@@ -523,7 +531,7 @@ def _create_mcp_instance():
                 prior = PriorReasoning()
                 prior.add(ChainOfThought(
                     agent_id="X",
-                    agent_name="X Intelligent",
+                    agent_name=AGENT_X_NAME,
                     concept_name=concept_name,
                     reasoning_steps=[ReasoningStep(step_number=1, thought=prior_reasoning)],
                     final_conclusion="See prior reasoning above",
@@ -545,7 +553,7 @@ def _create_mcp_instance():
 
             _iq = getattr(result, '_inference_quality', 'unknown')
             payload = {
-                "agent": "Z Guardian",
+                "agent": AGENT_Z_NAME,
                 "concept": concept_name,
                 "reasoning_steps": [
                     {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
@@ -569,7 +577,7 @@ def _create_mcp_instance():
 
         except Exception as e:
             return wrap_response({
-                "agent": "Z Guardian",
+                "agent": AGENT_Z_NAME,
                 "status": "error",
                 "error": str(e),
                 "concept": concept_name
@@ -662,7 +670,7 @@ def _create_mcp_instance():
             result = await agent.analyze(concept, prior)
 
             payload = {
-                "agent": "CS Security",
+                "agent": AGENT_CS_NAME,
                 "concept": concept_name,
                 "reasoning_steps": [
                     {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
@@ -686,7 +694,7 @@ def _create_mcp_instance():
 
         except Exception as e:
             return wrap_response({
-                "agent": "CS Security",
+                "agent": AGENT_CS_NAME,
                 "status": "error",
                 "error": str(e),
                 "concept": concept_name

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.38"
+        assert http_server.SERVER_VERSION == "0.5.39"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.38", (
-            f"Expected 0.5.38, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.39", (
+            f"Expected 0.5.39, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.38"
+        assert SERVER_VERSION == "0.5.39"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.38"
+        assert SERVER_VERSION == "0.5.39"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.38", f"Expected 0.5.38, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.39", f"Expected 0.5.39, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.38", f"Expected 0.5.38, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.39", f"Expected 0.5.39, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -171,7 +171,7 @@ class TestResolveUuidTier:
 
 
 # ---------------------------------------------------------------------------
-# v0.5.38 — 429 CTA branching (tier-audit T4/T5)
+# v0.5.39 — 429 CTA branching (tier-audit T4/T5)
 # ---------------------------------------------------------------------------
 
 class TestBuildRateLimitCta:
@@ -214,4 +214,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.38", f"Expected 0.5.38, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.39", f"Expected 0.5.39, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.38"
+        assert http_server.SERVER_VERSION == "0.5.39"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.38"
+        assert http_server.SERVER_VERSION == "0.5.39"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.38",
-  "version": "3.15.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.39",
+  "version": "3.16.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## v0.5.39 — Registry Scanner Block (IP #10) + SonarCloud P2 batch-2

Combined patch: security-hygiene block (10th `BLOCKED_IPS` entry, AY+AZ forensics 2026-05-30) + the second batch of SonarCloud P2 dup-literal extractions (provider.py + server.py).

### Blocklist — `3.137.30.179` (`AISEC_REGISTRY_SCANNER`)
| Field | Value |
|---|---|
| User-Agent | `aisec-registry/0.2 (+https://sec.sqrx.io)` on **100% of 400 req** |
| Pattern | 5-day cron-like persistence (May 23–27, ~80 req/day); MCP/OAuth surface enumeration |
| Defense outcome | HTTP 200 = **0** (never reached a handler) · 268× 429 · 88× 404 |
| Class | Non-user automated probe (not builder, not Scholar conversion candidate, no `/register`) |

**`BLOCKED_IPS`: 9 → 10.** Acceptance criteria from AY+AZ handoff met.

### SonarCloud P2 batch-2 — 8 module-level constants
27 dup-literal occurrences → 8 definitions (one per constant).

| File | Constants extracted | Occurrences before |
|---|---|---|
| `llm/provider.py` | `PROVIDER_DEFAULT_GEMINI_MODEL` / `_OPENAI_MODEL` / `_GROQ_MODEL` / `_CEREBRAS_MODEL` | 12 |
| `server.py` | `AGENT_X_NAME` / `AGENT_Z_NAME` / `AGENT_CS_NAME` / `MASTER_PROMPT_FILENAME` | 13 |

### Scope discipline (substance preservation per Genesis §13.X proposal)
- **Deferred (1 candidate):** `"?"` at `provider.py:361` — single-char placeholder; extraction would *add* cognitive load disproportionate to the noise removed. Mark Safe in SonarCloud UI alternatively.
- **Out of P2 batch-2 scope:** S3776 cognitive-complexity refactors (6 in provider.py, 1 in server.py) — slated for **P2 batch-3** (function-level, different risk profile).
- **False-match audit pre-flight (PASSED):** verified the substring traps (`"llama-3.3-70b"` ≠ `"llama-3.3-70b-versatile"`, `"gemini-2.5-flash"` ≠ `"gemini-2.5-flash-lite"`) before each `replace_all`.

### Expected SonarCloud gate behavior
- **Net positive on dup-literal CRITICAL** (−25 of 40 mcp-server S1192 hits).
- **1 new S1313 hotspot** on the IP #10 entry — same by-design class as the 37 existing IP-blocklist hotspots; admin-merge precedent established in #237 (v0.5.38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)