### PR TITLE
feat(v0.5.42): server-card description refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.42 - Server-Card Description Refresh (June 9, 2026)
+
+Patch release: refreshes the `/.well-known/mcp/server-card.json` MCP discovery surface, which carried stale copy.
+
+### What changed
+- **Server-card description refreshed:** removed stale "Genesis v4.2 Sentinel-Verified / Z-Protocol v1.1 (21 frameworks)" marketing; replaced with current accurate descriptors — **13 free MCP tools** (Trinity + prompt-template library + coordination), **BYOK across 6 providers** (Gemini, Anthropic, OpenAI, Groq, Cerebras, Mistral), free tier on Gemini 2.5 Flash.
+- **Docstring corrected:** server-card handler is a general MCP discovery card (Smithery listing sunset 2026-03-01), not Smithery-specific.
+- **BYOK provider list** in the config schema corrected to the full 6 key-based providers.
+
+### Why
+Pre-submission accuracy pass (Google Challenge): the public MCP discovery surface should reflect the current v0.5.41+ feature set, not pre-rebuild marketing copy.
+
+---
+
 ## v0.5.41 - Register Page Dead-Link Fix (June 5, 2026)
 
 Patch release: fixes a dead link on the registration page that undermined the v0.5.40 funnel fix.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** June 5, 2026
+**Last Updated:** June 9, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.41 "Register Page Dead-Link Fix" — deployed June 5, 2026**
+**v0.5.42 "Server-Card Description Refresh" — deployed June 9, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Server-Card Description Refresh (v0.5.42)**: `/.well-known/mcp/server-card.json` refreshed — stale "Genesis v4.2" copy → current descriptors (13 free tools, BYOK 6 providers); docstring de-Smithery'd (listing sunset 2026-03-01); pre-submission accuracy pass — June 9, 2026
 - **Register Page Dead-Link Fix (v0.5.41)**: `/register` "check your status" link pointed to `/early-adopters/status/` (bare, 404) — repointed to `/whoami` self-serve endpoint. Last dead link in the registration funnel, caught by Alton — June 5, 2026
 - **Registration Funnel Fix + /whoami (v0.5.40)**: Closes Scholar UUID registration funnel leak — `rate_limiter.py` now reads `early_adopters` (single source of truth, D-30-3); `/early-adopters/status/{uuid}` returns `200 + register CTA` instead of `404` for valid unregistered UUIDs; new `/whoami` endpoint for self-serve tier/status check; `claude-opus-4-8` model currency bump — June 5, 2026
 - **Registry Scanner Block + P2 Batch-2 (v0.5.39)**: 10th IP added to application-layer blocklist (BLOCKED_IPS: 10 entries total) — `3.137.30.179` (AISEC_REGISTRY_SCANNER); UA `aisec-registry/0.2 (+https://sec.sqrx.io)` on 100% of 400 requests over 5-day cron-like persistence (May 23–27, ~80 req/day); MCP/OAuth surface enumeration (89× POST `/mcp` + 89× GET `/mcp/.well-known/oauth-*` discovery); HTTP 200 = 0 (never reached a real handler), 268× 429, 88× 404. Not a builder, no `/register` intent. AY+AZ forensics 2026-05-30. + SonarCloud P2 batch-2: 8 module-level constants extracted from 25 dup-literal occurrences in `llm/provider.py` (4 provider-default-model constants) and `server.py` (4 agent/prompt constants); behavior-identical refactors; substance preservation per Genesis §13.X proposal — June 1, 2026

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.41"
+SERVER_VERSION = "0.5.42"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32
@@ -880,19 +880,21 @@ async def logo_handler(request):
 
 
 async def smithery_server_card_handler(request):
-    """Smithery server-card.json — skips auto-scan during publish.
+    """MCP server-card.json — general MCP discovery surface.
 
-    Advertised at /.well-known/mcp/server-card.json per Smithery publish spec:
-    https://smithery.ai/docs/build/publish#troubleshooting
+    Advertised at /.well-known/mcp/server-card.json. Originally per the Smithery
+    publish spec; the Smithery listing sunset 2026-03-01, but this endpoint
+    remains a valid MCP discovery card served directly at the deployment URL.
     """
     return JSONResponse({
         "displayName": "VerifiMind-PEAS",
         "description": (
             "Multi-model AI validation framework. Validate concepts end-to-end across "
             "innovation (X Agent), ethics & compliance (Z Agent), and security (CS Agent) "
-            "using the X-Z-CS RefleXion Trinity. Genesis v4.2 Sentinel-Verified — forced "
-            "citation patterns, Z-Protocol v1.1 (21 frameworks, 4 tiers), CS Security v1.1 "
-            "(6-stage, 12-dimension, OWASP Agentic AI). Free tier powered by Gemini 2.5 Flash."
+            "via the X-Z-CS RefleXion Trinity. 13 free MCP tools (Trinity validation, "
+            "prompt-template library, and cross-session coordination). BYOK across 6 "
+            "providers (Gemini, Anthropic, OpenAI, Groq, Cerebras, Mistral). Free tier "
+            "powered by Gemini 2.5 Flash."
         ),
         "version": SERVER_VERSION,
         "iconUrl": "https://verifimind.ysenseai.org/logo.png",
@@ -903,7 +905,7 @@ async def smithery_server_card_handler(request):
                 "configSchema": {
                     "type": "object",
                     "properties": {},
-                    "description": "No configuration required. Free tier uses developer-hosted Gemini 2.5 Flash. Optional: set LLM_PROVIDER + API key headers for BYOK (groq, anthropic, openai, gemini)."
+                    "description": "No configuration required. Free tier uses developer-hosted Gemini 2.5 Flash. Optional: set LLM_PROVIDER + API key headers for BYOK (gemini, anthropic, openai, groq, cerebras, mistral)."
                 }
             }
         ],

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.41"
+SERVER_VERSION = "0.5.42"
 
 # Agent role names + master prompt filename — single source of truth.
 # (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.41"
+        assert http_server.SERVER_VERSION == "0.5.42"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.41", (
+        assert SERVER_VERSION == "0.5.42", (
             f"Expected 0.5.40, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.41"
+        assert SERVER_VERSION == "0.5.42"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.41"
+        assert SERVER_VERSION == "0.5.42"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.41", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.42", f"Expected 0.5.40, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.41", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.42", f"Expected 0.5.40, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -214,4 +214,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.41", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.42", f"Expected 0.5.40, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.41"
+        assert http_server.SERVER_VERSION == "0.5.42"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.41"
+        assert http_server.SERVER_VERSION == "0.5.42"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.41",
-  "version": "3.18.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.42",
+  "version": "3.19.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
Refresh /.well-known/mcp/server-card.json — stale Genesis-v4.2 copy → current (13 free tools, BYOK 6 providers). De-Smithery'd docstring. Version 0.5.42, server.json 3.19.0, 570 tests pass. Pre-submission accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)