### PR TITLE
v0.5.44 "Reasoning Visible" — expose the auditable reasoning layer (P1-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.44 - Reasoning Visible (June 12, 2026)
+
+Makes the auditable reasoning layer — the core of the product — visible in tool responses by default. The X/Z/CS agents already generated per-step reasoning, framework citations, an ethics scoring breakdown, and Socratic questions on every call; previously the flagship `run_full_trinity` JSON response trimmed all of it and returned only scores. This is serialization, not new inference — no added cost or latency.
+
+### What changed
+
+- **New `reasoning` block on `run_full_trinity`** via a `detail` parameter:
+  - `detail="standard"` (**new default**) — returns the reasoning block: per-agent reasoning steps, Z's 5-dimension ethics scoring breakdown + framework citations + detected jurisdictions, CS's threat level + Socratic questions + attack vectors, and the per-agent inference quality (with the v0.5.43 `inference_warning`).
+  - `detail="full"` — adds per-step evidence and the heaviest structured fields (12-dimension security matrix, 6-stage record, MACP assessment, market-competition analysis).
+  - `detail="summary"` — omits the reasoning block, reproducing the exact pre-v0.5.44 response shape (opt-out for cost/context-tight clients).
+- **The block is strictly additive** — every existing response field is unchanged at every level; a `summary` call is byte-compatible with prior releases.
+- **`consult_agent_x/z/cs`** gain the same `detail` ladder — they previously dropped per-step evidence and the structured fields (scoring breakdown, jurisdictions, threat level, etc.).
+- **Markdown report** (`Accept: text/markdown`) now renders the ethics scoring breakdown, detected jurisdictions, CS threat level, and the degraded-inference warning; its generator-version stamp is sourced from the live server version (was pinned at a stale `0.4.1`).
+- **Discovery surfaces** (server-card, `/setup`) updated to advertise auditable-reasoning-by-default and the corrected `save_to_history` default.
+
+### Why
+
+VerifiMind's differentiator is auditable, multi-model verification reasoning — and it was being computed, then discarded before reaching the caller. A skeptic received a bare score indistinguishable from any rubric API. Returning the reasoning by default is the proof surface for the epistemic-verification positioning, and the object downstream evaluation scores. Approved by T+L Session 41 (default `standard`; `full` stays free).
+
+**PR:** #256
+
+---
+
 ## v0.5.43 - Foundation Integrity (June 11, 2026)
 
 Patch release hardening the verification core and the MCP resource surface — three integrity fixes surfaced by a foundation-effectiveness audit (Issue #68), plus two currency fixes.

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.43"
+SERVER_VERSION = "0.5.44"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32
@@ -246,8 +246,8 @@ async def mcp_config_handler(request):
             },
             {
                 "name": "run_full_trinity",
-                "description": "Complete X → Z → CS validation with per-agent optimized providers",
-                "parameters": ["concept_name", "concept_description", "context (optional)", "save_to_history (default: true)"]
+                "description": "Complete X → Z → CS validation with per-agent optimized providers; returns auditable reasoning by default",
+                "parameters": ["concept_name", "concept_description", "context (optional)", "save_to_history (default: false)", "detail (summary|standard|full, default: standard)"]
             },
             # v0.4.0 Template Tools
             {
@@ -299,7 +299,7 @@ async def mcp_config_handler(request):
         ],
         # Resources
         "resources": [
-            {"uri": "genesis://config/master_prompt", "description": "Genesis Master Prompt v16.1"},
+            {"uri": "genesis://config/master_prompt", "description": "Genesis methodology — live X/Z/CS production prompts"},
             {"uri": "genesis://history/latest", "description": "Most recent validation result"},
             {"uri": "genesis://history/all", "description": "Complete validation history"},
             {"uri": "genesis://state/project_info", "description": "Project metadata and agent info"}
@@ -892,9 +892,10 @@ async def smithery_server_card_handler(request):
             "Multi-model AI validation framework. Validate concepts end-to-end across "
             "innovation (X Agent), ethics & compliance (Z Agent), and security (CS Agent) "
             "via the X-Z-CS RefleXion Trinity. 13 free MCP tools (Trinity validation, "
-            "prompt-template library, and cross-session coordination). BYOK across 6 "
-            "providers (Gemini, Anthropic, OpenAI, Groq, Cerebras, Mistral). Free tier "
-            "powered by Gemini 2.5 Flash."
+            "prompt-template library, and cross-session coordination). Auditable reasoning "
+            "returned by default — per-step reasoning, framework citations, ethics scoring "
+            "breakdown, and Socratic questions. BYOK across 6 providers (Gemini, Anthropic, "
+            "OpenAI, Groq, Cerebras, Mistral). Free tier powered by Gemini 2.5 Flash."
         ),
         "version": SERVER_VERSION,
         "iconUrl": "https://verifimind.ysenseai.org/logo.png",

--- a/mcp-server/src/verifimind_mcp/reporting/markdown_reporter.py
+++ b/mcp-server/src/verifimind_mcp/reporting/markdown_reporter.py
@@ -19,8 +19,17 @@ from ..models.reasoning import (
     ReasoningStep,
 )
 
-SERVER_VERSION = "0.4.1"
 FORMAT_VERSION = "markdown-first/1.0"
+
+
+def _server_version() -> str:
+    """Source the live server version lazily (avoids a hardcoded 3rd constant
+    drifting out of sync — v0.5.44 fix; was pinned at a stale "0.4.1")."""
+    try:
+        from ..server import SERVER_VERSION as _SV
+        return _SV
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
 
 
 def generate_yaml_frontmatter(result: TrinityResult) -> str:
@@ -43,7 +52,7 @@ def generate_yaml_frontmatter(result: TrinityResult) -> str:
         f"veto_triggered: {'true' if result.synthesis.veto_triggered else 'false'}",
         f"confidence: {result.synthesis.confidence:.2f}",
         f"timestamp: {iso_ts}",
-        f"generator: verifimind-peas/{SERVER_VERSION}",
+        f"generator: verifimind-peas/{_server_version()}",
         f"format: {FORMAT_VERSION}",
         "---",
     ]
@@ -153,6 +162,14 @@ def _section_executive_summary(s: TrinitySynthesis) -> str:
             "",
         ])
 
+    # v0.5.44: surface the degraded-inference fail-safe (if set)
+    inference_warning = getattr(s, "inference_warning", None)
+    if inference_warning:
+        lines.extend([
+            f"> ⚠️ **DEGRADED INFERENCE — HUMAN REVIEW REQUIRED:** {inference_warning}",
+            "",
+        ])
+
     lines.extend([
         "| Agent | Score | Role |",
         "|-------|-------|------|",
@@ -212,6 +229,24 @@ def _section_z_agent(z: ZAgentAnalysis) -> str:
         "",
     ]
 
+    # v0.5.44: jurisdiction + framework citations (the auditable ethics layer)
+    jurisdiction = getattr(z, "jurisdiction_detected", None)
+    if jurisdiction:
+        lines.append(f"**Jurisdictions detected:** {', '.join(jurisdiction)}")
+        lines.append("")
+    breakdown = getattr(z, "scoring_breakdown", None)
+    if isinstance(breakdown, dict) and breakdown:
+        lines.append("### Ethics Scoring Breakdown")
+        lines.append("")
+        lines.append("| Dimension | Score | Weight | Frameworks |")
+        lines.append("|-----------|------:|-------:|------------|")
+        for dim, d in breakdown.items():
+            if isinstance(d, dict):
+                fw = d.get("frameworks", [])
+                fw_str = ", ".join(fw) if isinstance(fw, list) else str(fw)
+                lines.append(f"| {dim.replace('_', ' ').title()} | {d.get('score', '?')} | {d.get('weight', '?')} | {fw_str} |")
+        lines.append("")
+
     lines.extend(_format_reasoning_chain(z.reasoning_steps))
 
     if z.ethical_concerns:
@@ -236,11 +271,13 @@ def _section_z_agent(z: ZAgentAnalysis) -> str:
 def _section_cs_agent(cs: CSAgentAnalysis) -> str:
     conf_pct = int(cs.confidence * 100)
 
+    threat = getattr(cs, "threat_level", None)
+    threat_str = f" | **Threat Level:** {threat}" if threat else ""
     lines = [
         f"## {cs.agent} — Security & Socratic Scrutiny",
         "",
         f"**Security Score:** {cs.security_score:.1f}/10 | "
-        f"**Confidence:** {conf_pct}%",
+        f"**Confidence:** {conf_pct}%{threat_str}",
         "",
     ]
 

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.43"
+SERVER_VERSION = "0.5.44"
 
 # Agent role names + master prompt filename — single source of truth.
 # (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences
@@ -471,6 +471,7 @@ def _create_mcp_instance():
         concept_name: str,
         concept_description: str,
         context: Optional[str] = None,
+        detail: str = "standard",
         llm_provider: Optional[str] = None,
         api_key: Optional[str] = None,
         user_uuid: Optional[str] = None,
@@ -537,13 +538,12 @@ def _create_mcp_instance():
             result = await agent.analyze(concept)
 
             _iq = getattr(result, '_inference_quality', 'unknown')
+            from .utils.reasoning_view import normalize_detail, consult_steps
+            detail = normalize_detail(detail)
             payload = {
                 "agent": AGENT_X_NAME,
                 "concept": concept_name,
-                "reasoning_steps": [
-                    {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
-                    for s in result.reasoning_steps
-                ],
+                "reasoning_steps": consult_steps(result.reasoning_steps, detail),
                 "innovation_score": result.innovation_score,
                 "strategic_value": result.strategic_value,
                 "opportunities": result.opportunities,
@@ -554,6 +554,13 @@ def _create_mcp_instance():
                 "_provider_used": provider.get_model_name(),
                 "_byok": byok_used
             }
+            # v0.5.44: structured fields at standard+; heaviest at full
+            if detail in ("standard", "full"):
+                payload["next_steps"] = getattr(result, "next_steps", None) or []
+                payload["research_prompts"] = getattr(result, "research_prompts", None) or []
+            if detail == "full":
+                payload["market_competition"] = getattr(result, "market_competition", None)
+                payload["competitive_analysis"] = getattr(result, "competitive_analysis", None)
             if _iq == "mock":
                 payload["_warning"] = MOCK_MODE_WARNING
             persist_trinity_result(user_uuid, "consult_agent_x", payload)
@@ -574,6 +581,7 @@ def _create_mcp_instance():
         concept_description: str,
         context: Optional[str] = None,
         prior_reasoning: Optional[str] = None,
+        detail: str = "standard",
         llm_provider: Optional[str] = None,
         api_key: Optional[str] = None,
         user_uuid: Optional[str] = None,
@@ -658,13 +666,12 @@ def _create_mcp_instance():
             result = await agent.analyze(concept, prior)
 
             _iq = getattr(result, '_inference_quality', 'unknown')
+            from .utils.reasoning_view import normalize_detail, consult_steps
+            detail = normalize_detail(detail)
             payload = {
                 "agent": AGENT_Z_NAME,
                 "concept": concept_name,
-                "reasoning_steps": [
-                    {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
-                    for s in result.reasoning_steps
-                ],
+                "reasoning_steps": consult_steps(result.reasoning_steps, detail),
                 "ethics_score": result.ethics_score,
                 "z_protocol_compliance": result.z_protocol_compliance,
                 "ethical_concerns": result.ethical_concerns,
@@ -676,6 +683,14 @@ def _create_mcp_instance():
                 "_provider_used": provider.get_model_name(),
                 "_byok": byok_used
             }
+            # v0.5.44: framework citations + scoring breakdown at standard+
+            if detail in ("standard", "full"):
+                payload["scoring_breakdown"] = getattr(result, "scoring_breakdown", None)
+                payload["jurisdiction_detected"] = getattr(result, "jurisdiction_detected", None)
+                payload["applicable_frameworks"] = getattr(result, "applicable_frameworks", None)
+                payload["compliance_timeline"] = getattr(result, "compliance_timeline", None)
+            if detail == "full":
+                payload["total_frameworks_evaluated"] = getattr(result, "total_frameworks_evaluated", None)
             if _iq == "mock":
                 payload["_warning"] = MOCK_MODE_WARNING
             persist_trinity_result(user_uuid, "consult_agent_z", payload)
@@ -696,6 +711,7 @@ def _create_mcp_instance():
         concept_description: str,
         context: Optional[str] = None,
         prior_reasoning: Optional[str] = None,
+        detail: str = "standard",
         llm_provider: Optional[str] = None,
         api_key: Optional[str] = None,
         user_uuid: Optional[str] = None,
@@ -775,13 +791,12 @@ def _create_mcp_instance():
             agent = CSAgent(llm_provider=provider)
             result = await agent.analyze(concept, prior)
 
+            from .utils.reasoning_view import normalize_detail, consult_steps
+            detail = normalize_detail(detail)
             payload = {
                 "agent": AGENT_CS_NAME,
                 "concept": concept_name,
-                "reasoning_steps": [
-                    {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
-                    for s in result.reasoning_steps
-                ],
+                "reasoning_steps": consult_steps(result.reasoning_steps, detail),
                 "security_score": result.security_score,
                 "vulnerabilities": result.vulnerabilities,
                 "attack_vectors": result.attack_vectors,
@@ -793,6 +808,16 @@ def _create_mcp_instance():
                 "_provider_used": provider.get_model_name(),
                 "_byok": byok_used
             }
+            # v0.5.44: threat assessment at standard+; 12-dim/6-stage/MACP at full
+            if detail in ("standard", "full"):
+                payload["threat_level"] = getattr(result, "threat_level", None)
+                payload["agentic_threats"] = getattr(result, "agentic_threats", None)
+                payload["reasoning_layer_findings"] = getattr(result, "reasoning_layer_findings", None)
+            if detail == "full":
+                payload["dimensions_evaluated"] = getattr(result, "dimensions_evaluated", None)
+                payload["stages_completed"] = getattr(result, "stages_completed", None)
+                payload["macp_security_assessment"] = getattr(result, "macp_security_assessment", None)
+                payload["standards_referenced"] = getattr(result, "standards_referenced", None)
             if payload["_inference_quality"] == "mock":
                 payload["_warning"] = MOCK_MODE_WARNING
             persist_trinity_result(user_uuid, "consult_agent_cs", payload)
@@ -813,6 +838,7 @@ def _create_mcp_instance():
         concept_description: str,
         context: Optional[str] = None,
         save_to_history: bool = False,
+        detail: str = "standard",
         llm_provider: Optional[str] = None,
         api_key: Optional[str] = None,
         x_provider: Optional[str] = None,
@@ -848,6 +874,13 @@ def _create_mcp_instance():
             save_to_history: Whether to save result to validation history (default: False).
                 History is a single shared store on this server instance; leaving this
                 False keeps your concept private to your own call (v0.5.43 privacy fix).
+            detail: Reasoning verbosity (v0.5.44) — "standard" (default) returns the
+                auditable `reasoning` block (per-step reasoning, ethics scoring breakdown
+                + framework citations, Socratic questions, threat assessment) alongside
+                the scores; "full" adds per-step evidence and the heaviest structured
+                fields (12-dimension matrix, 6-stage record, MACP assessment); "summary"
+                omits the reasoning block for the smallest payload. The block is additive —
+                existing response fields are unchanged at every level.
             llm_provider: Optional global LLM provider for all agents
             api_key: Optional global API key for all agents (ephemeral, never stored)
             x_provider: Optional provider override for X agent only
@@ -862,6 +895,9 @@ def _create_mcp_instance():
         """
         if user_uuid:
             emit_tracer(user_uuid, "run_full_trinity")
+        # v0.5.44: normalize reasoning verbosity (invalid → "standard")
+        from .utils.reasoning_view import normalize_detail
+        detail = normalize_detail(detail)
         # Check Accept header for markdown content negotiation
         output_format = "json"
         if ctx and hasattr(ctx, 'request_context'):
@@ -1081,6 +1117,16 @@ def _create_mcp_instance():
                 **_byok_meta,
                 **session.to_metadata(),
             }
+            # v0.5.44: attach the auditable reasoning block (additive). "summary"
+            # callers opt out and receive the exact pre-0.5.44 shape.
+            if detail in ("standard", "full"):
+                from .utils.reasoning_view import build_reasoning_block
+                payload["reasoning"] = build_reasoning_block(
+                    x_result, z_result, cs_result,
+                    chain_status, overall_quality,
+                    getattr(trinity_result.synthesis, 'inference_warning', None),
+                    detail,
+                )
             if overall_quality == "synthetic":
                 payload["_warning"] = MOCK_MODE_WARNING
             persist_trinity_result(user_uuid, "run_full_trinity", payload)

--- a/mcp-server/src/verifimind_mcp/utils/reasoning_view.py
+++ b/mcp-server/src/verifimind_mcp/utils/reasoning_view.py
@@ -1,0 +1,153 @@
+"""
+Reasoning-view serialization for VerifiMind-PEAS — v0.5.44 "Reasoning Visible".
+
+The X/Z/CS agents generate a rich auditable-reasoning layer (per-step reasoning,
+framework citations, ethics scoring breakdown, Socratic questions, security
+dimensions) on every call. Prior to v0.5.44 the flagship `run_full_trinity` JSON
+response trimmed all of it, returning only scores + a short summary. That layer IS
+the product — this module serializes it into an additive `reasoning` block.
+
+Verbosity ladder (the `detail` parameter):
+- "summary"  → no reasoning block (exact pre-0.5.44 response shape — opt-out)
+- "standard" → reasoning steps + citations + breakdowns (NEW default; T+L D-41-2)
+- "full"     → standard + per-step evidence + the heaviest structured fields
+
+Backward compatibility: the block is strictly additive. Existing response keys are
+never removed or renamed; a "summary" call reproduces the old bytes exactly.
+
+Note on per-step citations: the `ReasoningStep` model only persists
+step_number / thought / evidence / confidence. Per-step `frameworks_cited` /
+`stage` / `standards_cited` that the prompts request are NOT in the schema, so they
+are surfaced via the model-level structured fields (scoring_breakdown,
+applicable_frameworks, dimensions_evaluated, standards_referenced) instead.
+"""
+
+from typing import Any, Dict, List, Optional
+
+VALID_DETAIL = ("summary", "standard", "full")
+DEFAULT_DETAIL = "standard"
+
+
+def normalize_detail(detail: Optional[str]) -> str:
+    """Coerce an arbitrary detail value to a valid level (default 'standard')."""
+    if not detail:
+        return DEFAULT_DETAIL
+    d = str(detail).strip().lower()
+    return d if d in VALID_DETAIL else DEFAULT_DETAIL
+
+
+def _serialize_steps(steps: List[Any], full: bool) -> List[Dict[str, Any]]:
+    """Render reasoning steps. Evidence is included only at 'full' detail."""
+    out: List[Dict[str, Any]] = []
+    for s in steps or []:
+        d: Dict[str, Any] = {
+            "n": s.step_number,
+            "thought": s.thought,
+            "confidence": s.confidence,
+        }
+        if full:
+            ev = getattr(s, "evidence", None)
+            if ev:
+                d["evidence"] = ev
+        out.append(d)
+    return out
+
+
+def consult_steps(steps: List[Any], detail: str) -> List[Dict[str, Any]]:
+    """Reasoning steps for the single-agent consult tools.
+
+    Preserves the legacy ``{"step", "thought", "confidence"}`` key shape (the
+    flagship Trinity block uses ``"n"`` instead) for backward compatibility, and
+    adds ``evidence`` only at 'full' detail.
+    """
+    full = detail == "full"
+    out: List[Dict[str, Any]] = []
+    for s in steps or []:
+        d: Dict[str, Any] = {"step": s.step_number, "thought": s.thought, "confidence": s.confidence}
+        if full:
+            ev = getattr(s, "evidence", None)
+            if ev:
+                d["evidence"] = ev
+        out.append(d)
+    return out
+
+
+def x_reasoning(x_result: Any, detail: str) -> Dict[str, Any]:
+    """X Intelligent reasoning view."""
+    full = detail == "full"
+    block: Dict[str, Any] = {
+        "steps": _serialize_steps(x_result.reasoning_steps, full),
+        "opportunities": x_result.opportunities,
+        "risks": x_result.risks,
+        "next_steps": getattr(x_result, "next_steps", None) or [],
+    }
+    if full:
+        block["market_competition"] = getattr(x_result, "market_competition", None)
+        block["competitive_analysis"] = getattr(x_result, "competitive_analysis", None)
+    return block
+
+
+def z_reasoning(z_result: Any, detail: str) -> Dict[str, Any]:
+    """Z Guardian reasoning view (carries framework citations + scoring breakdown)."""
+    full = detail == "full"
+    block: Dict[str, Any] = {
+        "steps": _serialize_steps(z_result.reasoning_steps, full),
+        "scoring_breakdown": getattr(z_result, "scoring_breakdown", None),
+        "jurisdiction_detected": getattr(z_result, "jurisdiction_detected", None),
+        "applicable_frameworks": getattr(z_result, "applicable_frameworks", None),
+        "compliance_timeline": getattr(z_result, "compliance_timeline", None),
+        "ethical_concerns": z_result.ethical_concerns,
+        "mitigation_measures": z_result.mitigation_measures,
+    }
+    if full:
+        block["total_frameworks_evaluated"] = getattr(z_result, "total_frameworks_evaluated", None)
+    return block
+
+
+def cs_reasoning(cs_result: Any, detail: str) -> Dict[str, Any]:
+    """CS Security reasoning view (Socratic questions + threat assessment)."""
+    full = detail == "full"
+    block: Dict[str, Any] = {
+        "steps": _serialize_steps(cs_result.reasoning_steps, full),
+        "threat_level": getattr(cs_result, "threat_level", None),
+        "socratic_questions": cs_result.socratic_questions,
+        "attack_vectors": cs_result.attack_vectors,
+        "agentic_threats": getattr(cs_result, "agentic_threats", None),
+        "reasoning_layer_findings": getattr(cs_result, "reasoning_layer_findings", None),
+        "security_recommendations": cs_result.security_recommendations,
+    }
+    if full:
+        block["dimensions_evaluated"] = getattr(cs_result, "dimensions_evaluated", None)
+        block["stages_completed"] = getattr(cs_result, "stages_completed", None)
+        block["macp_security_assessment"] = getattr(cs_result, "macp_security_assessment", None)
+        block["standards_referenced"] = getattr(cs_result, "standards_referenced", None)
+    return block
+
+
+def build_reasoning_block(
+    x_result: Any,
+    z_result: Any,
+    cs_result: Any,
+    chain_status: Dict[str, str],
+    overall_quality: str,
+    inference_warning: Optional[str],
+    detail: str,
+) -> Dict[str, Any]:
+    """Build the additive `reasoning` block for run_full_trinity.
+
+    Caller must only invoke this for detail in ('standard', 'full'); 'summary'
+    callers skip the block entirely to preserve the exact legacy shape.
+    """
+    return {
+        "detail": detail,
+        "x": x_reasoning(x_result, detail),
+        "z": z_reasoning(z_result, detail),
+        "cs": cs_reasoning(cs_result, detail),
+        "inference": {
+            "x": chain_status.get("x_agent"),
+            "z": chain_status.get("z_agent"),
+            "cs": chain_status.get("cs_agent"),
+            "overall": overall_quality,
+            "warning": inference_warning,
+        },
+    }

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -279,4 +279,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.43"
+        assert http_server.SERVER_VERSION == "0.5.44"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.43", (
-            f"Expected 0.5.43, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.44", (
+            f"Expected 0.5.44, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.43"
+        assert SERVER_VERSION == "0.5.44"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.43"
+        assert SERVER_VERSION == "0.5.44"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.43", f"Expected 0.5.43, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.44", f"Expected 0.5.44, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -72,4 +72,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.43", f"Expected 0.5.43, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.44", f"Expected 0.5.44, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -214,4 +214,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.43", f"Expected 0.5.43, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.44", f"Expected 0.5.44, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -82,4 +82,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.43"
+        assert http_server.SERVER_VERSION == "0.5.44"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.43"
+        assert http_server.SERVER_VERSION == "0.5.44"

--- a/mcp-server/tests/unit/test_v0544_reasoning_visible.py
+++ b/mcp-server/tests/unit/test_v0544_reasoning_visible.py
@@ -1,0 +1,179 @@
+"""
+v0.5.44 "Reasoning Visible" — regression tests for the reasoning-exposure layer.
+
+Covers:
+- detail normalization (invalid → standard; case-insensitive)
+- consult_steps: legacy "step" key; evidence only at full
+- build_reasoning_block: structure, "n" step key, evidence/heavy fields only at full,
+  inference.warning passthrough
+- markdown report: inference_warning callout + ethics scoring breakdown render
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from verifimind_mcp.utils.reasoning_view import (
+    normalize_detail,
+    consult_steps,
+    build_reasoning_block,
+    DEFAULT_DETAIL,
+)
+
+
+# ---------- detail normalization ----------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("summary", "summary"),
+    ("standard", "standard"),
+    ("full", "full"),
+    ("FULL", "full"),
+    ("  Standard  ", "standard"),
+    ("bogus", "standard"),
+    ("", "standard"),
+    (None, "standard"),
+])
+def test_normalize_detail(raw, expected):
+    assert normalize_detail(raw) == expected
+
+
+def test_default_detail_is_standard():
+    assert DEFAULT_DETAIL == "standard"
+
+
+# ---------- consult_steps ----------
+
+def _steps():
+    return [
+        SimpleNamespace(step_number=1, thought="t1", evidence="e1", confidence=0.9),
+        SimpleNamespace(step_number=2, thought="t2", evidence=None, confidence=0.8),
+    ]
+
+
+def test_consult_steps_legacy_key_and_no_evidence_at_standard():
+    out = consult_steps(_steps(), "standard")
+    assert out[0] == {"step": 1, "thought": "t1", "confidence": 0.9}
+    assert "evidence" not in out[0]
+
+
+def test_consult_steps_evidence_only_at_full():
+    out = consult_steps(_steps(), "full")
+    assert out[0]["evidence"] == "e1"
+    # step 2 had no evidence → key omitted, not null
+    assert "evidence" not in out[1]
+
+
+# ---------- build_reasoning_block ----------
+
+def _x():
+    return SimpleNamespace(
+        reasoning_steps=_steps(), opportunities=["o1"], risks=["r1"],
+        next_steps=["n1"], market_competition={"m": 1}, competitive_analysis={"c": 1},
+    )
+
+
+def _z():
+    return SimpleNamespace(
+        reasoning_steps=_steps(), scoring_breakdown={"ethical_alignment": {"score": 8}},
+        jurisdiction_detected=["EU"], applicable_frameworks={"tier_1_international": ["UNESCO"]},
+        compliance_timeline=["EU Art50: Aug 2026"], ethical_concerns=["ec1"],
+        mitigation_measures=["m1"], total_frameworks_evaluated=5,
+    )
+
+
+def _cs():
+    return SimpleNamespace(
+        reasoning_steps=_steps(), threat_level="Medium Risk",
+        socratic_questions=["[Assumption Challenge]: q1"], attack_vectors=["av1"],
+        agentic_threats=["ASI01: x"], reasoning_layer_findings=["rl1"],
+        security_recommendations=["sr1"], dimensions_evaluated={"traditional": {}},
+        stages_completed=[{"stage": 1}], macp_security_assessment={"git_audit_trail": "N/A"},
+        standards_referenced=["OWASP"],
+    )
+
+
+def _chain():
+    return {"x_agent": "real", "z_agent": "real", "cs_agent": "real"}
+
+
+def test_reasoning_block_structure_and_step_key():
+    b = build_reasoning_block(_x(), _z(), _cs(), _chain(), "full", None, "standard")
+    assert set(b.keys()) == {"detail", "x", "z", "cs", "inference"}
+    # Trinity block uses "n" (not "step")
+    assert b["x"]["steps"][0]["n"] == 1
+    assert "step" not in b["x"]["steps"][0]
+
+
+def test_standard_omits_evidence_and_heavy_fields():
+    b = build_reasoning_block(_x(), _z(), _cs(), _chain(), "full", None, "standard")
+    assert "evidence" not in b["z"]["steps"][0]
+    # heavy/full-only fields absent at standard
+    assert "market_competition" not in b["x"]
+    assert "dimensions_evaluated" not in b["cs"]
+    assert "total_frameworks_evaluated" not in b["z"]
+    # but citations/breakdown present at standard (the differentiator)
+    assert b["z"]["scoring_breakdown"] == {"ethical_alignment": {"score": 8}}
+    assert b["z"]["jurisdiction_detected"] == ["EU"]
+    assert b["cs"]["socratic_questions"] == ["[Assumption Challenge]: q1"]
+    assert b["cs"]["threat_level"] == "Medium Risk"
+
+
+def test_full_adds_evidence_and_heavy_fields():
+    b = build_reasoning_block(_x(), _z(), _cs(), _chain(), "full", None, "full")
+    assert b["z"]["steps"][0]["evidence"] == "e1"
+    assert b["x"]["market_competition"] == {"m": 1}
+    assert b["cs"]["dimensions_evaluated"] == {"traditional": {}}
+    assert b["cs"]["macp_security_assessment"] == {"git_audit_trail": "N/A"}
+    assert b["z"]["total_frameworks_evaluated"] == 5
+
+
+def test_inference_block_passthrough():
+    b = build_reasoning_block(_x(), _z(), _cs(), _chain(), "degraded",
+                              "Ethics inference degraded — review required", "standard")
+    assert b["inference"]["x"] == "real"
+    assert b["inference"]["overall"] == "degraded"
+    assert b["inference"]["warning"] == "Ethics inference degraded — review required"
+
+
+# ---------- markdown report renders the new structured fields ----------
+
+def test_markdown_renders_inference_warning_and_breakdown():
+    from verifimind_mcp.models.reasoning import (
+        ReasoningStep, XAgentAnalysis, ZAgentAnalysis, CSAgentAnalysis,
+    )
+    from verifimind_mcp.models.results import TrinityResult, TrinitySynthesis
+    from verifimind_mcp.reporting.markdown_reporter import generate_markdown_report
+
+    steps = [ReasoningStep(step_number=1, thought="t", evidence="e", confidence=0.8)]
+    x = XAgentAnalysis(reasoning_steps=steps, innovation_score=7.0, strategic_value=7.0,
+                       opportunities=["o"], risks=["r"], recommendation="ok", confidence=0.8)
+    z = ZAgentAnalysis(reasoning_steps=steps, ethics_score=8.0, z_protocol_compliance=True,
+                       ethical_concerns=["ec"], mitigation_measures=["m"], recommendation="ok",
+                       veto_triggered=False, confidence=0.8,
+                       jurisdiction_detected=["EU", "US"],
+                       scoring_breakdown={"ethical_alignment": {"score": 8.0, "weight": 0.25, "frameworks": ["UNESCO-AI"]}})
+    cs = CSAgentAnalysis(reasoning_steps=steps, security_score=7.0, vulnerabilities=["v"],
+                         attack_vectors=["av"], security_recommendations=["sr"],
+                         socratic_questions=["[Assumption Challenge]: q"], recommendation="ok",
+                         confidence=0.8, threat_level="Medium Risk")
+    synthesis = TrinitySynthesis(
+        summary="s", innovation_score=7.0, ethics_score=8.0, security_score=7.0,
+        overall_score=4.0, strengths=["st"], concerns=["c"], recommendations=["rec"],
+        recommendation="revise", confidence=0.8,
+        inference_warning="Ethics (Z) inference quality was 'fallback' — human review required.",
+    )
+    result = TrinityResult(
+        validation_id="abc123", concept_name="C", concept_description="D",
+        x_analysis=x, z_analysis=z, cs_analysis=cs, synthesis=synthesis,
+        started_at=datetime.now(), completed_at=datetime.now(),
+    )
+    md = generate_markdown_report(result)
+    assert "DEGRADED INFERENCE" in md
+    assert "human review required" in md
+    assert "Ethics Scoring Breakdown" in md
+    assert "UNESCO-AI" in md
+    assert "Jurisdictions detected" in md
+    assert "Medium Risk" in md
+    # generator stamp is the live version, not the stale 0.4.1
+    assert "verifimind-peas/0.4.1" not in md

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Growth-first. v0.5.43",
-  "version": "3.20.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Auditable reasoning. v0.5.44",
+  "version": "3.21.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## Summary

Implements **P1-1** (foundation audit, Issue #68) — the single highest-leverage change for the epistemic-verification positioning. **Approved by T+L Session 41** (D-41-1/2/3: default `standard`, `full` stays free).

The X/Z/CS agents already generate per-step reasoning, framework citations, a 5-dimension ethics scoring breakdown, and Socratic questions on every call — and `run_full_trinity` was **trimming all of it** from the JSON response, returning only scores. A skeptic got a bare number indistinguishable from any rubric API. This serializes that layer into an additive `reasoning` block. **Zero new inference cost** — the tokens are already spent; this is serialization, not new generation.

## What changed

- **`detail` parameter on `run_full_trinity`** + a new top-level `reasoning` block:
  - `summary` → exact pre-v0.5.44 bytes (opt-out)
  - `standard` (**new default**) → reasoning steps + Z scoring breakdown/citations/jurisdictions + CS threat level/Socratic questions + per-agent inference quality (incl. `inference_warning`)
  - `full` → + per-step evidence + 12-dimension matrix + 6-stage record + MACP assessment + market competition
- **Strictly additive** — every existing response field is unchanged at every level; `summary` is byte-compatible with prior releases.
- **`consult_agent_x/z/cs`** gain the same ladder (they previously dropped per-step evidence + structured fields).
- **Markdown report** renders the ethics scoring breakdown, jurisdictions, CS threat level, and the degraded-inference warning; generator version sourced from the live constant (was stale `0.4.1`).
- **Discovery surfaces** (server-card, `/setup`) updated; corrected the `save_to_history` default text (was still "true").

## Tests
- New `test_v0544_reasoning_visible.py` (16 cases): detail normalization, consult-step legacy-key + evidence-only-at-full, reasoning-block structure/additivity, inference passthrough, markdown rendering.
- Full suite: **682 passed, 14 skipped.**
- Version `0.5.43 → 0.5.44` (2 constants + 9 pinned tests + server.json 3.21.0).

## Backward compatibility
Additive only — no existing key removed or renamed. `detail="summary"` reproduces the exact prior shape. Design doc: `.macp/design/20260611_RNA_P1-1_reasoning_exposure_design.md` (PRIVATE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)