### PR TITLE
chore: SonarCloud config — pin Python version + ignore S1313 on IP blocklist

### DIFF
--- a/.github/workflows/docs-ci-bypass.yml
+++ b/.github/workflows/docs-ci-bypass.yml
@@ -15,6 +15,7 @@ on:
       - '**.txt'
       - '**.rst'
       - 'server.json'
+      - 'sonar-project.properties'
       - 'cloudbuild.yaml'
       - '.github/workflows/publish-mcp-registry.yml'
       - '.github/workflows/docs-ci-bypass.yml'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,20 @@
+# SonarCloud / SonarQube Cloud analysis configuration
+# (Project runs on SonarCloud Automatic Analysis — GitHub App. This file supplies
+#  analysis parameters only; it does NOT add a CI scanner step.)
+
+# --- Python version (fixes the "analyzed as compatible with all Python 3 versions" warning) ---
+# Pin the exact supported range so analysis is precise instead of defaulting to all of Python 3.
+# pyproject.toml: requires-python = ">=3.11". Runtimes in use: 3.11 (CI: test + security-scan),
+# 3.12 (Dockerfile / Cloud Run). Listing the range we actually support:
+sonar.python.version=3.11, 3.12, 3.13
+
+# --- Intentional-by-design exclusion: the IP blocklist ---
+# mcp-server/.../middleware/ip_blocklist.py is a security control whose ENTIRE PURPOSE is hardcoded
+# scanner/rogue IPs (BLOCKED_IPS). SonarCloud's python:S1313 ("hardcoded IP address") is a false
+# positive there and recurs as a new-code-gate failure on every block deploy (see the v0.5.48
+# per-line `# NOSONAR` workaround). Ignore S1313 for that one file at the config level — durable,
+# so future block deploys don't need per-IP suppression. (The matching hotspots are reviewed Safe
+# in the SonarCloud UI; this only clears the duplicate *issue*.)
+sonar.issue.ignore.multicriteria=blocklistIPs
+sonar.issue.ignore.multicriteria.blocklistIPs.ruleKey=python:S1313
+sonar.issue.ignore.multicriteria.blocklistIPs.resourceKey=**/ip_blocklist.py


### PR DESCRIPTION
## What
Adds `sonar-project.properties` with two analysis settings:

1. **`sonar.python.version=3.11, 3.12, 3.13`** — fixes the SonarCloud warning *"analyzed as compatible with all Python 3 versions by default."* Our `requires-python = ">=3.11"`; we run on 3.11 (CI) and 3.12 (Docker/Cloud Run). Pinning the range makes analysis precise.
2. **Ignore `python:S1313` on `**/ip_blocklist.py`** — that file is a security control whose entire purpose is hardcoded scanner/rogue IPs (`BLOCKED_IPS`). S1313 ("hardcoded IP address") is a false positive there and recurs as a new-code-gate failure on every block deploy (cf. the v0.5.48 per-line `# NOSONAR` workaround). This handles it durably at the config level.

## Safety
Config-only (no CI scanner step). The project uses SonarCloud **Automatic Analysis**; this file supplies analysis parameters only. **Do not merge unless the SonarCloud check on this PR stays healthy** — if automatic analysis is disturbed, revert.

## Out of scope (needs SonarCloud UI)
The 40 security **hotspots** are reviewed Safe in the SonarCloud UI (separate from this issue-level config) — disposition handed to the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)