### PR TITLE
v0.5.43 "Foundation Integrity" — P0 Trinity/resource fixes (HOLD for T+L sign-off)

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.42"
+SERVER_VERSION = "0.5.43"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/agents/base_agent.py
+++ b/mcp-server/src/verifimind_mcp/agents/base_agent.py
@@ -91,8 +91,19 @@ class BaseAgent(ABC):
             context=concept.context or "No additional context provided.",
             prior_reasoning=prior_context
         )
-        
-        return prompt
+
+        # v0.5.43: anchor the model to the real current date. Without this, agents
+        # default to their training-cutoff year (research prompts said "2024") and
+        # Z's "upcoming deadline" reasoning silently rots as regulations take effect.
+        from datetime import date
+        today = date.today()
+        date_header = (
+            f"CURRENT DATE: {today.isoformat()} ({today.strftime('%B %d, %Y')}). "
+            "Treat this as today when assessing market timing, recency, and whether "
+            "any cited regulatory deadline is upcoming or already in effect.\n\n"
+        )
+
+        return date_header + prompt
     
     async def analyze(
         self,

--- a/mcp-server/src/verifimind_mcp/models/concepts.py
+++ b/mcp-server/src/verifimind_mcp/models/concepts.py
@@ -52,8 +52,10 @@ class ValidationRequest(BaseModel):
         description="Whether to pass reasoning between agents"
     )
     save_to_history: bool = Field(
-        default=True,
-        description="Whether to save result to validation history"
+        default=False,
+        description="Whether to save result to the shared validation history store. "
+                    "Default False (v0.5.43): the history file is instance-global, so "
+                    "opting in exposes the concept to other clients of this server."
     )
     
     

--- a/mcp-server/src/verifimind_mcp/models/results.py
+++ b/mcp-server/src/verifimind_mcp/models/results.py
@@ -57,6 +57,14 @@ class TrinitySynthesis(BaseModel):
         description="Plain-language summary for non-technical founders: verdict, score_plain, what_works, things_to_address, next_steps, research_continuation"
     )
 
+    # v0.5.43 — fail-safe transparency: set when an agent's inference was degraded
+    # (partial/fallback/synthetic). Surfaces that the verdict rests on synthesized
+    # defaults so a caller never reads a clean PROCEED off untrustworthy ethics data.
+    inference_warning: Optional[str] = Field(
+        None,
+        description="Non-null when Trinity inference was degraded; explains why the recommendation was capped and human review is required"
+    )
+
 
 class TrinityResult(BaseModel):
     """

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.42"
+SERVER_VERSION = "0.5.43"
 
 # Agent role names + master prompt filename — single source of truth.
 # (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences
@@ -193,14 +193,65 @@ HISTORY_PATH = _get_history_path()
 
 
 def load_master_prompt() -> str:
-    """Load Genesis Master Prompt from repository."""
+    """Build the Genesis methodology surface from the LIVE production prompts.
+
+    v0.5.43 fix: this resource previously served a Sept-2025 v1.1 collection that
+    no longer matched the prompts the agents actually run and embedded internal
+    business targets + personal contact info. It is now generated directly from
+    the in-code AGENT_CONFIGS, so the public methodology surface is exactly the
+    prompt contract X / Z / CS execute — it cannot drift or misrepresent.
+    """
     try:
-        if MASTER_PROMPT_PATH.exists():
-            return MASTER_PROMPT_PATH.read_text(encoding="utf-8")
-        else:
-            return f"# Genesis Master Prompt v16.1\n\n(Master Prompt file not found at: {MASTER_PROMPT_PATH})\n\nSearched locations:\n- {Path.cwd()}/reflexion-master-prompts-v1.1.md\n- {Path(__file__).parent.parent.parent}/reflexion-master-prompts-v1.1.md"
-    except Exception as e:
-        return f"# Error Loading Master Prompt\n\nError: {str(e)}\nPath: {MASTER_PROMPT_PATH}"
+        from .models.concepts import AGENT_CONFIGS
+    except Exception as e:  # pragma: no cover - defensive
+        return f"# Error Building Master Prompt\n\nError: {str(e)}"
+
+    role_titles = {
+        "X": "X Intelligent — Innovation & Strategy",
+        "Z": "Z Guardian — Ethics & Compliance (VETO power)",
+        "CS": "CS Security — Security & Socratic Challenge",
+    }
+
+    lines = [
+        "# VerifiMind™ PEAS — Genesis Methodology (Live Production Prompts)",
+        "",
+        f"*Server version: {SERVER_VERSION}. Generated from the in-code agent "
+        "configuration — this is the exact prompt contract the X / Z / CS agents run.*",
+        "",
+        "The RefleXion Trinity validates a concept through three sequential agents. "
+        "Each agent sees the prior agents' Chain-of-Thought reasoning. Synthesis "
+        "weights: Innovation (X) 30% · Ethics (Z) 40% · Security (CS) 30%. A Z veto "
+        "caps the overall score at 3.0 and forces a REJECT verdict. If any agent's "
+        "inference is degraded, the recommendation is capped at REVISE pending human "
+        "review (fail-safe).",
+        "",
+        "---",
+        "",
+    ]
+
+    for agent_id in ("X", "Z", "CS"):
+        cfg = AGENT_CONFIGS[agent_id]
+        lines.extend([
+            f"## {role_titles.get(agent_id, cfg.name)}",
+            "",
+            f"**Role:** {cfg.role}",
+            "",
+            "**Focus areas:** " + "; ".join(cfg.focus_areas),
+            "",
+            f"**Inference settings:** temperature={cfg.temperature}, max_tokens={cfg.max_tokens}",
+            "",
+            "**Production prompt template (verbatim):**",
+            "",
+            "```text",
+            cfg.prompt_template.strip(),
+            "```",
+            "",
+            "---",
+            "",
+        ])
+
+    lines.append("*VerifiMind™ PEAS — github.com/creator35lwb-web/VerifiMind-PEAS*")
+    return "\n".join(lines)
 
 
 def load_validation_history() -> dict[str, Any]:
@@ -248,6 +299,60 @@ def get_latest_validation() -> dict[str, Any]:
         }
 
 
+def _redacted_latest_validation() -> dict[str, Any]:
+    """Non-identifying summary of the most recent validation.
+
+    The validation-history store is shared across all clients of this server
+    instance, so this MUST NOT return concept_name / concept_description or any
+    free-text the caller supplied (v0.5.43 cross-tenant privacy fix).
+    """
+    latest = get_latest_validation()
+    if not isinstance(latest, dict) or latest.get("status") == "no_validations":
+        return {
+            "status": "no_validations",
+            "message": "No validations recorded on this instance.",
+        }
+    synthesis = latest.get("synthesis", {}) if isinstance(latest.get("synthesis"), dict) else {}
+    return {
+        "validation_id": latest.get("validation_id"),
+        "recommendation": synthesis.get("recommendation"),
+        "overall_score": synthesis.get("overall_score"),
+        "veto_triggered": synthesis.get("veto_triggered"),
+        "completed_at": latest.get("completed_at"),
+        "_note": "Concept name/description intentionally omitted — shared instance store (v0.5.43 privacy).",
+    }
+
+
+def _aggregate_validation_stats() -> dict[str, Any]:
+    """Aggregate, non-identifying statistics over the shared validation history."""
+    history = load_validation_history()
+    validations = history.get("validations", []) if isinstance(history, dict) else []
+    total = len(validations)
+    if total == 0:
+        return {
+            "total_validations": 0,
+            "recommendation_distribution": {},
+            "veto_count": 0,
+            "last_updated": history.get("metadata", {}).get("last_updated") if isinstance(history, dict) else None,
+            "_note": "Aggregate stats only — per-concept detail never exposed (v0.5.43 privacy).",
+        }
+    rec_dist: dict[str, int] = {}
+    veto_count = 0
+    for v in validations:
+        synthesis = v.get("synthesis", {}) if isinstance(v, dict) else {}
+        rec = synthesis.get("recommendation", "unknown")
+        rec_dist[rec] = rec_dist.get(rec, 0) + 1
+        if synthesis.get("veto_triggered"):
+            veto_count += 1
+    return {
+        "total_validations": total,
+        "recommendation_distribution": rec_dist,
+        "veto_count": veto_count,
+        "last_updated": history.get("metadata", {}).get("last_updated"),
+        "_note": "Aggregate stats only — per-concept detail never exposed (v0.5.43 privacy).",
+    }
+
+
 def get_project_info() -> dict[str, Any]:
     """Get current project information."""
     return {
@@ -255,7 +360,7 @@ def get_project_info() -> dict[str, Any]:
         "methodology": "Genesis Methodology",
         "version": "2.0.1",
         "architecture": "RefleXion Trinity (X-Z-CS)",
-        "mcp_server_version": "0.4.5",
+        "mcp_server_version": SERVER_VERSION,
         "agents": {
             "X": {
                 "name": AGENT_X_NAME,
@@ -274,7 +379,7 @@ def get_project_info() -> dict[str, Any]:
                 "focus": ["Security vulnerabilities", "Attack vectors", "Socratic questioning"]
             }
         },
-        "master_prompt_version": "v16.1",
+        "master_prompt_version": "live (generated from production AGENT_CONFIGS)",
         "repository": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
         "documentation": "https://github.com/creator35lwb-web/VerifiMind-PEAS/docs",
         "white_paper": "https://github.com/creator35lwb-web/VerifiMind-PEAS/docs/white_paper/Genesis_Methodology_White_Paper_v1.1.md"
@@ -298,15 +403,15 @@ def _create_mcp_instance():
     @app.resource("genesis://config/master_prompt")
     def get_master_prompt() -> str:
         """
-        Genesis Master Prompt v16.1
+        Genesis Methodology — Live Production Prompts
 
-        Returns the complete Genesis Master Prompt defining roles for X Intelligent,
-        Z Guardian, and CS Security agents. This prompt ensures consistent agent
-        behavior across all validation workflows.
+        Returns the X / Z / CS prompt contract generated directly from the agents'
+        in-code configuration, so it always matches what the agents actually run
+        (v0.5.43). Includes roles, focus areas, inference settings, and the verbatim
+        production prompt templates.
 
         URI: genesis://config/master_prompt
         Format: Markdown
-        Version: v16.1
         """
         return load_master_prompt()
 
@@ -314,33 +419,34 @@ def _create_mcp_instance():
     @app.resource("genesis://history/latest")
     def get_latest_validation_resource() -> str:
         """
-        Latest Validation Result
+        Latest Validation — Privacy-Safe Summary
 
-        Returns the most recent validation result from VerifiMind-PEAS validation
-        history. Includes agent perspectives (X, Z, CS), conflict resolution, and
-        final verdict.
+        Returns a NON-IDENTIFYING summary of the most recent validation (verdict,
+        scores, timestamp). Concept names and descriptions are NOT exposed: the
+        validation-history store is shared across all clients of this server
+        instance, so returning raw concept text would leak one caller's idea to
+        another (v0.5.43 cross-tenant privacy fix).
 
         URI: genesis://history/latest
         Format: JSON
         """
-        latest = get_latest_validation()
-        return json.dumps(latest, indent=2)
+        return json.dumps(_redacted_latest_validation(), indent=2)
 
 
     @app.resource("genesis://history/all")
     def get_all_validations() -> str:
         """
-        Complete Validation History
+        Validation History — Aggregate Statistics Only
 
-        Returns the complete validation history including all past validations,
-        metadata, and statistics. Useful for analyzing validation trends and
-        decision patterns over time.
+        Returns aggregate statistics over the shared validation history (total
+        count, score/verdict distribution, last-updated) — never the per-concept
+        names or descriptions. The history store is instance-global; exposing raw
+        entries here would leak other clients' concepts (v0.5.43 privacy fix).
 
         URI: genesis://history/all
         Format: JSON
         """
-        history = load_validation_history()
-        return json.dumps(history, indent=2)
+        return json.dumps(_aggregate_validation_stats(), indent=2)
 
 
     @app.resource("genesis://state/project_info")
@@ -706,7 +812,7 @@ def _create_mcp_instance():
         concept_name: str,
         concept_description: str,
         context: Optional[str] = None,
-        save_to_history: bool = True,
+        save_to_history: bool = False,
         llm_provider: Optional[str] = None,
         api_key: Optional[str] = None,
         x_provider: Optional[str] = None,
@@ -739,7 +845,9 @@ def _create_mcp_instance():
             concept_name: Short name or title of the concept
             concept_description: Detailed description of the concept
             context: Optional additional context or background
-            save_to_history: Whether to save result to validation history (default: True)
+            save_to_history: Whether to save result to validation history (default: False).
+                History is a single shared store on this server instance; leaving this
+                False keeps your concept private to your own call (v0.5.43 privacy fix).
             llm_provider: Optional global LLM provider for all agents
             api_key: Optional global API key for all agents (ephemeral, never stored)
             x_provider: Optional provider override for X agent only
@@ -963,6 +1071,7 @@ def _create_mcp_instance():
                     "concerns": trinity_result.synthesis.concerns[:3],
                     "confidence": trinity_result.synthesis.confidence,
                     "founder_summary": getattr(trinity_result.synthesis, 'founder_summary', None),
+                    "inference_warning": getattr(trinity_result.synthesis, 'inference_warning', None),
                 },
                 "human_decision_required": True,
                 "saved_to_history": save_to_history,

--- a/mcp-server/src/verifimind_mcp/utils/synthesis.py
+++ b/mcp-server/src/verifimind_mcp/utils/synthesis.py
@@ -21,57 +21,79 @@ from ..models import (
 def calculate_overall_score(
     x_result: XAgentAnalysis,
     z_result: ZAgentAnalysis,
-    cs_result: CSAgentAnalysis
+    cs_result: CSAgentAnalysis,
+    z_quality: str = "real"
 ) -> float:
     """
     Calculate overall score from individual agent scores.
-    
+
     Weights:
     - Innovation (X): 30%
     - Ethics (Z): 40% (higher weight for ethical considerations)
     - Security (CS): 30%
-    
+
     If Z triggers veto, overall score is capped at 3.0.
+    If Z inference was degraded (z_quality != "real"), the ethics score may be a
+    synthesized default — cap the overall out of the PROCEED bands so a degraded
+    run can never read as a clean pass.
     """
     # Base weighted average
     innovation_weight = 0.30
     ethics_weight = 0.40
     security_weight = 0.30
-    
+
     # Average X scores
     x_score = (x_result.innovation_score + x_result.strategic_value) / 2
-    
+
     weighted_score = (
         x_score * innovation_weight +
         z_result.ethics_score * ethics_weight +
         cs_result.security_score * security_weight
     )
-    
+
     # Cap score if veto triggered
     if z_result.veto_triggered:
         weighted_score = min(weighted_score, 3.0)
-    
+
+    # Fail-safe: degraded REAL inference (truncated/repaired JSON) cannot be trusted
+    # to clear a concept. "mock" is test-mode and carries its own synthetic warning,
+    # so it is intentionally excluded here.
+    if z_quality in ("partial", "fallback"):
+        weighted_score = min(weighted_score, 4.0)
+
     return round(weighted_score, 1)
 
 
 def determine_recommendation(
     overall_score: float,
     z_result: ZAgentAnalysis,
-    cs_result: CSAgentAnalysis
+    cs_result: CSAgentAnalysis,
+    z_quality: str = "real"
 ) -> str:
     """
     Determine overall recommendation based on scores and flags.
-    
+
     Returns one of: "proceed", "proceed_with_caution", "revise", "reject"
+
+    Fail-safe polarity (v0.5.43): a veto_triggered=False / ethics_score read off
+    DEGRADED Z inference is untrustworthy — when truncated Z JSON is repaired by
+    schema defaults, veto defaults to False and ethics to a midpoint. So if Z
+    inference was not "real", we never auto-pass: cap at REVISE pending human review.
     """
     # Veto always results in reject
     if z_result.veto_triggered:
         return "reject"
-    
+
+    # Fail-safe: never auto-clear a concept on degraded real ethics inference
+    # (truncated Z JSON repaired by schema defaults → veto=False, ethics=midpoint).
+    # "mock" is test-mode with its own synthetic warning and is excluded.
+    if z_quality in ("partial", "fallback"):
+        return "revise"
+
     # High security vulnerabilities require revision
     if cs_result.security_score < 4.0:
         return "revise"
-    
+
     # Score-based recommendations
     if overall_score >= 7.5:
         return "proceed"
@@ -246,11 +268,27 @@ def create_synthesis(
     This is the core synthesis function that combines all perspectives
     into a unified assessment.
     """
-    overall_score = calculate_overall_score(x_result, z_result, cs_result)
-    recommendation = determine_recommendation(overall_score, z_result, cs_result)
+    # v0.5.43 fail-safe: read the ethics layer's inference quality (attached by
+    # BaseAgent.analyze). "real" = trustworthy; partial/fallback = synthesized.
+    z_quality = getattr(z_result, "_inference_quality", "real")
+
+    overall_score = calculate_overall_score(x_result, z_result, cs_result, z_quality)
+    recommendation = determine_recommendation(overall_score, z_result, cs_result, z_quality)
+
+    inference_warning = None
+    if z_quality in ("partial", "fallback"):
+        inference_warning = (
+            f"Ethics (Z) inference quality was '{z_quality}', not 'real' — the veto flag "
+            "and ethics score may be synthesized schema defaults rather than a genuine "
+            "ethical assessment. Recommendation has been capped at REVISE; a human must "
+            "review ethics before this concept proceeds."
+        )
 
     # Build summary
     summary_parts = []
+
+    if inference_warning:
+        summary_parts.append("⚠️ DEGRADED ETHICS INFERENCE — human review required")
 
     if z_result.veto_triggered:
         summary_parts.append("VETO TRIGGERED by Z Guardian.")
@@ -271,6 +309,16 @@ def create_synthesis(
         cs_result.confidence
     ) / 3
 
+    founder_summary = build_founder_summary(
+        overall_score, recommendation, x_result, z_result, cs_result
+    )
+    # Surface the degraded-inference caveat at the top of the founder verdict too
+    if inference_warning and isinstance(founder_summary, dict):
+        founder_summary["verdict"] = (
+            "NEEDS HUMAN REVIEW: the ethics check did not complete cleanly, so this "
+            "result is not trustworthy on its own. " + founder_summary.get("verdict", "")
+        ).strip()
+
     synthesis = TrinitySynthesis(
         summary=summary,
         innovation_score=x_result.innovation_score,
@@ -284,9 +332,8 @@ def create_synthesis(
         confidence=round(avg_confidence, 2),
         veto_triggered=z_result.veto_triggered,
         veto_reason=z_result.ethical_concerns[0] if z_result.veto_triggered and z_result.ethical_concerns else None,
-        founder_summary=build_founder_summary(
-            overall_score, recommendation, x_result, z_result, cs_result
-        ),
+        founder_summary=founder_summary,
+        inference_warning=inference_warning,
     )
 
     return synthesis

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.42"
+        assert http_server.SERVER_VERSION == "0.5.43"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.42", (
-            f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.43", (
+            f"Expected 0.5.43, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.42"
+        assert SERVER_VERSION == "0.5.43"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.42"
+        assert SERVER_VERSION == "0.5.43"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.42", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.43", f"Expected 0.5.43, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.42", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.43", f"Expected 0.5.43, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -214,4 +214,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.42", f"Expected 0.5.40, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.43", f"Expected 0.5.43, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.42"
+        assert http_server.SERVER_VERSION == "0.5.43"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.42"
+        assert http_server.SERVER_VERSION == "0.5.43"

--- a/mcp-server/tests/unit/test_v0543_foundation_integrity.py
+++ b/mcp-server/tests/unit/test_v0543_foundation_integrity.py
@@ -1,0 +1,136 @@
+"""
+v0.5.43 Foundation Integrity — regression tests for the P0 fixes.
+
+Covers:
+- P0-1: Z veto fail-safe polarity on DEGRADED real inference (partial/fallback)
+- P0-2: cross-tenant validation-history leak — resources expose no raw concept text
+- P0-3: master_prompt resource serves the live production prompts (no stale PII)
+- P1-4: project_info advertises the real SERVER_VERSION
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from verifimind_mcp.utils.synthesis import (
+    calculate_overall_score,
+    determine_recommendation,
+)
+from verifimind_mcp import server
+
+
+def _x(score=8.0):
+    return SimpleNamespace(innovation_score=score, strategic_value=score)
+
+
+def _z(ethics=9.0, veto=False, quality="real"):
+    ns = SimpleNamespace(ethics_score=ethics, veto_triggered=veto)
+    ns._inference_quality = quality
+    return ns
+
+
+def _cs(security=9.0):
+    return SimpleNamespace(security_score=security)
+
+
+# ---------- P0-1: fail-safe polarity ----------
+
+def test_clean_high_score_proceeds_when_inference_real():
+    """Baseline: a clean, real-inference run with high scores still proceeds."""
+    score = calculate_overall_score(_x(9.0), _z(9.0), _cs(9.0), z_quality="real")
+    rec = determine_recommendation(score, _z(9.0), _cs(9.0), z_quality="real")
+    assert rec == "proceed"
+    assert score >= 7.5
+
+
+@pytest.mark.parametrize("degraded", ["partial", "fallback"])
+def test_degraded_z_inference_never_auto_passes(degraded):
+    """A high-scoring run must NOT proceed if Z inference was degraded — the veto
+    flag and ethics score could be synthesized schema defaults."""
+    z = _z(ethics=9.0, veto=False, quality=degraded)
+    score = calculate_overall_score(_x(9.0), z, _cs(9.0), z_quality=degraded)
+    rec = determine_recommendation(score, z, _cs(9.0), z_quality=degraded)
+    assert rec == "revise", f"degraded={degraded} must cap at revise, got {rec}"
+    assert score <= 4.0, f"degraded score must stay out of proceed bands, got {score}"
+
+
+def test_mock_inference_excluded_from_failsafe():
+    """'mock' is test-mode with its own synthetic warning — it must NOT trip the
+    degraded-inference fail-safe (would break every mock-based test)."""
+    z = _z(ethics=9.0, veto=False, quality="mock")
+    score = calculate_overall_score(_x(9.0), z, _cs(9.0), z_quality="mock")
+    rec = determine_recommendation(score, z, _cs(9.0), z_quality="mock")
+    assert rec == "proceed"
+
+
+def test_veto_still_rejects_regardless_of_quality():
+    z = _z(ethics=2.0, veto=True, quality="real")
+    score = calculate_overall_score(_x(9.0), z, _cs(9.0), z_quality="real")
+    rec = determine_recommendation(score, z, _cs(9.0), z_quality="real")
+    assert rec == "reject"
+    assert score <= 3.0
+
+
+# ---------- P0-2: history resources leak no raw concept text ----------
+
+def test_latest_validation_resource_omits_concept_text(monkeypatch):
+    leaky = {
+        "validation_id": "abc123",
+        "concept_name": "SECRET STARTUP IDEA",
+        "concept_description": "confidential description that must not leak",
+        "completed_at": "2026-06-11T00:00:00",
+        "synthesis": {"recommendation": "proceed", "overall_score": 8.0, "veto_triggered": False},
+    }
+    monkeypatch.setattr(server, "get_latest_validation", lambda: leaky)
+    out = server._redacted_latest_validation()
+    blob = str(out)
+    assert "SECRET STARTUP IDEA" not in blob
+    assert "confidential description" not in blob
+    assert out["recommendation"] == "proceed"
+    assert out["validation_id"] == "abc123"
+
+
+def test_aggregate_stats_omit_concept_text(monkeypatch):
+    history = {
+        "validations": [
+            {"concept_name": "Idea A", "concept_description": "desc A",
+             "synthesis": {"recommendation": "proceed", "veto_triggered": False}},
+            {"concept_name": "Idea B", "concept_description": "desc B",
+             "synthesis": {"recommendation": "reject", "veto_triggered": True}},
+        ],
+        "metadata": {"last_updated": "2026-06-11"},
+    }
+    monkeypatch.setattr(server, "load_validation_history", lambda: history)
+    out = server._aggregate_validation_stats()
+    blob = str(out)
+    assert "Idea A" not in blob and "Idea B" not in blob
+    assert "desc A" not in blob and "desc B" not in blob
+    assert out["total_validations"] == 2
+    assert out["veto_count"] == 1
+    assert out["recommendation_distribution"] == {"proceed": 1, "reject": 1}
+
+
+# ---------- P0-3: master_prompt is live + free of stale PII/targets ----------
+
+def test_master_prompt_serves_live_prompts():
+    doc = server.load_master_prompt()
+    assert "Genesis Methodology" in doc
+    # Real agent roles present
+    assert "X Intelligent" in doc and "Z Guardian" in doc and "CS Security" in doc
+    # Reflects current server version
+    assert server.SERVER_VERSION in doc
+
+
+def test_master_prompt_drops_stale_internal_artifacts():
+    doc = server.load_master_prompt()
+    # The old v1.1 collection embedded a personal email and internal revenue target
+    assert "creator35lwb@gmail.com" not in doc
+    assert "5亿美元" not in doc  # internal 2030 revenue target
+    assert "200万用户" not in doc
+
+
+# ---------- P1-4: project_info version currency ----------
+
+def test_project_info_reports_real_version():
+    info = server.get_project_info()
+    assert info["mcp_server_version"] == server.SERVER_VERSION


### PR DESCRIPTION
## Summary

Foundation-effectiveness audit (Issue #68, Alton-directed, Fable 5) live-tested the Trinity core on production v0.5.42 and found the core **genuinely effective** (Z veto fires; production is real multi-model X=Gemini / Z+CS=Groq-Llama; scoring is proportional) — but surfaced **three P0 integrity defects** plus two cheap high-leverage fixes.

> **Status: HOLD for T+L sign-off.** PR opened for review per Dual-Repo Protocol. Deploy + `server.json` bump are the post-approval step — do not merge until T+L ratify on the PRIVATE alignment issue.

## P0 fixes

**P0-1 — Z veto fail-safe polarity.** When Z's JSON truncates, `_fill_schema_defaults` repairs it with `veto_triggered=False` + `ethics_score=5.0`, and the recommendation logic never checked inference quality — so a should-be-vetoed concept could read as a clean PROCEED on synthesized data. `synthesis.py` now caps recommendation at REVISE + overall ≤4.0 and emits `inference_warning` when `z_quality ∈ {partial, fallback}`. `mock` (test-mode, has its own synthetic warning) is intentionally excluded.

**P0-2 — Cross-tenant validation-history leak.** `save_to_history` defaulted `True`, appending every caller's concept (name + full description) to an **instance-global** file that `genesis://history/latest` and `/all` served verbatim to any other client. Default → `False`; the two resources now return a non-identifying summary / aggregate stats only.

**P0-3 — `master_prompt` resource served the wrong artifact.** Production returned a Sept-2025 Chinese v1.1 collection containing an internal 2030 revenue target and a personal email — not the prompts the agents run. Now generated from the live `AGENT_CONFIGS`, so the public methodology surface can't drift from or misrepresent what executes.

## P1 fixes (adjacent, low-risk)

- **P1-2** — agents now receive the current date (research prompts said "2024"; Z's "upcoming deadline" reasoning rotted silently).
- **P1-4** — `project_info` advertised version `0.4.5` / master_prompt `v16.1` → now reads `SERVER_VERSION`.

## Tests

- New `test_v0543_foundation_integrity.py` (10 cases): fail-safe polarity incl. mock-exclusion + veto-still-rejects, history redaction (no raw concept text), live master_prompt (no stale PII), version currency.
- Full suite: **666 passed, 14 skipped.**
- Version bumped `0.5.42 → 0.5.43` (2 constants + 9 version-pinned tests).

## Not in this PR (routed)

- **P1-1** full reasoning-chain exposure (our differentiator is trimmed from the flagship tool response) — bigger response-shape change, needs T+L decision.
- **P1-3** Z regulatory-DB maintenance cadence + **P2-3** score reproducibility → Council / M2-M3 eval.

Audit detail: Issue #68 comment (CSO assessment). Live probes: `bae06d0a` (veto PASS), `eca1b3cd` (quality PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)