### PR TITLE
v0.5.48: Scanner Cluster Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Full version history also available at [verifimind.ysenseai.org/changelog](https
 
 ---
 
+## v0.5.48 - Scanner Cluster Block (June 28, 2026)
+
+Security-hygiene batch: three config/secret/RCE scanners blocked at the application layer (`BLOCKED_IPS` 23 → 26), one rotation-proof UA block added, two crawler UAs flagged for monitoring. Zero sensitive-path 200s confirmed across all three IPs. AY+AZ flagged the cluster in Report 099 / `.macp/handoffs/20260628_AY_AZ_to_RNA_probe_blocklist_tlm_config_scanners.md`; Sentinel independently re-verified against live GCP logs (30-day window) before recommending action. No functional change; 613 unit tests pass (3 skipped), full suite gated in CI.
+
+### What changed
+- **Probe #24 — `45.148.10.62` (CONFIG_SECRET_SCANNER):** weekly cron scanner (four rounds Jun 5/10/17/27 ~16:00 UTC, ~30 req/session, rotating browser UAs). Probed `.git/config`, `.env` tree (18+ variants), `wp-config.php`, `phpinfo.php`, `aws.config.js`. 80×404 (67%), 36×429 (30%), 4×200 on root `/` only — zero leak. Same `45.148.10.0/24` as probe #23 (`45.148.10.15`, blocked 2026-06-18).
+- **Probe #25 — `45.148.10.67` (CONFIG_SECRET_SCANNER, `TLM-Audit-Scanner/1.0`):** extreme-velocity single burst 2026-06-27 02:43:36–53 UTC (~59 req/s, 17 s, 1,000+ req). Self-identifying UA static on 100% of requests. Multi-technology credential dictionary: Stripe (`stripe-credentials.json`, `stripe-keys.json`, `stripe.env`), Terraform (`.tfvars`, `.tfstate(.backup)`), AWS Lambda (`var/task/amplify.yml`, `docker-compose.yml`, `serverless.yaml`, `next.config.*`), WordPress (`wp-config.php*`, `wp-json/gravitysmtp`, `wp-content/mysql.sql`), `.env` tree (v1/v2/v3/staging/src/srv/shop), Webmin CGI. 635×302 (HTTP→HTTPS), 364×429 (36%), 4×200 (`/`, `/register`, `/?phpinfo=1`, `/?pp=env` — all public-safe). Zero sensitive 200s. Same /24 as #23/#24.
+- **Probe #26 — `93.123.109.103` (CONFIG_RCE_SCANNER, new class):** single 6-minute burst 2026-06-24 04:41–47 UTC, 180 req @ ~0.5 req/s. Primary UA Firefox/47.0 (2016-era, static); secondary Chrome/Win10 + empty UA at overlapping timestamps (proxy cluster / multi-tool). Dictionary includes `.aws/credentials` (highest-value target), `swagger.json`, `backend/config/default.yml`, `storage/logs/laravel.log`, `apis/controllers/users.js`, `admin/controllers/merchant.js`. **Escalation:** embedded Node.js `child_process.execSync` RCE probe in a query param (`?param=test?cmd=<base64: echo VULN_TEST>`) targeting JS injection (SSTI/eval). Server is Python/FastAPI — probe returned root-page HTML, zero execution, zero leak. 108×404 (60%), 64×429 (36%), 5×200 (root + ignored query params), 3×302. New signature class `CONFIG_RCE_SCANNER`.
+- **UA block — `TLM-Audit-Scanner`:** substring added to `BLOCKED_UA_PATTERNS`; rotation-proof coverage for probe #25 and any successor IPs in the /24.
+- **Crawler UAs `agent-tools.cloud-crawler/0.1` + `mcp-rugpull-research/1.0`:** MONITOR only — originate via Cloudflare edge `172.68.23.137`, 57 live hits all 307/redirect, no config/credential probing. No UA block at this volume; re-evaluate if >20/7d or behavior shifts to credential paths.
+
+### /24 watch-item
+Three IPs now blocked in `45.148.10.0/24` (#23 + #24 + #25) within 10 days — likely a coordinated campaign or shared rented scan infra. Per Alton 2026-06-28: **remarked as a watch-item, no CIDR `/24` block now** — revisit the CIDR decision (route to T) only if a **4th** IP from this /24 appears within ~30 days.
+
+### Why
+All three scanners were already fully deflected by existing defense layers (zero sensitive-path 200s), but L1 IP blocks convert their residual handler-reach to instant 403s at zero processing cost and eliminate recurring log noise. The RCE-probe dimension on `93.123.109.103` raises urgency above hygiene-only. No engagement-metric impact (scanner hits already scrubbed from Report 099). AY+AZ forensics + Sentinel verification 2026-06-28; Alton-approved.
+
+**PR:** _pending_
+
+---
+
 ## v0.5.47 - Model Currency (June 23, 2026)
 
 Keeps the BYOK frontier-model menu current and migrates the Gemini integration to the supported SDK. All model IDs were live-verified against each provider before listing (no aspirational names). The default free-tier path (Gemini 2.5 Flash + Groq) is unchanged — cost and stability preserved. 699 tests pass; pre-deploy live Trinity smoke green on both the default and a frontier BYOK config.

--- a/SERVER_STATUS.md
+++ b/SERVER_STATUS.md
@@ -1,16 +1,17 @@
 # VerifiMind-PEAS Server Status
 
-**Last Updated:** June 23, 2026
+**Last Updated:** June 28, 2026
 
 ---
 
 ## Current Status: Operational
 
-**v0.5.47 "Model Currency" — deployed June 23, 2026**
+**v0.5.48 "Scanner Cluster Block" — deployed June 28, 2026**
 
 The VerifiMind MCP server is fully operational. All security gates passed. (Per-version public detail now lives in [GitHub Releases](https://github.com/creator35lwb-web/VerifiMind-PEAS/releases) since the `/changelog` redirect in v0.5.36.)
 
 - 13 MCP tools (4 core Trinity + 6 template management + 3 coordination) — **all free for everyone**
+- **Scanner Cluster Block (v0.5.48)**: blocked a coordinated config/secret/RCE scanner cluster — `45.148.10.62` + `45.148.10.67` (CONFIG_SECRET_SCANNER, same `45.148.10.0/24` as probe #23) and `93.123.109.103` (CONFIG_RCE_SCANNER, new class — carried a Node.js `child_process.execSync` RCE probe our Python/FastAPI ignored: zero execution/leak). `TLM-Audit-Scanner` UA-substring block added (rotation-proof). `BLOCKED_IPS` 23 → 26. Zero sensitive-path 200s on all three (Sentinel re-verified live GCP, 30d). `/24` remarked as a watch-item — revisit CIDR only on a 4th IP (Alton 2026-06-28). 613 unit tests; AY+AZ Report 099 + Sentinel forensics — June 28, 2026
 - **Model Currency (v0.5.47)**: BYOK frontier menu refreshed + Gemini SDK migration. `GeminiProvider` moved to the supported `google-genai` SDK (enables Gemini 3.x); `gemini-3.1-pro-preview`/`gemini-3.5-flash` added as BYOK options. OpenAI BYOK default → `gpt-5.5` (+ gpt-5.x `max_completion_tokens` fix); Mistral → `mistral-medium-3`. All IDs live-verified before listing. Default free-tier path (Gemini 2.5 Flash + Groq) unchanged — cost/stability preserved. Probe #23 (config/secret scanner) blocked. 699 tests; pre-deploy live Trinity smoke green. R-S51 + T+L S45/S46/S51 — June 23, 2026
 - **BYOK Robustness (v0.5.46)**: production-hardening bundle surfaced by dogfooding the M2 P3 evaluation — `provider/model` shorthand now accepted server-side (fixes June-17 prod rejection of valid BYOK configs), Z/CS `max_tokens` raised 4096 → 8192 (Groq clamped per-provider) to stop verbose-model truncation, the Z token-monitor repaired (silently read 0 since v0.5.3), and structured provider evidence coerced to string for schema conformance. Strictly additive — no change to the default free-tier path. 698 tests pass. T+L S46 D-46-1/2 + S47 D-47-1 + Alton — June 19, 2026
 - **Probe Blocklist (v0.5.45)**: blocked an MCP-endpoint scanner family polluting engagement metrics — AgentSure-MCPScan (9 IPs; primary `152.55.176.35` logged ~11h of cron-driven fake "engagement"), LeakIX l9scan (2 IPs), and a self-declared `MCP-Inspector (security-scan)` IP (`14.194.11.238`, orchestrator-flagged, Sentinel-confirmed: 330-req/100s dictionary sweep, zero 200, zero leak). `BLOCKED_IPS` 10 → 22; UA-substring blocks added for `AgentSure-MCPScan` / `l9scan` / `(security-scan)` (rotation-proof, live-verified 403). Honest-metrics gate held — AY held Report 097 until this deploy. AY+AZ forensics 2026-06-12 + Sentinel 2026-06-16 — June 16, 2026

--- a/mcp-server/http_server.py
+++ b/mcp-server/http_server.py
@@ -64,7 +64,7 @@ mcp_server = create_http_server()
 mcp_app = mcp_server.http_app(path='/', transport='streamable-http')
 
 # Server version
-SERVER_VERSION = "0.5.47"
+SERVER_VERSION = "0.5.48"
 
 # MCP endpoint constants — single source of truth for URL/path strings used in
 # JSON responses, quickstart commands, and HTML setup pages. Extracted in v0.5.32

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -106,7 +106,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # .git/config (high-value), .env tree (18+ variants incl. admin/.env, backend/.env), wp-config.php, phpinfo.php,
     # aws.config.js; 80x404 (67%), 36x429 (30%), 4x200 all on public root / ; ZERO sensitive 200s. Same /24 as #23
     # (45.148.10.15, 2026-06-18) and #25 (45.148.10.67, this batch). AY+AZ flagged, Sentinel-verified 2026-06-28.
-    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR: blocklist data — hardcoded scanner IP is the intended security control
+    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR
     # Config/Secret Scanner #25 (45.148.10.0/24) — UA TLM-Audit-Scanner/1.0 (self-identifying, 100% static); single
     # extreme-velocity burst 2026-06-27 02:43:36-53 UTC (~59 req/s, 17s, 1000+ req); multi-tech credential dictionary:
     # Stripe (stripe-credentials.json/keys.json/.env), Terraform (.tfvars/.tfstate(.backup)), AWS Lambda (var/task/
@@ -114,7 +114,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # wp-content/mysql.sql), .env tree (v1/v2/v3/staging/src/srv/shop/services/website), Webmin CGI; 635x302
     # (HTTP->HTTPS), 364x429 (36%), 4x200 (/, /register, /?phpinfo=1, /?pp=env&pp=env — all public-safe); ZERO
     # sensitive 200s. UA `TLM-Audit-Scanner` added to BLOCKED_UA_PATTERNS for rotation-proof /24 coverage.
-    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR: blocklist data — hardcoded scanner IP is the intended security control
+    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR
     # Config/RCE Scanner #26 (NEW class) — primary UA Firefox/47.0 (2016-era static); secondary Chrome/Win10 + empty
     # UA at overlapping timestamps = proxy cluster / multi-tool orchestration; single 6-min burst 2026-06-24
     # 04:41-47 UTC, 180 req @ ~0.5 req/s; probed .aws/credentials (high-value), swagger.json, backend/config/
@@ -123,7 +123,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # ESCALATION: embedded Node.js child_process.execSync RCE probe via query param (?param=test?cmd=<base64:echo
     # VULN_TEST>) — returned 200 root page (Python/FastAPI ignores query params; zero execution, zero leak);
     # 108x404 (60%), 64x429 (36%), 5x200 (root + ignored-query paths), 3x302; ZERO sensitive 200s. Sentinel 2026-06-28.
-    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR: blocklist data — hardcoded scanner IP is the intended security control
+    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -106,7 +106,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # .git/config (high-value), .env tree (18+ variants incl. admin/.env, backend/.env), wp-config.php, phpinfo.php,
     # aws.config.js; 80x404 (67%), 36x429 (30%), 4x200 all on public root / ; ZERO sensitive 200s. Same /24 as #23
     # (45.148.10.15, 2026-06-18) and #25 (45.148.10.67, this batch). AY+AZ flagged, Sentinel-verified 2026-06-28.
-    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),
+    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR(S1313): blocklist data — hardcoded scanner IP is the intended security control
     # Config/Secret Scanner #25 (45.148.10.0/24) — UA TLM-Audit-Scanner/1.0 (self-identifying, 100% static); single
     # extreme-velocity burst 2026-06-27 02:43:36-53 UTC (~59 req/s, 17s, 1000+ req); multi-tech credential dictionary:
     # Stripe (stripe-credentials.json/keys.json/.env), Terraform (.tfvars/.tfstate(.backup)), AWS Lambda (var/task/
@@ -114,7 +114,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # wp-content/mysql.sql), .env tree (v1/v2/v3/staging/src/srv/shop/services/website), Webmin CGI; 635x302
     # (HTTP->HTTPS), 364x429 (36%), 4x200 (/, /register, /?phpinfo=1, /?pp=env&pp=env — all public-safe); ZERO
     # sensitive 200s. UA `TLM-Audit-Scanner` added to BLOCKED_UA_PATTERNS for rotation-proof /24 coverage.
-    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),
+    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR(S1313): blocklist data — hardcoded scanner IP is the intended security control
     # Config/RCE Scanner #26 (NEW class) — primary UA Firefox/47.0 (2016-era static); secondary Chrome/Win10 + empty
     # UA at overlapping timestamps = proxy cluster / multi-tool orchestration; single 6-min burst 2026-06-24
     # 04:41-47 UTC, 180 req @ ~0.5 req/s; probed .aws/credentials (high-value), swagger.json, backend/config/
@@ -123,7 +123,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # ESCALATION: embedded Node.js child_process.execSync RCE probe via query param (?param=test?cmd=<base64:echo
     # VULN_TEST>) — returned 200 root page (Python/FastAPI ignores query params; zero execution, zero leak);
     # 108x404 (60%), 64x429 (36%), 5x200 (root + ignored-query paths), 3x302; ZERO sensitive 200s. Sentinel 2026-06-28.
-    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),
+    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR(S1313): blocklist data — hardcoded scanner IP is the intended security control
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -106,7 +106,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # .git/config (high-value), .env tree (18+ variants incl. admin/.env, backend/.env), wp-config.php, phpinfo.php,
     # aws.config.js; 80x404 (67%), 36x429 (30%), 4x200 all on public root / ; ZERO sensitive 200s. Same /24 as #23
     # (45.148.10.15, 2026-06-18) and #25 (45.148.10.67, this batch). AY+AZ flagged, Sentinel-verified 2026-06-28.
-    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR(S1313): blocklist data — hardcoded scanner IP is the intended security control
+    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR: blocklist data — hardcoded scanner IP is the intended security control
     # Config/Secret Scanner #25 (45.148.10.0/24) — UA TLM-Audit-Scanner/1.0 (self-identifying, 100% static); single
     # extreme-velocity burst 2026-06-27 02:43:36-53 UTC (~59 req/s, 17s, 1000+ req); multi-tech credential dictionary:
     # Stripe (stripe-credentials.json/keys.json/.env), Terraform (.tfvars/.tfstate(.backup)), AWS Lambda (var/task/
@@ -114,7 +114,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # wp-content/mysql.sql), .env tree (v1/v2/v3/staging/src/srv/shop/services/website), Webmin CGI; 635x302
     # (HTTP->HTTPS), 364x429 (36%), 4x200 (/, /register, /?phpinfo=1, /?pp=env&pp=env — all public-safe); ZERO
     # sensitive 200s. UA `TLM-Audit-Scanner` added to BLOCKED_UA_PATTERNS for rotation-proof /24 coverage.
-    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR(S1313): blocklist data — hardcoded scanner IP is the intended security control
+    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR: blocklist data — hardcoded scanner IP is the intended security control
     # Config/RCE Scanner #26 (NEW class) — primary UA Firefox/47.0 (2016-era static); secondary Chrome/Win10 + empty
     # UA at overlapping timestamps = proxy cluster / multi-tool orchestration; single 6-min burst 2026-06-24
     # 04:41-47 UTC, 180 req @ ~0.5 req/s; probed .aws/credentials (high-value), swagger.json, backend/config/
@@ -123,7 +123,7 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # ESCALATION: embedded Node.js child_process.execSync RCE probe via query param (?param=test?cmd=<base64:echo
     # VULN_TEST>) — returned 200 root page (Python/FastAPI ignores query params; zero execution, zero leak);
     # 108x404 (60%), 64x429 (36%), 5x200 (root + ignored-query paths), 3x302; ZERO sensitive 200s. Sentinel 2026-06-28.
-    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR(S1313): blocklist data — hardcoded scanner IP is the intended security control
+    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),  # NOSONAR: blocklist data — hardcoded scanner IP is the intended security control
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)

--- a/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
+++ b/mcp-server/src/verifimind_mcp/middleware/ip_blocklist.py
@@ -101,6 +101,29 @@ BLOCKED_IPS: list[tuple[str, str, str, str]] = [
     # 59x429, 20x404, 2x200 (root / only); ZERO sensitive 200s, ZERO /mcp success, ZERO /register, 0 flying
     # hours. Alton-flagged during adoption review; AY+AZ GCP forensics 2026-06-18 (D-45-3). Hygiene block.
     ("45.148.10.15", "CONFIG_SECRET_SCANNER", "2026-06-18", "AY_AZ_COO_CPO"),
+    # Config/Secret Scanner #24 (45.148.10.0/24) — rotating browser UA per request (Chrome/macOS/Linux/Win +
+    # Firefox = botnet/spoof); weekly cron (Jun 5/10/17/27 ~16:00 UTC), 4 rounds x ~30 req/session; probed
+    # .git/config (high-value), .env tree (18+ variants incl. admin/.env, backend/.env), wp-config.php, phpinfo.php,
+    # aws.config.js; 80x404 (67%), 36x429 (30%), 4x200 all on public root / ; ZERO sensitive 200s. Same /24 as #23
+    # (45.148.10.15, 2026-06-18) and #25 (45.148.10.67, this batch). AY+AZ flagged, Sentinel-verified 2026-06-28.
+    ("45.148.10.62", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),
+    # Config/Secret Scanner #25 (45.148.10.0/24) — UA TLM-Audit-Scanner/1.0 (self-identifying, 100% static); single
+    # extreme-velocity burst 2026-06-27 02:43:36-53 UTC (~59 req/s, 17s, 1000+ req); multi-tech credential dictionary:
+    # Stripe (stripe-credentials.json/keys.json/.env), Terraform (.tfvars/.tfstate(.backup)), AWS Lambda (var/task/
+    # amplify.yml, docker-compose, serverless.yaml, next.config.*), WordPress (wp-config.php*, wp-json/gravitysmtp,
+    # wp-content/mysql.sql), .env tree (v1/v2/v3/staging/src/srv/shop/services/website), Webmin CGI; 635x302
+    # (HTTP->HTTPS), 364x429 (36%), 4x200 (/, /register, /?phpinfo=1, /?pp=env&pp=env — all public-safe); ZERO
+    # sensitive 200s. UA `TLM-Audit-Scanner` added to BLOCKED_UA_PATTERNS for rotation-proof /24 coverage.
+    ("45.148.10.67", "CONFIG_SECRET_SCANNER", "2026-06-28", "RNA_CSO"),
+    # Config/RCE Scanner #26 (NEW class) — primary UA Firefox/47.0 (2016-era static); secondary Chrome/Win10 + empty
+    # UA at overlapping timestamps = proxy cluster / multi-tool orchestration; single 6-min burst 2026-06-24
+    # 04:41-47 UTC, 180 req @ ~0.5 req/s; probed .aws/credentials (high-value), swagger.json, backend/config/
+    # default.yml, storage/logs/laravel.log, config.js + .env tree (10+ variants incl. crm/.env, core/.env,
+    # application/.env), phpinfo.php, server-info.php, apis/controllers/users.js, admin/controllers/merchant.js;
+    # ESCALATION: embedded Node.js child_process.execSync RCE probe via query param (?param=test?cmd=<base64:echo
+    # VULN_TEST>) — returned 200 root page (Python/FastAPI ignores query params; zero execution, zero leak);
+    # 108x404 (60%), 64x429 (36%), 5x200 (root + ignored-query paths), 3x302; ZERO sensitive 200s. Sentinel 2026-06-28.
+    ("93.123.109.103", "CONFIG_RCE_SCANNER", "2026-06-28", "RNA_CSO"),
 ]
 
 # Blocked User-Agent substrings (case-insensitive substring match)
@@ -109,6 +132,7 @@ BLOCKED_UA_PATTERNS: list[str] = [
     "AgentSure-MCPScan",   # AgentSure MCP scanner — rotation-proof block across its Azure IP family
     "l9scan",              # LeakIX internet background scanner
     "(security-scan)",     # self-declared scanner suffix (e.g. MCP-Inspector/1.8.0 (security-scan)); surgical — does not collide with standard MCP Inspector usage
+    "TLM-Audit-Scanner",   # TLM-Audit-Scanner/1.0 — self-identifying commercial scanner; rotation-proof coverage for 45.148.10.67 (#25, 2026-06-28) and any /24 successor IPs
 ]
 
 # Pre-computed lookup structures (module-level, built once at import)

--- a/mcp-server/src/verifimind_mcp/server.py
+++ b/mcp-server/src/verifimind_mcp/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 # v0.4.3 — System Notice: broadcast messages to all MCP users via env var
 _RAW_SYSTEM_NOTICE = os.environ.get("SYSTEM_NOTICE", "")
-SERVER_VERSION = "0.5.47"
+SERVER_VERSION = "0.5.48"
 
 # Agent role names + master prompt filename — single source of truth.
 # (SonarCloud P2 batch-2: extracted in v0.5.39 from 13 dup-literal occurrences

--- a/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
+++ b/mcp-server/tests/unit/test_p0_tool_manifest_audit.py
@@ -278,4 +278,4 @@ class TestServerVersion:
 
     def test_server_version_is_0522(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.47"
+        assert http_server.SERVER_VERSION == "0.5.48"

--- a/mcp-server/tests/unit/test_v050_foundation.py
+++ b/mcp-server/tests/unit/test_v050_foundation.py
@@ -67,7 +67,7 @@ class TestSmitheryRemoval:
     def test_server_version_is_0513(self):
         """SERVER_VERSION must be bumped to 0.5.16 (Scholar Incentives — P1-A/P1-C)."""
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.47", (
+        assert SERVER_VERSION == "0.5.48", (
             f"Expected 0.5.47, got {SERVER_VERSION}"
         )
 

--- a/mcp-server/tests/unit/test_v0511_coordination.py
+++ b/mcp-server/tests/unit/test_v0511_coordination.py
@@ -588,7 +588,7 @@ class TestFreeToolRegression:
 
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.47"
+        assert SERVER_VERSION == "0.5.48"
 
     def test_wrap_response_still_works(self):
         from verifimind_mcp.server import wrap_response

--- a/mcp-server/tests/unit/test_v0512_polar.py
+++ b/mcp-server/tests/unit/test_v0512_polar.py
@@ -549,4 +549,4 @@ class TestStripeDocstringRemoved:
 class TestServerVersion:
     def test_server_version_is_0513(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.47"
+        assert SERVER_VERSION == "0.5.48"

--- a/mcp-server/tests/unit/test_v0516_trinity_history.py
+++ b/mcp-server/tests/unit/test_v0516_trinity_history.py
@@ -161,4 +161,4 @@ class TestServerWiring:
 
     def test_server_version_is_0516(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.47", f"Expected 0.5.47, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.48", f"Expected 0.5.47, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0517_mcp_config_header.py
+++ b/mcp-server/tests/unit/test_v0517_mcp_config_header.py
@@ -65,4 +65,4 @@ class TestServerVersion:
 
     def test_server_version_is_0517(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.47", f"Expected 0.5.47, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.48", f"Expected 0.5.47, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
+++ b/mcp-server/tests/unit/test_v0519_uuid_rate_limiter.py
@@ -213,4 +213,4 @@ class TestServerVersion:
 
     def test_server_version_is_0519(self):
         from verifimind_mcp.server import SERVER_VERSION
-        assert SERVER_VERSION == "0.5.47", f"Expected 0.5.47, got {SERVER_VERSION}"
+        assert SERVER_VERSION == "0.5.48", f"Expected 0.5.47, got {SERVER_VERSION}"

--- a/mcp-server/tests/unit/test_v0525_inference_mode.py
+++ b/mcp-server/tests/unit/test_v0525_inference_mode.py
@@ -80,4 +80,4 @@ class TestServerVersion:
 
     def test_server_version_is_0525(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.47"
+        assert http_server.SERVER_VERSION == "0.5.48"

--- a/mcp-server/tests/unit/test_v0526_scanner_block_head.py
+++ b/mcp-server/tests/unit/test_v0526_scanner_block_head.py
@@ -90,4 +90,4 @@ class TestServerVersion:
 
     def test_server_version_is_0526(self):
         import http_server
-        assert http_server.SERVER_VERSION == "0.5.47"
+        assert http_server.SERVER_VERSION == "0.5.48"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.creator35lwb-web/verifimind-genesis",
   "title": "VerifiMind PEAS - RefleXion Trinity",
-  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Auditable reasoning. v0.5.47",
-  "version": "3.24.0",
+  "description": "Multi-Agent AI Validation: X-Z-CS Trinity. 13 tools FREE. Auditable reasoning. v0.5.48",
+  "version": "3.25.0",
   "repository": {
     "url": "https://github.com/creator35lwb-web/VerifiMind-PEAS",
     "source": "github"


### PR DESCRIPTION
## v0.5.48 — Scanner Cluster Block

Security-hygiene batch: blocks a coordinated config/secret scanner cluster + a combined config/RCE scanner, confirmed via GCP forensic analysis. `BLOCKED_IPS` 23 → 26; one rotation-proof UA-substring block added. Zero sensitive-path data served to any blocked actor. No functional change.

### What changed
- **Config/secret scanner cluster** (2 IPs, same `/24` as a prior probe) blocked at the application layer
- **Combined config/RCE scanner** (1 IP) blocked — carried an active Node.js injection probe our Python/FastAPI server ignored (zero execution, zero leak); tracked as a new `CONFIG_RCE_SCANNER` signature class
- **UA-substring block** added for a self-identifying scanner tool (rotation-proof across the IP family)
- **Monitoring:** two crawler UAs flagged for a 14-day watch; no IP block at current volume

### Verification
- Sentinel sub-agent independently re-verified all three against live GCP logs (30-day window) before the block — every sensitive path hit 404/429/302; only public surfaces served 200.
- Gate #1 (canonical currency) clean at v0.5.48; 613 unit tests pass (3 skipped); full suite gated in CI.

### Disclosure
Full forensic detail lives in the commit + internal `CHANGELOG.md`/`SERVER_STATUS.md`. The public GitHub Release body uses sanitized wording per the disclosure policy (since v0.5.33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)