### PR TITLE
chore(codeql): clear code-scanning hygiene alerts (quality, zero security)

### DIFF
--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -1742,7 +1742,6 @@ async def polar_webhook_handler(request):
     except Exception as e:
         # Signature verification failure or parse error
         # Return 400 so Polar retries; don't expose internal details
-        import logging
         logging.getLogger(__name__).warning("Polar webhook error: %s", type(e).__name__)
         return JSONResponse({"status": "error", "detail": "verification_failed"}, status_code=400)
 

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -215,15 +215,19 @@ def load_master_prompt() -> str:
     lines = [
         "# VerifiMind™ PEAS — Genesis Methodology (Live Production Prompts)",
         "",
-        f"*Server version: {SERVER_VERSION}. Generated from the in-code agent "
-        "configuration — this is the exact prompt contract the X / Z / CS agents run.*",
+        (
+            f"*Server version: {SERVER_VERSION}. Generated from the in-code agent "
+            "configuration — this is the exact prompt contract the X / Z / CS agents run.*"
+        ),
         "",
-        "The RefleXion Trinity validates a concept through three sequential agents. "
-        "Each agent sees the prior agents' Chain-of-Thought reasoning. Synthesis "
-        "weights: Innovation (X) 30% · Ethics (Z) 40% · Security (CS) 30%. A Z veto "
-        "caps the overall score at 3.0 and forces a REJECT verdict. If any agent's "
-        "inference is degraded, the recommendation is capped at REVISE pending human "
-        "review (fail-safe).",
+        (
+            "The RefleXion Trinity validates a concept through three sequential agents. "
+            "Each agent sees the prior agents' Chain-of-Thought reasoning. Synthesis "
+            "weights: Innovation (X) 30% · Ethics (Z) 40% · Security (CS) 30%. A Z veto "
+            "caps the overall score at 3.0 and forces a REJECT verdict. If any agent's "
+            "inference is degraded, the recommendation is capped at REVISE pending human "
+            "review (fail-safe)."
+        ),
         "",
         "---",
         "",

--- a/mcp-server/tests/unit/llm/test_providers.py
+++ b/mcp-server/tests/unit/llm/test_providers.py
@@ -20,7 +20,6 @@ from verifimind_mcp.llm.provider import (
     list_free_tier_providers,
     get_provider_info,
     MockProvider,
-    CerebrasProvider,
     PROVIDER_CONFIGS,
 )
 

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -262,7 +262,6 @@ class TestLoggerDefined:
 
     def test_http_server_has_module_logger(self):
         import http_server
-        import logging
         assert hasattr(http_server, "logger")
         assert isinstance(http_server.logger, logging.Logger)
 

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -8,13 +8,6 @@ Coverage:
   - Server version assertion
 """
 
-import inspect
-
-import verifimind_mcp.server as _srv_module
-
-_SERVER_SOURCE = inspect.getsource(_srv_module)
-
-
 class TestMcpConfigHeader:
 
     def _extras(self, uuid: str = "019d40d6-9e84-7738-9c0c-fa85b2930600"):

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -20,7 +20,6 @@ from verifimind_mcp.middleware.rate_limiter import (
     RateLimitStore,
     _resolve_uuid_tier,
     _uuid_tier_cache,
-    UUID_TIER_CACHE_TTL,
     _build_rate_limit_cta,
 )
 
@@ -152,7 +151,7 @@ class TestResolveUuidTier:
     def test_result_is_cached(self):
         test_uuid = "019aaaaa-0000-7000-0000-000000000001"
         _uuid_tier_cache.pop(test_uuid, None)
-        tier1 = _resolve_uuid_tier(test_uuid)
+        _resolve_uuid_tier(test_uuid)  # first resolve — result intentionally unused; populates cache
         # Inject fake cache entry to prove it's used
         _uuid_tier_cache[test_uuid] = ("pioneer", time.time() + 9999)
         tier2 = _resolve_uuid_tier(test_uuid)

--- a/mcp-server/tests/unit/test_v0522_ip_blocklist.py
+++ b/mcp-server/tests/unit/test_v0522_ip_blocklist.py
@@ -18,10 +18,8 @@ from verifimind_mcp.middleware.ip_blocklist import (
     IPBlocklistMiddleware,
     BLOCKED_IPS,
     BLOCKED_UA_PATTERNS,
-    _BLOCKED_IP_SET,
     _check_ip,
     _check_ua,
-    _get_all_ips,
 )
 
 

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -10,9 +10,7 @@ Coverage:
   - Server version is 0.5.25
 """
 
-import os
 import importlib
-import pytest
 
 
 def _reload_http_server():


### PR DESCRIPTION
Clears the open code-scanning alerts. **All 14 are code-quality CodeQL notes — none carry a security-severity level** (maintainability, not vulnerabilities). Resolving them keeps our own Security tab clean, which matters for a verification/security product.

## Fixed (11)
- **#174** (the only `warning`): wrapped intentional multi-line strings in the `master_prompt` resource list in explicit parens so they can't be misread as a missing-comma bug.
- **#168**: removed redundant local `import logging` in the http_server Polar handler (module-level import exists).
- **#172 #173 #171 #167 #166 #169**: removed verified-unused test imports.
- **#165**: dropped an unused assignment (kept the cache-populating call).
- **#163 #164**: removed an unused `_SERVER_SOURCE` + its module-import — also clears the dual-import note.

## Dismissed as won't-fix (3)
- **#160 #130**: intentional dual-import patterns in tests (module reference for `inspect.getsource` / fresh-store reset + symbol import).
- **#125**: managed cyclic import in `z_agent.py`, broken at runtime by lazy imports in `AgentRegistry`.

No behavior change, no version bump. **682 tests passing.** CodeQL re-scans `main` on merge and auto-closes the fixed alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)