### PR TITLE
chore(v0.5.43): docs — server.json + CHANGELOG + SERVER_STATUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.43 - Foundation Integrity (June 11, 2026)
+
+Patch release hardening the verification core and the MCP resource surface — three integrity fixes surfaced by a foundation-effectiveness audit (Issue #68), plus two currency fixes.
+
+### What changed
+
+- **Ethics veto fail-safe (P0):** The Z Guardian veto and ethics score could previously be read off *degraded* inference — if the Z model's JSON was truncated and repaired with schema defaults, the veto flag defaulted to "not triggered" and the ethics score to a midpoint, so a concept that should have been stopped could surface a clean recommendation. The synthesis layer now detects degraded ethics inference (`partial`/`fallback`), caps the recommendation at REVISE, holds the overall score out of the proceed range, and returns an explicit `inference_warning` requiring human review. Genuine (`real`) and test (`mock`) inference are unaffected.
+- **Validation-history privacy (P0):** `save_to_history` now defaults to **off**, and the `genesis://history/latest` and `genesis://history/all` resources return only non-identifying summaries / aggregate statistics. Previously the history store was shared per server instance and the resources could surface one caller's concept text to another; concept names and descriptions are no longer exposed through these resources.
+- **Methodology resource accuracy (P0):** The `genesis://config/master_prompt` resource is now generated directly from the live agent configuration, so it always reflects the exact X / Z / CS prompts the agents run. It previously served an outdated prompt collection that no longer matched production.
+- **Current-date awareness (P1):** Every agent prompt is now anchored to the real current date, so market-recency reasoning and regulatory-deadline checks no longer drift toward the model's training cutoff.
+- **Version currency (P1):** `genesis://state/project_info` now reports the live server version.
+
+### Why
+
+A live-tested audit of the flagship `run_full_trinity` tool confirmed the core is effective (the ethics veto fires; production runs genuinely multi-model; scoring is proportional) but found the verdict could rest on synthesized defaults in the degraded path, and that the resource surface had drifted from production. Fail-safe-first behavior and resource accuracy are foundational to an epistemic-verification product.
+
+**PR:** #254
+
+---
+
 ## v0.5.42 - Server-Card Description Refresh (June 9, 2026)
 
 Patch release: refreshes the `/.well-known/mcp/server-card.json` MCP discovery surface, which carried stale copy.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** June 9, 2026
+**Last Updated:** June 11, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.42 "Server-Card Description Refresh" — deployed June 9, 2026**
+**v0.5.43 "Foundation Integrity" — deployed June 11, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Foundation Integrity (v0.5.43)**: three integrity fixes from the Issue #68 foundation audit — (1) ethics-veto fail-safe: degraded Z inference (`partial`/`fallback`) now caps the recommendation at REVISE + emits `inference_warning` instead of allowing a clean pass on synthesized defaults; (2) validation-history privacy: `save_to_history` defaults off and `genesis://history/*` resources return non-identifying aggregates only (no cross-instance concept-text exposure); (3) `genesis://config/master_prompt` now generated from live agent config (was serving a stale prompt collection). Plus current-date injection into agent prompts and `project_info` version currency. 10 new regression tests — June 11, 2026
 - **Server-Card Description Refresh (v0.5.42)**: `/.well-known/mcp/server-card.json` refreshed — stale "Genesis v4.2" copy → current descriptors (13 free tools, BYOK 6 providers); docstring de-Smithery'd (listing sunset 2026-03-01); pre-submission accuracy pass — June 9, 2026
 - **Register Page Dead-Link Fix (v0.5.41)**: `/register` "check your status" link pointed to `/early-adopters/status/` (bare, 404) — repointed to `/whoami` self-serve endpoint. Last dead link in the registration funnel, caught by Alton — June 5, 2026
 - **Registration Funnel Fix + /whoami (v0.5.40)**: Closes Scholar UUID registration funnel leak — `rate_limiter.py` now reads `early_adopters` (single source of truth, D-30-3); `/early-adopters/status/{uuid}` returns `200 + register CTA` instead of `404` for valid unregistered UUIDs; new `/whoami` endpoint for self-serve tier/status check; `claude-opus-4-8` model currency bump — June 5, 2026
@@ -44,8 +45,8 @@ The VerifiMind MCP server is fully operational. All security gates passed. (Per-
 - **CS Agent v1.1**: 6-stage, 12-dimension, OWASP Agentic AI Top 10
 - Input sanitization active (20+ secret patterns)
 - Rate limiting and EDoS protection active
-- GCP Cloud Run revision: `verifimind-mcp-server-00394-gcj`
-- CI/CD pipeline passing — 631 tests, 0 CodeQL medium+ alerts
+- GCP Cloud Run revision: `verifimind-mcp-server-00450-qjb`
+- CI/CD pipeline passing — 666 tests passing (680 collected, 14 skipped), 0 CodeQL medium+ alerts
 
 ---
 

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.42",
-  "version": "3.19.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.43",
+  "version": "3.20.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
Documentation surfaces for v0.5.43 "Foundation Integrity" (code shipped in #254, deployed to Cloud Run rev `verifimind-mcp-server-00450-qjb`).

- `server.json`: registry version `3.19.0 → 3.20.0`, description `v0.5.42 → v0.5.43` (79 chars, under the 100 limit)
- `CHANGELOG.md`: v0.5.43 entry (3 P0 + 2 P1 fixes, measured privacy/hardening framing)
- `SERVER_STATUS.md`: version, GCP revision, test count (666 passing)

Live verified: `/health` v0.5.43; `project_info` reports 0.5.43; `master_prompt` resource serves live prompts (stale PII gone); Trinity no-regression probe clean with `inference_warning` field present + `saved_to_history:false` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)