### PR TITLE
feat(v0.5.40): registration funnel fix (D-30-3) + /whoami + model-currency bump

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -1210,18 +1210,81 @@ async def ea_register_handler(request):
 
 
 async def ea_status_handler(request):
-    """GET /early-adopters/status/{uuid} — check EA tier status."""
+    """GET /early-adopters/status/{uuid} — check EA tier status (D-30-3).
+
+    Returns 200 for any valid UUID:
+      - registered EA → full status record
+      - valid UUID without EA record → scholar tier response + register CTA
+    Only returns 400/404 for missing or invalid UUID format.
+    """
+    from verifimind_mcp.utils.uuid_tracer import is_valid_uuid
     uuid = request.path_params.get("uuid", "")
     if not uuid:
         return JSONResponse({"error": "UUID required"}, status_code=400)
+    if not is_valid_uuid(uuid):
+        return JSONResponse({"error": "Invalid UUID format"}, status_code=400)
 
     status = await get_ea_status(uuid)
     if status is None:
-        return JSONResponse(
-            {"error": "Early Adopter record not found for this UUID"},
-            status_code=404,
-        )
+        return JSONResponse({
+            "uuid": uuid,
+            "tier": "scholar",
+            "status": "unregistered",
+            "message": (
+                "You have a valid Scholar UUID. Register as an Early Adopter to unlock "
+                "full benefits and help shape the v0.6.0-Beta roadmap."
+            ),
+            "register_url": "https://verifimind.ysenseai.org/register",
+        }, status_code=200)
     return JSONResponse(status.model_dump())
+
+
+async def whoami_handler(request):
+    """GET /whoami — self-serve UUID tier and registration status (D-30-3).
+
+    Reads UUID from X-VerifiMind-UUID header or ?uuid= query param.
+    Returns tier, registration state, and next-step guidance.
+    No auth required — privacy-safe (UUID is user's own identifier).
+    """
+    from verifimind_mcp.utils.uuid_tracer import is_valid_uuid
+    uuid = (
+        request.headers.get("x-verifimind-uuid", "").strip()
+        or request.query_params.get("uuid", "").strip()
+    )
+    if not uuid or not is_valid_uuid(uuid):
+        return JSONResponse({
+            "tier": "anonymous",
+            "status": "no_uuid",
+            "message": (
+                "No valid UUID provided. Set VERIFIMIND_UUID in your MCP config or "
+                "pass ?uuid=<your-uuid> to check your status."
+            ),
+            "setup_url": "https://verifimind.ysenseai.org/setup",
+            "register_url": "https://verifimind.ysenseai.org/register",
+        }, status_code=200)
+
+    ea_status = await get_ea_status(uuid)
+    if ea_status is not None:
+        return JSONResponse({
+            "uuid": uuid,
+            "tier": ea_status.tier,
+            "status": ea_status.status,
+            "registered_at": ea_status.registered_at,
+            "benefits_free_until": ea_status.benefits_free_until,
+            "rate_limit": "100 req/60s",
+        }, status_code=200)
+
+    return JSONResponse({
+        "uuid": uuid,
+        "tier": "scholar",
+        "status": "unregistered",
+        "rate_limit": "30 req/60s",
+        "message": (
+            "You have a valid Scholar UUID (30 req/60s, BYOK enabled). "
+            "Register as an Early Adopter for higher limits and v0.6.0-Beta benefits."
+        ),
+        "register_url": "https://verifimind.ysenseai.org/register",
+    }, status_code=200)
 
 
 async def ea_dashboard_handler(request):
@@ -1730,6 +1793,7 @@ app = Starlette(
         Route(MCP_CONFIG_PATH, mcp_config_handler),
         Route("/.well-known/mcp/server-card.json", smithery_server_card_handler),
         # v0.5.6 Gateway: EA registration + feedback + policy
+        Route("/whoami", whoami_handler, methods=["GET"]),
         Route("/early-adopters/register", ea_register_handler, methods=["POST"]),
         Route("/early-adopters/status/{uuid}", ea_status_handler, methods=["GET"]),
         Route("/early-adopters/dashboard/{uuid}", ea_dashboard_handler, methods=["GET"]),

--- a/mcp-server/src/verifimind_mcp/llm/provider.py
+++ b/mcp-server/src/verifimind_mcp/llm/provider.py
@@ -95,7 +95,7 @@ PROVIDER_CONFIGS: Dict[str, Dict[str, Any]] = {
     "anthropic": {
         "name": "Anthropic Claude",
         "default_model": os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
-        "models": ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5-20251001"],
+        "models": ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5-20251001"],
         "api_key_env": "ANTHROPIC_API_KEY",
         "base_url": "https://api.anthropic.com/v1",
         "free_tier": False,

--- a/mcp-server/src/verifimind_mcp/middleware/rate_limiter.py
+++ b/mcp-server/src/verifimind_mcp/middleware/rate_limiter.py
@@ -5,8 +5,8 @@ v0.5.19 - UUID Tier-Aware Rate Limiting (P0-A)
 
 Tiers (per 60s window):
   Anonymous  — no valid UUID header → 10 req/60s per IP
-  Scholar    — valid UUID, not in ea_registrations → 30 req/60s per UUID
-  EA/Pioneer — valid UUID, in ea_registrations → 100 req/60s per UUID
+  Scholar    — valid UUID, not in early_adopters → 30 req/60s per UUID
+  EA/Pioneer — valid UUID, in early_adopters → 100 req/60s per UUID
 
 UUID is read from the X-VerifiMind-UUID header (auto-sent by mcp-remote
 after v0.5.17 mcp_config header fix). Falls back to IP-based limit when
@@ -46,13 +46,14 @@ _uuid_tier_cache: Dict[str, Tuple[str, float]] = {}
 UUID_TIER_CACHE_TTL = 300  # 5 minutes — matches Firestore session TTL
 
 # Exempt paths from rate limiting
-EXEMPT_PATHS = {"/health", "/", "/.well-known/mcp-config", "/setup", "/register", "/optout", "/privacy", "/terms", "/robots.txt", "/favicon.ico", "/early-adopters/register"}
+EXEMPT_PATHS = {"/health", "/", "/.well-known/mcp-config", "/setup", "/register", "/optout", "/privacy", "/terms", "/robots.txt", "/favicon.ico", "/early-adopters/register", "/whoami"}
 
 
 def _resolve_uuid_tier(uuid: str) -> str:
     """Return tier for a valid UUID. Cached for UUID_TIER_CACHE_TTL seconds.
 
-    Checks ea_registrations Firestore collection:
+    Checks early_adopters Firestore collection (D-30-3: B3 consolidation,
+    early_adopters = single source of truth):
       - found → "pioneer"  (EA + Pioneer both get 100/60s)
       - not found → "scholar" (valid UUID, free tier, 30/60s)
       - Firestore unavailable → "scholar" (fail-open, generous)
@@ -62,10 +63,10 @@ def _resolve_uuid_tier(uuid: str) -> str:
     if cached and now < cached[1]:
         return cached[0]
     try:
-        from verifimind_mcp.registration import _get_firestore, COLLECTION_REGISTRATIONS
+        from verifimind_mcp.registration import _get_firestore, COLLECTION_EA
         db = _get_firestore()
         if db is not None:
-            doc = db.collection(COLLECTION_REGISTRATIONS).document(uuid).get()
+            doc = db.collection(COLLECTION_EA).document(uuid).get()
             tier = "pioneer" if doc.exists else "scholar"
         else:
             tier = "scholar"

--- a/mcp-server/tests/unit/llm/test_providers.py
+++ b/mcp-server/tests/unit/llm/test_providers.py
@@ -62,10 +62,11 @@ class TestProviderConfiguration:
         assert info['default_model'] == 'llama-3.3-70b'
 
     def test_anthropic_model_ids_updated(self):
-        """Verify Anthropic model IDs use Claude 4 family."""
+        """Verify Anthropic model IDs use Claude 4 family (claude-opus-4-8 current)."""
         info = get_provider_info('anthropic')
         assert 'claude-sonnet-4-6' in info['models']
-        assert 'claude-opus-4-7' in info['models']
+        assert 'claude-opus-4-8' in info['models']
+        assert 'claude-opus-4-7' not in info['models'], "Stale opus-4-7 model ID still present"
         assert 'claude-sonnet-4-20250514' not in info['models'], "Stale model ID still present"
 
     def test_openai_default_updated(self):


### PR DESCRIPTION
## Summary

Three hardening items for v0.5.40:

### 1. Registration funnel fix — D-30-3 (T+L ruling 2026-06-05)
- **B3 consolidation:** `rate_limiter.py` now reads `early_adopters` (single source of truth) instead of `ea_registrations`. Closes the mismatch that caused Scholar UUID holders to get tier-resolved as anonymous.
- **`ea_status_handler`:** Returns `200 + register CTA` for valid UUIDs without an EA record (previously returned `404`, causing 16/16 UUID holders to see errors per AY/AZ forensic audit).
- **`/whoami` endpoint (new):** Self-serve tier/status lookup — reads `X-VerifiMind-UUID` header or `?uuid=` param, returns tier + rate limit + registration guidance. Added to `EXEMPT_PATHS` (no rate limit on self-service check). Addresses AY/AZ finding: 89 interested IPs → 2 completed registrations (2.2% conversion) because users had no self-service visibility into their status.

### 2. Model currency — Issue #68 scope
- `provider.py`: `claude-opus-4-7` → `claude-opus-4-8` (current Opus model)
- `test_providers.py`: updated assertion to match

### Why this matters for Phase 90
The registration funnel leak is the **highest-leverage Phase-90 growth fix** (AY/AZ `20260605_AY_AZ_to_RNA_T_registration_funnel_leak.md`). 89 distinct IPs showed interest in 30 days; only 2 converted. The 404 on `/early-adopters/status` and the wrong-collection rate-limit read were the structural blockers.

## Test plan
- [ ] 570 unit tests pass, 0 failures (pre-verified locally)
- [ ] CI Bandit SAST, CodeQL, Safety, Run Tests, Server Health all green
- [ ] `/whoami` responds 200 with `tier=scholar` for valid UUID without EA record
- [ ] `/early-adopters/status/{uuid}` responds 200 + register CTA for valid UUID without EA record (no more 404)
- [ ] Rate limiter correctly elevates registered UUIDs to `pioneer` tier via `early_adopters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)