### PR TITLE
fix(register): dead /early-adopters/status/ link → /whoami self-serve

### DIFF
--- a/mcp-server/src/verifimind_mcp/pages.py
+++ b/mcp-server/src/verifimind_mcp/pages.py
@@ -758,10 +758,10 @@ _REGISTER_BODY = """
 <div class="card" style="padding: 1rem 1.5rem;">
   <p class="text-sm muted">
     Already registered?
-    Use <a href="/early-adopters/status/" style="color: var(--accent)">
-      /early-adopters/status/{uuid}
-    </a>
-    to check your status.
+    Check your tier and status at
+    <a href="/whoami" style="color: var(--accent)">/whoami</a>
+    (pass <code style="font-size:0.85em">?uuid=&lt;your-uuid&gt;</code>, or set
+    <code style="font-size:0.85em">VERIFIMIND_UUID</code> in your MCP client).
     &nbsp;&middot;&nbsp;
     <a href="/optout" style="color: var(--muted)">Opt out</a>
   </p>


### PR DESCRIPTION
## Summary
The `/register` page's "Already registered? check your status" link pointed to `href="/early-adopters/status/"` (bare, no UUID) — which returns **HTTP 404**. A dead link on the conversion-critical registration page, directly undermining the v0.5.40 funnel fix.

## Fix
Repointed to **`/whoami`** — the v0.5.40 self-serve tier/status endpoint that returns `200` and accepts `?uuid=` or the `X-VerifiMind-UUID` header. You can't link to a templated `{uuid}` URL anyway; `/whoami` is the correct self-serve surface.

## Verification
- `curl /early-adopters/status/` → 404 (the bug)
- `curl /whoami` → 200 (the fix target, live since v0.5.40)
- 25 page/register unit tests pass

## Note
Server-rendered HTML — takes effect on next deploy (v0.5.41 or batched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)