### PR TITLE
chore(v0.5.41): version bump — register dead-link fix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.41 - Register Page Dead-Link Fix (June 5, 2026)
+
+Patch release: fixes a dead link on the registration page that undermined the v0.5.40 funnel fix.
+
+### What changed
+
+- **`/register` dead link → `/whoami`:** The "Already registered? check your status" link pointed to `/early-adopters/status/` (bare, no UUID) which returned **HTTP 404**. Repointed to `/whoami` (the v0.5.40 self-serve tier/status endpoint, returns 200, accepts `?uuid=` or the `X-VerifiMind-UUID` header). A dead link on the conversion-critical registration page — caught by Alton, fixed same day.
+
+### Why
+The v0.5.40 funnel fix removed the structural 404 on the status endpoint itself; this removes the last dead link pointing *at* it from the registration UI. The funnel is now clean end-to-end.
+
+---
+
 ## v0.5.40 - Registration Funnel Fix + /whoami + Model Currency (June 5, 2026)
 
 Closes the Scholar UUID registration funnel leak (AY/AZ forensic audit 2026-06-05: 89 interested IPs/30d, 16/16 UUID holders 404-ing on status check, 2.2% conversion), implements `/whoami` self-service tier endpoint (D-30-3), and bumps model list to `claude-opus-4-8`.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -6,11 +6,12 @@
 
 ## Current Status: Operational
 
-**v0.5.40 "Registration Funnel Fix + /whoami + Model Currency" — deployed June 5, 2026**
+**v0.5.41 "Register Page Dead-Link Fix" — deployed June 5, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Register Page Dead-Link Fix (v0.5.41)**: `/register` "check your status" link pointed to `/early-adopters/status/` (bare, 404) — repointed to `/whoami` self-serve endpoint. Last dead link in the registration funnel, caught by Alton — June 5, 2026
 - **Registration Funnel Fix + /whoami (v0.5.40)**: Closes Scholar UUID registration funnel leak — `rate_limiter.py` now reads `early_adopters` (single source of truth, D-30-3); `/early-adopters/status/{uuid}` returns `200 + register CTA` instead of `404` for valid unregistered UUIDs; new `/whoami` endpoint for self-serve tier/status check; `claude-opus-4-8` model currency bump — June 5, 2026
 - **Registry Scanner Block + P2 Batch-2 (v0.5.39)**: 10th IP added to application-layer blocklist (BLOCKED_IPS: 10 entries total) — `3.137.30.179` (AISEC_REGISTRY_SCANNER); UA `aisec-registry/0.2 (+https://sec.sqrx.io)` on 100% of 400 requests over 5-day cron-like persistence (May 23–27, ~80 req/day); MCP/OAuth surface enumeration (89× POST `/mcp` + 89× GET `/mcp/.well-known/oauth-*` discovery); HTTP 200 = 0 (never reached a real handler), 268× 429, 88× 404. Not a builder, no `/register` intent. AY+AZ forensics 2026-05-30. + SonarCloud P2 batch-2: 8 module-level constants extracted from 25 dup-literal occurrences in `llm/provider.py` (4 provider-default-model constants) and `server.py` (4 agent/prompt constants); behavior-identical refactors; substance preservation per Genesis §13.X proposal — June 1, 2026
 - **Scanner Block (v0.5.38)**: 2 additional scanners added to application-layer IP blocklist (9 entries total) — `4.228.83.111` (CMS_WEBSHELL_SCANNER, Azure; null UA, 310 req/7d in 2 bursts, WordPress + PHP webshell dictionary) and `2602:fb54:99a::` (SECRET_SCANNER, IPv6; rotating UA across 18+ browser strings — botnet pattern; 65 req single 15-sec burst probing GCP service-account JSON + .env tree + .git internals). GCP forensic analysis (Sentinel investigation): zero 200 on any sensitive endpoint, zero data leak on either actor; defense layers caught everything (50–60% rate-limited, 13–34% 404). Independent actors (19h apart, different tooling). Address-only block on the IPv6 — no /48 rotation evidence — May 29, 2026

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.40"
+SERVER_VERSION = "0.5.41"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.40"
+SERVER_VERSION = "0.5.41"
 
 # Agent role names + master prompt filename — single source of truth.
 # (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.40"
+        assert http_server.SERVER_VERSION == "0.5.41"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.40", (
+        assert SERVER_VERSION == "0.5.41", (
             f"Expected 0.5.40, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.40"
+        assert SERVER_VERSION == "0.5.41"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.40"
+        assert SERVER_VERSION == "0.5.41"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.40", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.41", f"Expected 0.5.40, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.40", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.41", f"Expected 0.5.40, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -214,4 +214,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.40", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.41", f"Expected 0.5.40, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.40"
+        assert http_server.SERVER_VERSION == "0.5.41"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.40"
+        assert http_server.SERVER_VERSION == "0.5.41"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.40",
-  "version": "3.17.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.41",
+  "version": "3.18.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
Version bump for v0.5.41 (register /whoami dead-link fix, #248). SERVER_VERSION 0.5.40→0.5.41, server.json 3.18.0, 9 tests + CHANGELOG + SERVER_STATUS. 570 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)