### PR TITLE
chore(v0.5.45): SERVER_STATUS — Probe Blocklist (rev 00454-kqz)

### DIFF
--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** June 12, 2026
+**Last Updated:** June 16, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.44 "Reasoning Visible" — deployed June 12, 2026**
+**v0.5.45 "Probe Blocklist" — deployed June 16, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Probe Blocklist (v0.5.45)**: blocked an MCP-endpoint scanner family polluting engagement metrics — AgentSure-MCPScan (9 IPs; primary `152.55.176.35` logged ~11h of cron-driven fake "engagement"), LeakIX l9scan (2 IPs), and a self-declared `MCP-Inspector (security-scan)` IP (`14.194.11.238`, orchestrator-flagged, Sentinel-confirmed: 330-req/100s dictionary sweep, zero 200, zero leak). `BLOCKED_IPS` 10 → 22; UA-substring blocks added for `AgentSure-MCPScan` / `l9scan` / `(security-scan)` (rotation-proof, live-verified 403). Honest-metrics gate held — AY held Report 097 until this deploy. AY+AZ forensics 2026-06-12 + Sentinel 2026-06-16 — June 16, 2026
 - **Reasoning Visible (v0.5.44)**: the auditable reasoning layer is now returned by default. `run_full_trinity` gains a `detail` parameter — `standard` (default) returns a `reasoning` block (per-agent reasoning steps, Z's 5-dimension ethics scoring breakdown + framework citations + jurisdictions, CS threat level + Socratic questions, per-agent inference quality incl. `inference_warning`); `full` adds per-step evidence + the 12-dimension/6-stage/MACP detail; `summary` reproduces the exact prior response shape (opt-out). Strictly additive — no existing field changed. `consult_agent_x/z/cs` gain the same ladder; markdown report renders the breakdown + jurisdictions + threat level + degraded-inference warning. Zero new inference cost (serialization only). T+L Session 41 approved (default `standard`, `full` free). 16 new tests — June 12, 2026
 - **Foundation Integrity (v0.5.43)**: three integrity fixes from the Issue #68 foundation audit — (1) ethics-veto fail-safe: degraded Z inference (`partial`/`fallback`) now caps the recommendation at REVISE + emits `inference_warning` instead of allowing a clean pass on synthesized defaults; (2) validation-history privacy: `save_to_history` defaults off and `genesis://history/*` resources return non-identifying aggregates only (no cross-instance concept-text exposure); (3) `genesis://config/master_prompt` now generated from live agent config (was serving a stale prompt collection). Plus current-date injection into agent prompts and `project_info` version currency. 10 new regression tests — June 11, 2026
 - **Server-Card Description Refresh (v0.5.42)**: `/.well-known/mcp/server-card.json` refreshed — stale "Genesis v4.2" copy → current descriptors (13 free tools, BYOK 6 providers); docstring de-Smithery'd (listing sunset 2026-03-01); pre-submission accuracy pass — June 9, 2026
@@ -46,7 +47,7 @@ The VerifiMind MCP server is fully operational. All security gates passed. (Per-
 - **CS Agent v1.1**: 6-stage, 12-dimension, OWASP Agentic AI Top 10
 - Input sanitization active (20+ secret patterns)
 - Rate limiting and EDoS protection active
-- GCP Cloud Run revision: `verifimind-mcp-server-00451-f95`
+- GCP Cloud Run revision: `verifimind-mcp-server-00454-kqz`
 - CI/CD pipeline passing — 682 tests passing (696 collected, 14 skipped), 0 CodeQL medium+ alerts
 
 ---


### PR DESCRIPTION
SERVER_STATUS for v0.5.45 (deployed, rev `verifimind-mcp-server-00454-kqz`, /health green). Live-verified: AgentSure-MCPScan / MCP-Inspector(security-scan) / l9scan UAs all return 403; normal UA 200. 684 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)