### PR TITLE
harden(mcp-server): add .dockerignore mirroring .gcloudignore

### DIFF
--- a/mcp-server/.dockerignore
+++ b/mcp-server/.dockerignore
@@ -1,0 +1,51 @@
+# Docker build-context exclusions for the VerifiMind MCP Server image.
+#
+# Mirrors .gcloudignore so that a local `docker build` produces an image
+# IDENTICAL to the `gcloud builds submit` deploy path. Without this file the
+# Dockerfile's `COPY . .` is unguarded: a direct `docker build` would ship
+# tests/, docs/, examples/, and any local .env into the running image even
+# though the gcloud deploy path filters them. Defense-in-depth — keeps the
+# prod/non-prod boundary deploy-path-independent.
+#
+# Reference: RNA triage 2026-06-03 (.macp/reports/20260603_RNA_nonprod_critical_bleed_triage.md, PRIVATE Hub)
+
+# Version control
+.git
+.gitignore
+
+# Python build artifacts
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.so
+*.egg
+*.egg-info
+dist
+build
+
+# Test / coverage tooling
+.pytest_cache
+.coverage
+htmlcov
+.tox
+
+# Secrets / local environments (MUST NOT ship in image)
+.env
+.venv
+venv/
+ENV/
+
+# Non-production source (not imported by the ASGI app; excluded from image)
+tests/
+docs/
+examples/
+*.md
+!README.md
+
+# OS / editor cruft
+.DS_Store
+*.swp
+*.swo
+node_modules/


### PR DESCRIPTION
## Summary
Adds `mcp-server/.dockerignore` mirroring the existing `.gcloudignore`, closing the one structural prod/non-prod bleed gap found in RNA's hardening-sprint triage (2026-06-03).

## Why
The Dockerfile's `COPY . .` is unguarded. Today the prod/non-prod boundary holds **only** because deploy goes through `gcloud builds submit`, which honors `.gcloudignore`. A raw `docker build` (or any non-gcloud build path) would ship `tests/`, `docs/`, `examples/`, and any local `.env` straight into the running image.

This makes the boundary **deploy-path-independent**: any build path now produces an image identical to the gcloud deploy.

## Impact
- **No behavior change** to the current `gcloud run deploy` path (`.gcloudignore` already filtered these).
- Pure **P3 defense-in-depth**. Not a version surface — no SERVER_VERSION bump, no `server.json` change, no deploy required.

## Verification
Mirrors `.gcloudignore` exactly (tests/docs/examples/*.md except README, secrets, build artifacts). Package install (`uv pip install .`) still has `src/`, `pyproject`, and `README.md` available.

## Context
Hardening Sprint Day ~3 (AI Council Session 28, D-28-2 operational resilience). Triage record: `.macp/reports/20260603_RNA_nonprod_critical_bleed_triage.md` (PRIVATE Hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)