### PR TITLE
docs(architecture): publish finalized architecture diagram

### DIFF
--- a/docs/architecture/VerifiMind-PEAS-Architecture-Diagram.md
+++ b/docs/architecture/VerifiMind-PEAS-Architecture-Diagram.md
@@ -1,0 +1,592 @@
+# VerifiMind™ PEAS — Architecture Diagram
+
+> **STATUS: FINAL** — XV (CIO) fact-check + RNA (CSO) technical-accuracy review applied (2026-06-09). Corrections per `.macp/handoffs/20260609_RNA_architecture_diagram_verified_review.md` + smithery addendum.
+
+**Version:** v0.6.0-Beta (Phase 90)  
+**Project:** VerifiMind™ PEAS — Powered by the Genesis Prompt Engineering Methodology  
+**Author:** Alton (Human Orchestrator) + FLYWHEEL TEAM  
+**Date:** June 2026  
+**Repository:** [github.com/creator35lwb-web/VerifiMind-PEAS](https://github.com/creator35lwb-web/VerifiMind-PEAS)  
+**White Paper:** [doi.org/10.5281/zenodo.17645665](https://doi.org/10.5281/zenodo.17645665)
+
+---
+
+## Part 1: Foundational Architecture — Multi-Agent Validation System
+
+The foundational architecture describes VerifiMind's core concept: a multi-agent AI validation system that places "Crystal Balls inside the Black Box" — using diverse AI models to illuminate decisions through structured, multi-perspective validation.
+
+---
+
+### 1.1 High-Level System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           USER INTERFACE                                  │
+│                                                                           │
+│   "I want to build a meditation app for kids aged 6-12"                  │
+│                                                                           │
+└────────────────────────────────┬──────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      SOCRATIC DIALOGUE ENGINE                             │
+│                                                                           │
+│   Asks clarifying questions:                                             │
+│   • Who is your target user?                                             │
+│   • What problem does it solve?                                          │
+│   • How should it work?                                                  │
+│   • What are your success metrics?                                       │
+│                                                                           │
+└────────────────────────────────┬──────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                   THREE-AGENT VALIDATION SYSTEM                           │
+│                                                                           │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐      │
+│  │  X INTELLIGENT   │  │   Z GUARDIAN     │  │   CS SECURITY    │      │
+│  │                  │  │                  │  │                  │      │
+│  │  • Market        │  │  • GDPR          │  │  • Prompt        │      │
+│  │    analysis      │  │  • COPPA         │  │    injection     │      │
+│  │  • Business      │  │  • Child         │  │  • SQL           │      │
+│  │    validation    │  │    protection    │  │    injection     │      │
+│  │  • Tech          │  │  • Ethics        │  │  • XSS           │      │
+│  │    feasibility   │  │  • Compliance    │  │  • SSRF          │      │
+│  │  • Roadmap       │  │  • Human         │  │  • Security      │      │
+│  │    generation    │  │    values        │  │    scanning      │      │
+│  │                  │  │                  │  │                  │      │
+│  │  Risk: 35/100   │  │  Risk: 60/100   │  │  Risk: 30/100   │      │
+│  │  Status: ✅      │  │  Status: ⚠️      │  │  Status: ✅      │      │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘      │
+│                                                                           │
+│              ┌─────────────────────────┐                                 │
+│              │   AGENT ORCHESTRATOR    │                                 │
+│              │  • Parallel execution   │                                 │
+│              │  • Conflict resolution  │                                 │
+│              │  • Priority: CS>Z>X     │                                 │
+│              │  Decision: APPROVED     │                                 │
+│              └─────────────────────────┘                                 │
+│                                                                           │
+└────────────────────────────────┬──────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      VALIDATION OUTPUT                                    │
+│                                                                           │
+│   • Multi-perspective risk assessment                                    │
+│   • Compliance verification                                              │
+│   • Security audit                                                       │
+│   • Actionable recommendations                                           │
+│   • Confidence scores with evidence                                      │
+│                                                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+> *Note: the "Socratic Dialogue Engine" above is a **conceptual** layer — implemented via Genesis-methodology prompt design within each agent (the `concept_name` / `concept_description` parameters), not a standalone deployed service.*
+
+### 1.2 Three-Agent Collaboration Flow
+
+```
+                    ┌─────────────────┐
+                    │  ConceptInput   │
+                    └────────┬────────┘
+                             │
+            ┌────────────────┼────────────────┐
+            │                │                │
+            ▼                ▼                ▼
+    ┌────────────┐   ┌────────────┐   ┌────────────┐
+    │  X Agent   │   │  Z Agent   │   │  CS Agent  │
+    │            │   │            │   │            │
+    │  Business  │   │ Compliance │   │  Security  │
+    │  Analysis  │   │   Review   │   │    Scan    │
+    └──────┬─────┘   └──────┬─────┘   └──────┬─────┘
+           │                │                │
+           │  Risk: 35      │  Risk: 60      │  Risk: 30
+           │  Status: ✅     │  Status: ⚠️     │  Status: ✅
+           │                │                │
+           └───────┬────────┴────────┬───────┘
+                   │                 │
+                   ▼                 ▼
+          ┌──────────────────────────────┐
+          │     Agent Orchestrator       │
+          │                              │
+          │   Conflict Resolution:       │
+          │   Priority: CS > Z > X       │
+          │                              │
+          │   If CS blocks:              │
+          │     → REJECT                 │
+          │   Else if Z warns:           │
+          │     → NEEDS REVISION         │
+          │   Else if X approves:        │
+          │     → APPROVE                │
+          └──────────┬───────────────────┘
+                     │
+                     ▼
+              ┌─────────────┐
+              │  Decision   │
+              │             │
+              │  Approved   │
+              │  with mods  │
+              └─────────────┘
+```
+
+---
+
+## Part 2: Current Architecture — Phase 90 (v0.6.0-Beta)
+
+The system has evolved from a 3-agent validation concept into a full multi-model, multi-platform AI orchestration system powered by the Genesis Prompt Engineering Methodology and the Multi-Agent Communication Protocol (MACP).
+
+---
+
+### 2.1 Genesis Methodology — 5-Step Process
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│              GENESIS PROMPT ENGINEERING METHODOLOGY                       │
+│              "Crystal Balls Inside the Black Box"                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+  │   STEP   │    │   STEP   │    │   STEP   │    │   STEP   │    │   STEP   │
+  │    01    │───▶│    02    │───▶│    03    │───▶│    04    │───▶│    05    │
+  │          │    │          │    │          │    │          │    │          │
+  │ Initial  │    │ Critical │    │ External │    │          │    │          │
+  │ Concept  │    │ Scrutiny │    │Validation│    │Synthesis │    │Iteration │
+  └──────────┘    └──────────┘    └──────────┘    └──────────┘    └──────────┘
+       │                │                │                │                │
+       ▼                ▼                ▼                ▼                ▼
+  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+  │  Human   │    │ Multiple │    │Independent│    │  Human   │    │ Recursive│
+  │ defines  │    │ AI models│    │ AI agent  │    │orchestr- │    │refinement│
+  │ problem  │    │ validate │    │ confirms  │    │ ates the │    │   and    │
+  │ + AI     │    │    and   │    │systematic │    │  final   │    │continuous│
+  │generates │    │challenge │    │ approach  │    │synthesis │    │improvmnt │
+  │ concepts │    │each other│    │           │    │          │    │          │
+  └──────────┘    └──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+---
+
+### 2.2 AI Council — Four-Agent Multi-Model Orchestration
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    AI COUNCIL ARCHITECTURE                                │
+│          "Synergizing Diverse AI Perspectives Under Human Direction"      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+                    ┌─────────────────────────┐
+                    │    HUMAN ORCHESTRATOR   │
+                    │        (Alton)          │
+                    │                         │
+                    │  • Persistent memory    │
+                    │  • Strategic direction  │
+                    │  • Final decisions      │
+                    │  • Quality control      │
+                    └────────────┬────────────┘
+                                 │
+                    ┌────────────┼────────────┐
+                    │            │            │
+     ┌──────────────┤            │            ├──────────────┐
+     │              │            │            │              │
+     ▼              ▼            ▼            ▼              │
+┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐     │
+│    Y     │  │    X     │  │    Z     │  │    CS    │     │
+│INNOVATOR │  │ ANALYST  │  │ GUARDIAN │  │VALIDATOR │     │
+│          │  │          │  │          │  │          │     │
+│ Gemini   │  │Perplexity│  │  Claude  │  │Perplexity│     │
+│3.5-Flash │  │ Sonar-Pro│  │Sonnet-4-6│  │ Sonar-Pro│     │
+│          │  │          │  │          │  │          │     │
+│• Creative│  │• Critical│  │• Ethical  │  │• External│     │
+│  concepts│  │  analysis│  │  compli- │  │  evidence│     │
+│• Strategy│  │• Weakness│  │  ance    │  │  validatn│     │
+│  insights│  │  finding │  │• Safety  │  │• Fact    │     │
+│• Novel   │  │• Data-   │  │• Human   │  │  checking│     │
+│  approach│  │  driven  │  │  values  │  │• Source  │     │
+│          │  │          │  │          │  │  verify  │     │
+└──────────┘  └──────────┘  └──────────┘  └──────────┘     │
+     │              │            │            │              │
+     └──────────────┴────────────┴────────────┘              │
+                         │                                   │
+                         ▼                                   │
+              ┌─────────────────────┐                        │
+              │  COUNCIL SYNTHESIS  │                        │
+              │                     │                        │
+              │ • Quorum rules      │◄───────────────────────┘
+              │ • Conflict resoltn  │    Feedback Loop
+              │ • Evidence weighting│
+              │ • Confidence scores │
+              │ • Actionable output │
+              └─────────────────────┘
+```
+
+---
+
+> *Note: Y (Innovator) is reachable only via the orchestrated `run_full_trinity` Council flow — there is no standalone `consult_agent_y` MCP tool (X/Z/CS each have individual tools). Y = `gemini-3.5-flash` in the AI Council; the live MCP-server Trinity is X/Z/CS only (§2.5).*
+
+### 2.3 MACP — Multi-Agent Communication Protocol (v2.4.1)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│         MULTI-AGENT COMMUNICATION PROTOCOL (MACP v2.4.1)                 │
+│         "Persistent Coordination Across Sessions and Platforms"           │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        COMMAND CENTRAL HUB                                │
+│                     (GitHub Repository — Git-Native)                      │
+│                                                                           │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  .macp/       │  │  .macp/       │  │  .macp/       │               │
+│  │  reasoning/   │  │  handoffs/    │  │  agent-memory/ │               │
+│  │               │  │               │  │               │               │
+│  │  Decision     │  │  Cross-agent  │  │  Persistent   │               │
+│  │  evidence +   │  │  context      │  │  operational  │               │
+│  │  §13.X prior  │  │  transfer     │  │  state per    │               │
+│  │  framing      │  │  records      │  │  agent        │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                                                                           │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  .macp/       │  │  .macp/       │  │  NORTH_STAR   │               │
+│  │  intelligence/│  │  research/    │  │  .md          │               │
+│  │               │  │               │  │               │               │
+│  │  External     │  │  Strategic    │  │  Canonical    │               │
+│  │  signal       │  │  analysis +   │  │  alignment    │               │
+│  │  tracking     │  │  policies     │  │  document     │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                                                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+
+                    MACP TRIAD (Mandatory Per Session)
+                    ══════════════════════════════════
+
+         ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+         │  REASONING   │  │   HANDOFF    │  │   MEMORY     │
+         │              │  │              │  │              │
+         │ WHY was this │  │ WHAT does    │  │ HOW does the │
+         │ decided?     │  │ the next     │  │ agent state  │
+         │              │  │ agent need   │  │ persist?     │
+         │ Evidence +   │  │ to know?     │  │              │
+         │ prior framing│  │              │  │ JSON state   │
+         │ preserved    │  │ Context +    │  │ updated per  │
+         │              │  │ routing      │  │ session      │
+         └──────────────┘  └──────────────┘  └──────────────┘
+```
+
+---
+
+### 2.4 FLYWHEEL TEAM — Multi-Platform Agent Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    FLYWHEEL TEAM ARCHITECTURE                             │
+│         "Self-Recursive Loop Where Methodology Validates Itself"         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                           │
+│                    ┌─────────────────────┐                               │
+│                    │   ALTON (HUMAN)     │                               │
+│                    │   Orchestrator      │                               │
+│                    │   Final Authority   │                               │
+│                    └──────────┬──────────┘                               │
+│                               │                                          │
+│          ┌────────────────────┼────────────────────┐                    │
+│          │                    │                    │                     │
+│          ▼                    ▼                    ▼                     │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐              │
+│  │  T (CTO)     │    │ RNA (CSO)    │    │  XV (CIO)    │              │
+│  │  Manus AI    │    │ Claude Code  │    │  Perplexity  │              │
+│  │              │    │              │    │              │              │
+│  │• Architecture│    │• Security    │    │• Intelligence│              │
+│  │• Strategy    │    │• Code impl.  │    │• Forecasting │              │
+│  │• Decisions   │    │• M2 eval     │    │• Peer audit  │              │
+│  │• Hub mgmt    │    │• MCP server  │    │• Calibration │              │
+│  └──────────────┘    └──────────────┘    └──────────────┘              │
+│          │                    │                    │                     │
+│          │            ┌───────┴───────┐            │                    │
+│          │            │               │            │                    │
+│          ▼            ▼               ▼            ▼                    │
+│  ┌──────────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐       │
+│  │  L (GodelAI) │  │ AY (COO) │  │ AZ (CPO) │  │ RNA-C        │       │
+│  │  Manus AI    │  │ Cursor   │  │ Cursor   │  │ (Derivative) │       │
+│  │              │  │          │  │          │  │ Claude Code  │       │
+│  │• CEO Advisor │  │• Ops     │  │• Product │  │              │       │
+│  │• Philosophy  │  │• Metrics │  │• Quality │  │• Challenge   │       │
+│  │• Identity    │  │• Reports │  │• Testing │  │  submissions │       │
+│  └──────────────┘  └──────────┘  └──────────┘  └──────────────┘       │
+│                                                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+
+                         PLATFORM DIVERSITY
+                         ══════════════════
+
+    ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
+    │ Manus AI │  │  Claude  │  │Perplexity│  │  Cursor  │
+    │          │  │   Code   │  │          │  │          │
+    │ T + L    │  │ RNA      │  │ XV       │  │ AY + AZ  │
+    │          │  │ RNA-C    │  │          │  │          │
+    └──────────┘  └──────────┘  └──────────┘  └──────────┘
+         │              │              │              │
+         └──────────────┴──────────────┴──────────────┘
+                                │
+                                ▼
+                    ┌───────────────────────┐
+                    │  COMMAND CENTRAL HUB  │
+                    │  (GitHub — Git-Native)│
+                    │                       │
+                    │  Single Source of     │
+                    │  Truth for ALL agents │
+                    └───────────────────────┘
+```
+
+---
+
+### 2.5 MCP Server — Production Interface
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│              VERIFIMIND MCP SERVER (v0.5.41 LIVE)                         │
+│              Model Context Protocol — Production Interface                │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                           │
+│  EXTERNAL USERS (~4,361 endpoints, floor-leaning — D-38-8 band)          │
+│                                                                           │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐               │
+│  │  Claude  │  │  Cursor  │  │  Custom  │  │   Any    │               │
+│  │ Desktop  │  │   IDE    │  │  Client  │  │MCP Client│               │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └────┬─────┘               │
+│       │              │              │              │                     │
+│       └──────────────┴──────────────┴──────────────┘                    │
+│                              │                                           │
+│                              ▼                                           │
+│              ┌───────────────────────────────┐                           │
+│              │     MCP PROTOCOL LAYER        │                           │
+│              │     (JSON-RPC 2.0)            │                           │
+│              └───────────────┬───────────────┘                           │
+│                              │                                           │
+│                              ▼                                           │
+│  ┌───────────────────────────────────────────────────────────────┐      │
+│  │         13 NAMED MCP TOOLS (invoked by name, JSON-RPC 2.0)    │      │
+│  │         (NOT HTTP paths — single endpoint at /mcp/)           │      │
+│  │                                                               │      │
+│  │  Trinity (4)        Templates (6)         Coordination (3)    │      │
+│  │  ─────────────      ──────────────────    ────────────────    │      │
+│  │  consult_agent_x    list_prompt_templates coordination_      │      │
+│  │  consult_agent_z    get_prompt_template     handoff_create   │      │
+│  │  consult_agent_cs   export_prompt_template coordination_     │      │
+│  │  run_full_trinity   register_custom_temp.   handoff_read     │      │
+│  │                     import_template_from_url coordination_   │      │
+│  │                     get_template_statistics  team_status     │      │
+│  │                                                               │      │
+│  └───────────────────────────────────────────────────────────────┘      │
+│                              │                                           │
+│                              ▼                                           │
+│              ┌───────────────────────────────────────────┐               │
+│              │   AI MODEL LAYER — MCP Server Trinity        │               │
+│              │   (X / Z / CS — note: Y is AI-Council-only)  │               │
+│              │                                             │               │
+│              │   X · Z · CS default: gemini-2.5-flash      │               │
+│              │   (Z via Claude when ANTHROPIC_API_KEY set) │               │
+│              │                                             │               │
+│              │   BYOK: 6 key-based providers —             │               │
+│              │   Google · Anthropic · OpenAI · Groq ·      │               │
+│              │   Cerebras · Mistral — plus Ollama (local)  │               │
+│              │                                             │               │
+│              │   (AI Council §2.2 adds Y=gemini-3.5-flash, │               │
+│              │    X/CS=sonar-pro — a separate model layer) │               │
+│              └───────────────────────────────────────────┘               │
+│                                                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 2.6 Self-Recursive Validation Loop
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│           SELF-RECURSIVE VALIDATION (Gödel Property)                     │
+│     "The methodology validates its own outputs using itself"             │
+└─────────────────────────────────────────────────────────────────────────┘
+
+    ┌─────────────────────────────────────────────────────────┐
+    │                                                         │
+    │   ┌──────────┐     ┌──────────┐     ┌──────────┐      │
+    │   │  CREATE  │────▶│ VALIDATE │────▶│  REFINE  │      │
+    │   │          │     │          │     │          │      │
+    │   │ Genesis  │     │ AI Council│     │ Human    │      │
+    │   │ produces │     │ validates │     │ synthe-  │      │
+    │   │ output   │     │ output   │     │ sizes    │      │
+    │   └──────────┘     └──────────┘     └──────────┘      │
+    │        ▲                                    │           │
+    │        │                                    │           │
+    │        └────────────────────────────────────┘           │
+    │                    RECURSIVE LOOP                        │
+    │                                                         │
+    └─────────────────────────────────────────────────────────┘
+
+    Applied to:
+    ├── M2 Evaluation Dataset (methodology evaluates its own eval set)
+    ├── White Paper (AI Council validates its own documentation)
+    ├── MCP Server (methodology validates its own production code)
+    ├── Architecture (this diagram validated by the system it describes)
+    └── NORTH_STAR (strategic alignment validated by the team it governs)
+```
+
+---
+
+### 2.7 Drift-Rate SLI — Continuous Quality Monitoring
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│              DRIFT-RATE SLI v1.1 — Quality Surveillance                  │
+└─────────────────────────────────────────────────────────────────────────┘
+
+    ┌──────────────────────────────────────────────────────────┐
+    │                  SURVEILLANCE TARGETS                      │
+    │                                                           │
+    │  ┌─────────────────┐  ┌─────────────────┐               │
+    │  │ Forbidden       │  │ Forbidden       │               │
+    │  │ Pattern (a)     │  │ Pattern (b)     │               │
+    │  │                 │  │                 │               │
+    │  │ Latest-version  │  │ GT-source       │               │
+    │  │ divergence      │  │ resolvability   │               │
+    │  │                 │  │                 │               │
+    │  │ Citing version- │  │ DOIs/URLs that  │               │
+    │  │ DOIs when       │  │ 404 or resolve  │               │
+    │  │ concept-DOI     │  │ to unrelated    │               │
+    │  │ exists          │  │ works           │               │
+    │  └─────────────────┘  └─────────────────┘               │
+    │                                                           │
+    │  Target: ≤1 incident per 30-day window                   │
+    │  Current: 1/30 (on target)                               │
+    │                                                           │
+    └──────────────────────────────────────────────────────────┘
+
+    Enforcement:
+    ├── XV weekly cron monitoring (automated)
+    ├── RNA GT-resolvability check script (authorized)
+    ├── XV cross-session consistency check (xv_consistency_check.py)
+    └── Human review on flagged incidents
+```
+
+---
+
+### 2.8 Protocol Layer Positioning
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│              WHERE MACP SITS IN THE PROTOCOL STACK                        │
+└─────────────────────────────────────────────────────────────────────────┘
+
+    ┌─────────────────────────────────────────────────────────────────┐
+    │  LAYER 4: PERSISTENT COORDINATION (MACP)                         │
+    │                                                                   │
+    │  • Human ↔ Agents across sessions, platforms, and time           │
+    │  • Git-native traceability                                       │
+    │  • Agent identity persistence                                    │
+    │  • Cross-session memory                                          │
+    │  • Decision provenance                                           │
+    │                                                                   │
+    │  ══════════════ UNIQUE TO VERIFIMIND ═══════════════════          │
+    └─────────────────────────────────────────────────────────────────┘
+    ┌─────────────────────────────────────────────────────────────────┐
+    │  LAYER 3: AGENT ↔ HUMAN UI (AGUI — CopilotKit)                  │
+    │  • Frontend integration for agent interactions                   │
+    └─────────────────────────────────────────────────────────────────┘
+    ┌─────────────────────────────────────────────────────────────────┐
+    │  LAYER 2: AGENT ↔ AGENT (A2A — Google)                           │
+    │  • Session-scoped agent-to-agent communication                   │
+    └─────────────────────────────────────────────────────────────────┘
+    ┌─────────────────────────────────────────────────────────────────┐
+    │  LAYER 1: AGENT ↔ TOOLS (MCP — Anthropic)                        │
+    │  • Tool discovery and invocation                                 │
+    └─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Part 3: System Integration Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│              VERIFIMIND™ PEAS — COMPLETE SYSTEM INTEGRATION               │
+│              Phase 90 · v0.6.0-Beta · Genesis v2.6.1                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                           │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                    PUBLIC INTERFACE                               │    │
+│  │                                                                   │    │
+│  │  MCP Server (v0.5.41)  ·  GitHub (Public Repo)  ·  Zenodo (DOI) │    │
+│  │  ~4,361 endpts (floor) ·  Open Source           ·  White Paper   │    │
+│  └──────────────────────────────┬──────────────────────────────────┘    │
+│                                  │                                        │
+│  ┌──────────────────────────────┼──────────────────────────────────┐    │
+│  │                    VALIDATION ENGINE                              │    │
+│  │                                                                   │    │
+│  │  AI Council (Y+X+Z+CS)  ·  Genesis 5-Step  ·  Self-Recursive   │    │
+│  │  4 models, 3 providers  ·  Methodology      ·  Validation Loop  │    │
+│  └──────────────────────────────┬──────────────────────────────────┘    │
+│                                  │                                        │
+│  ┌──────────────────────────────┼──────────────────────────────────┐    │
+│  │                    COORDINATION LAYER                             │    │
+│  │                                                                   │    │
+│  │  MACP v2.4.1  ·  FLYWHEEL TEAM  ·  Command Central Hub         │    │
+│  │  Protocol      ·  7 Agents        ·  Git-Native State           │    │
+│  └──────────────────────────────┬──────────────────────────────────┘    │
+│                                  │                                        │
+│  ┌──────────────────────────────┼──────────────────────────────────┐    │
+│  │                    QUALITY ASSURANCE                              │    │
+│  │                                                                   │    │
+│  │  Drift-Rate SLI v1.1  ·  M2 Evaluation  ·  XV Peer Audit       │    │
+│  │  2 forbidden patterns  ·  κ/α metrics    ·  Calibrated forecasts│    │
+│  └──────────────────────────────┬──────────────────────────────────┘    │
+│                                  │                                        │
+│  ┌──────────────────────────────┼──────────────────────────────────┐    │
+│  │                    EVIDENCE BASE                                  │    │
+│  │                                                                   │    │
+│  │  ~120 days documented ·  41+ sessions ·  90 phases              │    │
+│  │  ~45,000+ Python LOC   ·  4 platforms  ·  3 providers (7 BYOK)   │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+│                                                                           │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| Development Duration | ~120 days documented FLYWHEEL TEAM work (since first Hub artifact 2026-02-08) |
+| Lines of Code | ~45,000+ (public repo, Python) |
+| FLYWHEEL TEAM Sessions | 41+ (across all agents, current) |
+| Project Phases | 90 |
+| AI Agents | 7 (T, L, RNA, XV, AY, AZ, RNA-C) |
+| AI Council Models | 4 (Y, X, Z, CS) |
+| AI Providers | 3 (Google, Anthropic, Perplexity) — AI Council defaults · 7 via MCP-server BYOK |
+| Platforms | 4 (Manus AI, Claude Code, Perplexity, Cursor) |
+| Real Endpoints | 4,361 floor-leaning · ~3,965 honest baseline · ~5,000+ true reach (D-38-8 band; never cited as verified humans) |
+| MCP Server Version | v0.5.41 LIVE |
+| MACP Protocol | v2.4.1 |
+| Genesis Methodology | v2.6.1 |
+
+---
+
+## References
+
+- **White Paper:** Alton. "VerifiMind™ PEAS: A Multi-Agent AI Validation System." Zenodo, 2026. [doi:10.5281/zenodo.17645665](https://doi.org/10.5281/zenodo.17645665)
+- **Repository:** [github.com/creator35lwb-web/VerifiMind-PEAS](https://github.com/creator35lwb-web/VerifiMind-PEAS)
+- **MCP Server:** Live production — `https://verifimind.ysenseai.org/mcp/` (direct streamable-HTTP, JSON-RPC 2.0). *(Smithery legacy listing sunset 2026-03-01; use the direct URL.)*
+- **ORCID:** [0009-0009-4803-1555](https://orcid.org/0009-0009-4803-1555)
+
+---
+
+*VerifiMind™ PEAS Architecture Diagram · v0.6.0-Beta · Phase 90 · June 2026*


### PR DESCRIPTION
## Summary
Publishes the finalized VerifiMind-PEAS architecture diagram to the public repo.

- Source: PRIVATE Hub `docs/architecture/VerifiMind-PEAS-Architecture-Diagram.md` (FINAL)
- Authorization: T+L Session 39 **PUBLISH-READY (D-39-1)** + Alton
- Review trail: XV fact-check (S42) + RNA technical-accuracy + finalization (corrections applied, smithery link fixed, DRAFT lifted)
- **Disclosure-gate clean:** 0 IPs, 0 INTERNAL markers, 0 forbidden EA numbers, 0 per-user/UUID data. Endpoint figures use the D-38-8 aggregate honest-methodology band (never "verified humans").

## Note
Legacy `docs/architecture/architecture-diagram.md` (Feb 2026, pre-rebuild) is **superseded** by this file. Flagging for a T+L removal/redirect decision (not deleting content I didn't author).

Docs-only — no code, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)