### PR TITLE
fix(byok): robustness bundle (Step 1) — evidence-coercion, max_tokens, token-monitor, provider/model shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.46 - BYOK Robustness (June 19, 2026)
+
+Production-hardening bundle surfaced by dogfooding our own M2 P3 evaluation — every fix serves real BYOK users *and* unblocked the clean 100/100 critique-quality baseline run. Strictly additive: no behavior change on the default free-tier path. 698 tests pass (690 + 8 new), 0 regressions.
+
+### What changed
+- **Provider-format normalization** — `config_helper.py` now accepts `provider/model` shorthand (e.g. `anthropic/claude-opus-4-8`), splitting it server-side, honoring the model, and returning an actionable error on a bad provider. Fixes the June-17 production rejection of valid `provider/model` BYOK configs.
+- **max_tokens** — Z/CS agents raised 4096 → 8192 (`concepts.py`); Groq clamped per-provider via new `_effective_max_tokens()` (`base_agent.py`). The 4096 ceiling was truncating verbose models mid-JSON.
+- **Token-monitor repair** — `_output_tokens` is now populated on agent results (`base_agent.py`); the Z-ceiling monitor had silently read 0 since v0.5.3, leaving us blind to truncation.
+- **Evidence-coercion** — structured `evidence`/`thought` (dict/list) returned by some providers (e.g. mistral-small) is coerced to a JSON string in `ReasoningStep`, fixing schema-conformance failures in multi-provider runs.
+
+### Why
+The M2 P3 evaluation exercised non-default BYOK providers for the first time, surfacing latent gaps that never bit the working default (Gemini X + Groq Z/CS) path. Fixing them ships value to BYOK users (a minority we couldn't previously see, because the monitor was dark) and produced the clean baseline measurement. T+L Session 46 D-46-1/D-46-2 concurred; deploy ratified S47 D-47-1 + Alton.
+
+**PR:** #262
+
+---
+
 ## v0.5.45 - Probe Blocklist (MCP-scanner family) (June 16, 2026)
 
 Security/metrics-integrity patch: blocks an MCP-endpoint scanner family that was polluting engagement metrics, plus a self-declared MCP scanner flagged by the orchestrator. `BLOCKED_IPS` 10 → 22; `BLOCKED_UA_PATTERNS` adds three rotation-proof substrings.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** June 16, 2026
+**Last Updated:** June 19, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.45 "Probe Blocklist" — deployed June 16, 2026**
+**v0.5.46 "BYOK Robustness" — deployed June 19, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **BYOK Robustness (v0.5.46)**: production-hardening bundle surfaced by dogfooding the M2 P3 evaluation — `provider/model` shorthand now accepted server-side (fixes June-17 prod rejection of valid BYOK configs), Z/CS `max_tokens` raised 4096 → 8192 (Groq clamped per-provider) to stop verbose-model truncation, the Z token-monitor repaired (silently read 0 since v0.5.3), and structured provider evidence coerced to string for schema conformance. Strictly additive — no change to the default free-tier path. 698 tests pass. T+L S46 D-46-1/2 + S47 D-47-1 + Alton — June 19, 2026
 - **Probe Blocklist (v0.5.45)**: blocked an MCP-endpoint scanner family polluting engagement metrics — AgentSure-MCPScan (9 IPs; primary `152.55.176.35` logged ~11h of cron-driven fake "engagement"), LeakIX l9scan (2 IPs), and a self-declared `MCP-Inspector (security-scan)` IP (`14.194.11.238`, orchestrator-flagged, Sentinel-confirmed: 330-req/100s dictionary sweep, zero 200, zero leak). `BLOCKED_IPS` 10 → 22; UA-substring blocks added for `AgentSure-MCPScan` / `l9scan` / `(security-scan)` (rotation-proof, live-verified 403). Honest-metrics gate held — AY held Report 097 until this deploy. AY+AZ forensics 2026-06-12 + Sentinel 2026-06-16 — June 16, 2026
 - **Reasoning Visible (v0.5.44)**: the auditable reasoning layer is now returned by default. `run_full_trinity` gains a `detail` parameter — `standard` (default) returns a `reasoning` block (per-agent reasoning steps, Z's 5-dimension ethics scoring breakdown + framework citations + jurisdictions, CS threat level + Socratic questions, per-agent inference quality incl. `inference_warning`); `full` adds per-step evidence + the 12-dimension/6-stage/MACP detail; `summary` reproduces the exact prior response shape (opt-out). Strictly additive — no existing field changed. `consult_agent_x/z/cs` gain the same ladder; markdown report renders the breakdown + jurisdictions + threat level + degraded-inference warning. Zero new inference cost (serialization only). T+L Session 41 approved (default `standard`, `full` free). 16 new tests — June 12, 2026
 - **Foundation Integrity (v0.5.43)**: three integrity fixes from the Issue #68 foundation audit — (1) ethics-veto fail-safe: degraded Z inference (`partial`/`fallback`) now caps the recommendation at REVISE + emits `inference_warning` instead of allowing a clean pass on synthesized defaults; (2) validation-history privacy: `save_to_history` defaults off and `genesis://history/*` resources return non-identifying aggregates only (no cross-instance concept-text exposure); (3) `genesis://config/master_prompt` now generated from live agent config (was serving a stale prompt collection). Plus current-date injection into agent prompts and `project_info` version currency. 10 new regression tests — June 11, 2026

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.45"
+SERVER_VERSION = "0.5.46"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/agents/base_agent.py
+++ b/mcp-server/src/verifimind_mcp/agents/base_agent.py
@@ -28,6 +28,13 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Groq free-tier carries a tighter total-request budget (~12K tokens input+output)
+# than large-context providers. Agent configs request 8192 output tokens so verbose
+# models (Claude, GPT) don't truncate mid-JSON; for Groq we clamp output back to a
+# safe ceiling so the full request stays under the budget. Large-context providers
+# (Anthropic, OpenAI, Gemini, Mistral, Cerebras) use the configured value unchanged.
+GROQ_SAFE_MAX_OUTPUT_TOKENS = 4096
+
 
 class BaseAgent(ABC):
     """
@@ -104,7 +111,21 @@ class BaseAgent(ABC):
         )
 
         return date_header + prompt
-    
+
+    def _effective_max_tokens(self) -> int:
+        """
+        Resolve the output-token budget for the active provider.
+
+        Configs request 8192 so verbose models don't truncate; Groq's tighter
+        total-request budget is honored by clamping to a safe ceiling. Detected
+        by provider class name to avoid importing every provider type here.
+        """
+        configured = self.config.max_tokens
+        provider_name = type(self.llm).__name__.lower()
+        if "groq" in provider_name:
+            return min(configured, GROQ_SAFE_MAX_OUTPUT_TOKENS)
+        return configured
+
     async def analyze(
         self,
         concept: Concept,
@@ -144,7 +165,7 @@ class BaseAgent(ABC):
                 prompt=prompt,
                 output_schema=output_schema,
                 temperature=self.config.temperature,
-                max_tokens=self.config.max_tokens
+                max_tokens=self._effective_max_tokens()
             )
             
             # Extract content, usage, and inference quality from response
@@ -163,6 +184,12 @@ class BaseAgent(ABC):
 
             # v0.4.3.1 C-S-P State: attach inference quality marker to result
             result._inference_quality = inference_quality
+
+            # v0.5.46 (P2-2 repair): expose API-reported output tokens on the result so
+            # the Z-Agent token-ceiling monitor (server.py) reads a real count. Previously
+            # `_output_tokens` was never populated → the monitor always saw 0 and never
+            # fired, masking truncation since v0.5.3.
+            result._output_tokens = usage.get("output_tokens", 0) if usage else 0
 
             # Update metrics if provided
             if metrics:

--- a/mcp-server/src/verifimind_mcp/config_helper.py
+++ b/mcp-server/src/verifimind_mcp/config_helper.py
@@ -97,6 +97,17 @@ def create_ephemeral_provider(
     if not llm_provider and not api_key:
         return None
 
+    # D-AZ-0618-1: accept the "provider/model" shorthand (e.g. "anthropic/claude-opus-4-8").
+    # Real users pass the combined slug they see in model docs; a June-17 prod request
+    # (anthropic/claude-opus-4-8) was rejected as "Invalid provider" because we only
+    # accepted a bare provider. Split it server-side so a valid provider is honored, and
+    # carry the model part through to the constructor.
+    byok_model = None
+    if llm_provider and "/" in llm_provider:
+        provider_part, _, model_part = llm_provider.partition("/")
+        llm_provider = provider_part.strip()
+        byok_model = model_part.strip() or None
+
     from .llm import (
         MockProvider,
         OpenAIProvider,
@@ -133,7 +144,10 @@ def create_ephemeral_provider(
     if llm_provider not in VALID_BYOK_PROVIDERS:
         raise ValueError(
             f"Invalid provider '{llm_provider}'. "
-            f"Supported: {', '.join(sorted(VALID_BYOK_PROVIDERS))}"
+            f"Supported: {', '.join(sorted(VALID_BYOK_PROVIDERS))}. "
+            f"To target a specific model, pass the provider and model separately "
+            f"(llm_provider='anthropic', model='claude-opus-4-8') or use the "
+            f"'provider/model' shorthand (e.g. 'anthropic/claude-opus-4-8')."
         )
 
     provider_map = {
@@ -150,9 +164,13 @@ def create_ephemeral_provider(
     provider_class = provider_map[llm_provider]
 
     if llm_provider in ("mock", "ollama"):
+        if byok_model and llm_provider == "ollama":
+            return provider_class(model=byok_model)
         return provider_class()
 
     # Keys are NEVER logged
+    if byok_model:
+        return provider_class(model=byok_model, api_key=api_key)
     return provider_class(api_key=api_key)
 
 

--- a/mcp-server/src/verifimind_mcp/models/concepts.py
+++ b/mcp-server/src/verifimind_mcp/models/concepts.py
@@ -323,8 +323,11 @@ CRITICAL RULES:
 - NEVER cite a framework you did not actually evaluate in your reasoning
 """,
     temperature=0.7,
-    max_tokens=4096  # Reduced from 8192: Z receives compressed X prior (~300 tokens);
-                     # total request (input ~5,000 + output 4,096) stays under Groq 12K limit
+    max_tokens=8192  # v0.5.46: restored to 8192. 4096 truncated verbose models (a live
+                     # Anthropic Z run lost ~45 responses mid-JSON). Groq's tighter total-
+                     # request budget is enforced per-provider by _effective_max_tokens()
+                     # in base_agent (clamps Groq to a safe ceiling; large-context
+                     # providers use the full 8192).
 )
 
 CS_AGENT_CONFIG = AgentConfig(
@@ -510,8 +513,9 @@ CRITICAL RULES:
 - reasoning_layer_findings: assess tool poisoning/shadowing risk even from concept description alone
 """,
     temperature=0.7,
-    max_tokens=4096  # Reduced from 8192: CS receives compressed X+Z prior (~1,600 tokens)
-                     # keeping total request (prior + prompt + output) safely under Groq 12K limit
+    max_tokens=8192  # v0.5.46: restored to 8192 (see Z_AGENT_CONFIG note). 4096 truncated
+                     # verbose models; Groq's total-request budget is enforced per-provider
+                     # by _effective_max_tokens() in base_agent.
 )
 
 # Agent configuration lookup

--- a/mcp-server/src/verifimind_mcp/models/reasoning.py
+++ b/mcp-server/src/verifimind_mcp/models/reasoning.py
@@ -6,9 +6,10 @@ enabling agents to share their thought processes with each other
 and with humans for full auditability.
 """
 
+import json
 from datetime import datetime
 from typing import Optional, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ReasoningStep(BaseModel):
@@ -27,7 +28,27 @@ class ReasoningStep(BaseModel):
         le=1.0,
         description="Confidence in this reasoning step (0.0 to 1.0)"
     )
-    
+
+    @field_validator("thought", "evidence", mode="before")
+    @classmethod
+    def _coerce_text_fields(cls, v):
+        """Coerce structured (dict/list) values to a string (v0.5.46 BYOK robustness).
+
+        Some BYOK providers (e.g. mistral-small) return per-step `evidence` (or
+        `thought`) as a nested object — e.g. {"prove": ..., "disprove": ...} — instead
+        of a string. Rather than fail Pydantic validation (which crashes the whole
+        agent for that caller), serialize the structure to a JSON string so the
+        reasoning is preserved and validation succeeds. Strings/None pass through.
+        """
+        if v is None or isinstance(v, str):
+            return v
+        if isinstance(v, (dict, list)):
+            try:
+                return json.dumps(v, ensure_ascii=False)
+            except Exception:
+                return str(v)
+        return str(v)
+
     class Config:
         json_schema_extra = {
             "example": {

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.45"
+SERVER_VERSION = "0.5.46"
 
 # Agent role names + master prompt filename — single source of truth.
 # (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -278,4 +278,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.45"
+        assert http_server.SERVER_VERSION == "0.5.46"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,8 +67,8 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.45", (
-            f"Expected 0.5.45, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.46", (
+            f"Expected 0.5.46, got {SERVER_VERSION}"
         )
 
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.45"
+        assert SERVER_VERSION == "0.5.46"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.45"
+        assert SERVER_VERSION == "0.5.46"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.45", f"Expected 0.5.45, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.46", f"Expected 0.5.46, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -65,4 +65,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.45", f"Expected 0.5.45, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.46", f"Expected 0.5.46, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -213,4 +213,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.45", f"Expected 0.5.45, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.46", f"Expected 0.5.46, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -80,4 +80,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.45"
+        assert http_server.SERVER_VERSION == "0.5.46"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.45"
+        assert http_server.SERVER_VERSION == "0.5.46"

--- a/mcp-server/tests/unit/test_v0546_evidence_coercion.py
+++ b/mcp-server/tests/unit/test_v0546_evidence_coercion.py
@@ -1,0 +1,63 @@
+"""
+v0.5.46 — BYOK evidence/thought coercion (provider output-format robustness).
+
+Reproduces the M2 P3 failure: mistral-small returned CS per-step `evidence` as a
+nested dict, crashing CSAgentAnalysis validation. The ReasoningStep `before` validator
+now coerces dict/list → JSON string so any BYOK provider's structured reasoning is
+preserved instead of failing validation.
+"""
+
+import json
+
+import pytest
+
+from verifimind_mcp.models.reasoning import ReasoningStep, CSAgentAnalysis
+
+
+def test_dict_evidence_coerced_to_json_string():
+    step = ReasoningStep(step_number=1, thought="t", evidence={"prove": "a", "disprove": "b"}, confidence=0.9)
+    assert isinstance(step.evidence, str)
+    assert json.loads(step.evidence) == {"prove": "a", "disprove": "b"}
+
+
+def test_list_evidence_coerced():
+    step = ReasoningStep(step_number=1, thought="t", evidence=["x", "y"], confidence=0.8)
+    assert isinstance(step.evidence, str)
+    assert json.loads(step.evidence) == ["x", "y"]
+
+
+def test_string_evidence_unchanged():
+    step = ReasoningStep(step_number=1, thought="t", evidence="plain string", confidence=0.8)
+    assert step.evidence == "plain string"
+
+
+def test_none_evidence_stays_none():
+    step = ReasoningStep(step_number=1, thought="t", evidence=None, confidence=0.8)
+    assert step.evidence is None
+
+
+def test_dict_thought_coerced():
+    step = ReasoningStep(step_number=1, thought={"FOR": ["a"], "AGAINST": ["b"]}, confidence=0.8)
+    assert isinstance(step.thought, str)
+    assert json.loads(step.thought) == {"FOR": ["a"], "AGAINST": ["b"]}
+
+
+def test_cs_agent_analysis_with_dict_evidence_validates():
+    """The exact M2 P3 repro: a CS reasoning step with dict evidence must now validate."""
+    cs = CSAgentAnalysis(
+        reasoning_steps=[
+            ReasoningStep(step_number=1, thought="stage 1", evidence="ok", confidence=0.9),
+            ReasoningStep(step_number=2, thought="stage 2",
+                          evidence={"disprove": "false-positive scenario", "prove": "exploit scenario"},
+                          confidence=0.85),
+        ],
+        security_score=7.0,
+        vulnerabilities=["v1"],
+        attack_vectors=["av1"],
+        security_recommendations=["sr1"],
+        socratic_questions=["[Assumption Challenge]: q1", "[Boundary Probe]: q2"],
+        recommendation="proceed after hardening",
+        confidence=0.85,
+    )
+    assert isinstance(cs.reasoning_steps[1].evidence, str)
+    assert "disprove" in cs.reasoning_steps[1].evidence

--- a/mcp-server/tests/unit/test_v0546_robustness_bundle.py
+++ b/mcp-server/tests/unit/test_v0546_robustness_bundle.py
@@ -1,0 +1,86 @@
+"""
+v0.5.46 — BYOK robustness bundle (Step 1 of the M2 unified path).
+
+Covers three production-hardening fixes surfaced by GCP logs + M2 P3 runs:
+
+1. Provider-format normalization (D-AZ-0618-1): a June-17 prod user passed
+   `anthropic/claude-opus-4-8` and was rejected as "Invalid provider". We now
+   accept the `provider/model` shorthand, split it server-side, honor the model,
+   and give an actionable error otherwise.
+2. Per-provider max_tokens clamp: configs request 8192 (verbose models like
+   Claude truncated at 4096); Groq's tighter total-request budget is clamped
+   back to a safe ceiling.
+3. Token-monitor repair (P2-2): `_output_tokens` is now populated on agent
+   results so the Z-Agent token-ceiling monitor reads a real count instead of 0.
+"""
+
+import pytest
+
+from verifimind_mcp.config_helper import create_ephemeral_provider
+from verifimind_mcp.agents.base_agent import GROQ_SAFE_MAX_OUTPUT_TOKENS
+from verifimind_mcp.agents import XAgent
+from verifimind_mcp.llm import MockProvider, GroqProvider, AnthropicProvider
+
+
+# --- 1. Provider-format normalization (D-AZ-0618-1) -------------------------
+
+def test_provider_model_shorthand_splits_and_honors_model():
+    """`anthropic/claude-opus-4-8` resolves to AnthropicProvider with that model."""
+    p = create_ephemeral_provider(llm_provider="anthropic/claude-opus-4-8", api_key="sk-ant-test")
+    assert isinstance(p, AnthropicProvider)
+    # the model part is honored on the provider; get_model_name() renders provider/model
+    assert p.model == "claude-opus-4-8"
+    assert p.get_model_name() == "anthropic/claude-opus-4-8"
+
+
+def test_bare_provider_still_works():
+    p = create_ephemeral_provider(llm_provider="mock")
+    assert isinstance(p, MockProvider)
+
+
+def test_invalid_provider_raises_actionable_error():
+    with pytest.raises(ValueError) as exc:
+        create_ephemeral_provider(llm_provider="claude-opus-4-8", api_key="sk-ant-test")
+    msg = str(exc.value)
+    assert "Invalid provider" in msg
+    # actionable guidance: tell the user how to pass a model
+    assert "provider/model" in msg or "separately" in msg
+
+
+def test_shorthand_without_model_part_is_bare_provider():
+    """Trailing slash / empty model part falls back to provider default model."""
+    p = create_ephemeral_provider(llm_provider="anthropic/", api_key="sk-ant-test")
+    assert isinstance(p, AnthropicProvider)
+
+
+# --- 2. Per-provider max_tokens clamp ---------------------------------------
+
+def test_large_context_provider_uses_full_config():
+    """X config requests 8192; a non-Groq provider keeps it."""
+    agent = XAgent(llm_provider=MockProvider())
+    assert agent.config.max_tokens == 8192
+    assert agent._effective_max_tokens() == 8192
+
+
+def test_groq_provider_clamped_to_safe_ceiling():
+    agent = XAgent(llm_provider=GroqProvider(api_key="gsk_test"))
+    assert agent._effective_max_tokens() == GROQ_SAFE_MAX_OUTPUT_TOKENS
+    assert agent._effective_max_tokens() <= agent.config.max_tokens
+
+
+# --- 3. Token-monitor repair (P2-2) -----------------------------------------
+
+def test_output_tokens_default_zero_is_safe():
+    """server.py reads getattr(result, '_output_tokens', 0); the monitor handles 0."""
+    from verifimind_mcp.utils.token_monitor import check_z_agent_response
+    m = check_z_agent_response(0)
+    assert m["token_count"] == 0
+    assert m["risk_level"] == "LOW"
+    assert m["truncated"] is False
+
+
+def test_monitor_flags_truncation_at_ceiling():
+    from verifimind_mcp.utils.token_monitor import check_z_agent_response
+    m = check_z_agent_response(8192)
+    assert m["risk_level"] == "CRITICAL"
+    assert m["truncated"] is True

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Auditable reasoning. v0.5.45",
-  "version": "3.22.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Auditable reasoning. v0.5.46",
+  "version": "3.23.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## BYOK Robustness Bundle — Step 1 of the unified path to the M2 value proof

Four production-hardening fixes surfaced by dogfooding our own M2 P3 eval. **698 tests pass (690 + 8 new), 0 regressions.** Strictly additive — no behavior change on the working default free-tier path.

### Fixes
1. **Provider-format normalization (D-AZ-0618-1)** — `config_helper.py` accepts `provider/model` shorthand (splits server-side, honors model, actionable error). Fixes the **June-17 live prod rejection** of `anthropic/claude-opus-4-8`.
2. **max_tokens** — Z/CS raised 4096→8192 (`concepts.py`); Groq clamped per-provider via `_effective_max_tokens()` (`base_agent.py`). 4096 truncated verbose models.
3. **Token-monitor repair (P2-2)** — `_output_tokens` now populated on results (`base_agent.py`); the Z-ceiling monitor had read 0 since v0.5.3 (we were blind to truncation).
4. **Evidence-coercion** (`6e78f3f`) — dict/list → JSON string in `ReasoningStep` (M2 P3 BYOK-Mistral finding).

### Provenance
- T+L Session 46: **D-46-1 / D-46-2 CONCURRED** (robustness bundle as Step 1; provider/model shorthand included).
- Proven in the live eval path: clean **100/100 M2 P3 baseline** ran on this bundle (0 errors / 0 truncation).

### ⚠️ Version + deploy decision PENDING FLYWHEEL TEAM coordination
This PR is **code-only — no version bump yet.** Per Alton, the version number is a team-alignment decision (see PRIVATE cto-alignment issue). RNA recommendation: ship as **v0.5.46 "BYOK Robustness"**, renumber the model-currency feature bundle to **v0.5.47**. Version surfaces (2 constants + test files + server.json) + `/verifimind-deploy` will be applied on T+L concurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
